### PR TITLE
handle coordinates tuples which contain spaces

### DIFF
--- a/fastkml/geometry.py
+++ b/fastkml/geometry.py
@@ -41,6 +41,7 @@ except ImportError:
     from pygeoif.geometry import GeometryCollection
     from pygeoif.geometry import as_shape as asShape
 
+import re
 import fastkml.config as config
 
 from .config import etree
@@ -314,7 +315,13 @@ class Geometry(_BaseObject):
     def _get_coordinates(self, element):
         coordinates = element.find('%scoordinates' % self.ns)
         if coordinates is not None:
-            latlons = coordinates.text.strip().split()
+            # https://developers.google.com/kml/documentation/kmlreference#coordinates
+            # Coordinates can be any number of tuples separated by a
+            # space (potentially any number of whitespace characters).
+            # Values in tuples should be separated by commas with no
+            # spaces. Clean up badly formatted tuples by stripping
+            # space following commas.
+            latlons = re.sub(r', +', ',', coordinates.text.strip()).split()
             coords = []
             for latlon in latlons:
                 coords.append([float(c) for c in latlon.split(',')])


### PR DESCRIPTION
This patch makes coordinate parsing more robust for a common problem.

It is not uncommon (especially in hand-generated data) to encounter KML with badly formatted coordinates tuples that contain spaces after the commas, like this:

        <coordinates>
          1.1, 2.2, 3.3
        </coordinates>

instead of the proper form noted in the [KML reference](https://developers.google.com/kml/documentation/kmlreference#coordinates) which says "Do not include spaces within a tuple":

        <coordinates>
          1.1,2.2,3.3
        </coordinates>

It is easy to unambiguously clean up/ignore spaces after commas, while still ensuring that coordinates with multiple tuples still work, such as these examples, each with two tuples separated by newlines and spaces, respectively:

        <coordinates>
          -122.365662,37.826988,0
          -122.365202,37.826302,0
        </coordinates>

and

        <coordinates>
          -122.365662,37.826988,0 -122.365202,37.826302,0
        </coordinates>
