### PR TITLE
Show the description correctly on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         open("README.rst").read() + "\n" +
         open(os.path.join("docs", "HISTORY.txt")).read()
     ),
+    long_description_content_type="text/x-rst",
     classifiers=[
         "Topic :: Scientific/Engineering :: GIS",
         "Programming Language :: Python",


### PR DESCRIPTION
PyPI uses markdawn on default, so you should set description content type.