### PR TITLE
Try hard to parse through broken XML

### DIFF
--- a/fastkml/kml.py
+++ b/fastkml/kml.py
@@ -85,7 +85,7 @@ class KML(object):
         if config.LXML:
             element = etree.fromstring(
                 xml_string,
-                parser=etree.XMLParser(huge_tree=True)
+                parser=etree.XMLParser(huge_tree=True, recover=True)
             )
         else:
             element = etree.XML(xml_string)

--- a/fastkml/test_main.py
+++ b/fastkml/test_main.py
@@ -863,6 +863,21 @@ class KmlFromStringTestCase(unittest.TestCase):
         doc = kml.KML()
         self.assertRaises(TypeError, doc.from_string, '<xml></xml>')
 
+    def test_from_string_with_unbound_prefix(self):
+        doc = """<kml xmlns="http://www.opengis.net/kml/2.2">
+        <Placemark>
+        <ExtendedData>
+          <lc:attachment>image.png</lc:attachment>
+        </ExtendedData>
+        </Placemark> </kml>"""
+
+        k = kml.KML()
+        if config.LXML:
+            k.from_string(doc)
+            self.assertEqual(len(list(k.features())), 1)
+        else:
+            self.assertRaises(etree.ParseError, k.from_string, doc)
+
     def test_address(self):
         doc = kml.Document()
 


### PR DESCRIPTION
This PR takes advantage of `recovery` option of the `lxml.etree.XMLParser` parser and aims to fix the following sort of issues:
```
>>> k = kml.KML()
>>> k.from_string(doc.encode('utf-8'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/denis/env/lib/python3.6/site-packages/fastkml/kml.py", line 91, in from_string
    parser=etree.XMLParser(huge_tree=True)
  File "src/lxml/etree.pyx", line 3213, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1877, in lxml.etree._parseMemoryDocument
  File "src/lxml/parser.pxi", line 1765, in lxml.etree._parseDoc
  File "src/lxml/parser.pxi", line 1127, in lxml.etree._BaseParser._parseDoc
  File "src/lxml/parser.pxi", line 601, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 711, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 640, in lxml.etree._raiseParseError
  File "<string>", line 33
lxml.etree.XMLSyntaxError: Namespace prefix lc on attachment is not defined, line 33, column 18
```