### PR TITLE
Handle case where Feature booleans are 'true' or 'false' during parsing

### DIFF
--- a/fastkml/kml.py
+++ b/fastkml/kml.py
@@ -493,10 +493,16 @@ class _Feature(_BaseObject):
             self.description = description.text
         visibility = element.find('%svisibility' % self.ns)
         if visibility is not None:
-            self.visibility = int(visibility.text)
+            if visibility.text in ['1', 'true']:
+                self.visibility = 1
+            else:
+                self.visibility = 0
         isopen = element.find('%sopen' % self.ns)
         if isopen is not None:
-            self.isopen = int(isopen.text)
+            if isopen.text in ['1', 'true']:
+                self.isopen = 1
+            else:
+                self.isopen = 0
         styles = element.findall('%sStyle' % self.ns)
         for style in styles:
             s = Style(self.ns)

--- a/fastkml/test_main.py
+++ b/fastkml/test_main.py
@@ -362,6 +362,30 @@ class KmlFromStringTestCase(unittest.TestCase):
         k2.from_string(k.to_string())
         self.assertEqual(k.to_string(), k2.to_string())
 
+    def test_document_booleans(self):
+        doc = """<kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document targetId="someTargetId">
+          <name>Document.kml</name>
+          <visibility>true</visibility>
+          <open>1</open>
+        </Document>
+        </kml>"""
+        k = kml.KML()
+        k.from_string(doc)
+        self.assertEqual(list(k.features())[0].visibility, 1)
+        self.assertEqual(list(k.features())[0].isopen, 1)
+        doc = """<kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document targetId="someTargetId">
+          <name>Document.kml</name>
+          <visibility>0</visibility>
+          <open>false</open>
+        </Document>
+        </kml>"""
+        k = kml.KML()
+        k.from_string(doc)
+        self.assertEqual(list(k.features())[0].visibility, 0)
+        self.assertEqual(list(k.features())[0].isopen, 0)        
+    
     def test_folders(self):
         doc = """<kml xmlns="http://www.opengis.net/kml/2.2">
         <Folder>


### PR DESCRIPTION
I've come across a few kml documents that use string 'true' or 'false' for the visibility and open boolean values instead of 1 or 0.  The current way of casting to int doesn't work for these.  The changes I made check for the string values and force to integer 1 or 0. 

I'm not sure this is the best solution as it doesn't preserve the original string values when using to_string, but it works for my needs.  I thought this might be useful for others as well.
