### PR TITLE
Bugfix to handle big files

### DIFF
--- a/fastkml/kml.py
+++ b/fastkml/kml.py
@@ -84,7 +84,11 @@ class KML(object):
 
     def from_string(self, xml_string):
         """ create a KML object from a xml string"""
-        element = etree.fromstring(xml_string, parser=etree.XMLParser(huge_tree=True))
+        if config.LXML:
+            element = etree.fromstring(xml_string, parser=etree.XMLParser(huge_tree=True))
+        else:
+            element = etree.XML(xml_string)
+
         if element.tag.endswith('kml'):
             ns = element.tag.rstrip('kml')
             documents = element.findall('%sDocument' % ns)


### PR DESCRIPTION
lxml fails for files > 9Mb if huge_tree is not set, which it isn't by default.

here is an example file (extract the doc.kml from the kmz using zfile.open) that fails without this fix, but passes with it:

http://mw1.gstatic.com/mw-earth-vectordb/Imagery_Updates/09-21-2010_Imagery_Update.kmz
