### PR TITLE
Drop python2

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -47,25 +47,6 @@ jobs:
         run: |
           python setup.py test
 
-  cpython-2:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['2.7']
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install "pytest<5"
-      - name: Test with pytest
-        run: |
-          python setup.py test
-
   static-tests:
     runs-on: ubuntu-latest
     strategy:
@@ -116,7 +97,7 @@ jobs:
 
   publish:
     if: "github.event_name == 'push' && github.repository == 'cleder/fastkml'"
-    needs: [cpython, static-tests, pypy, cpython-2, cpython-lxml]
+    needs: [cpython, static-tests, pypy, cpython-lxml]
     name: Build and publish to PyPI and TestPyPI
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ _build/
 # virtual environments
 .venv
 venv
+
+# editors
+.vscode/
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -46,8 +46,6 @@ Is Maintained and documented:
     :target: https://www.openhub.net/p/fastkml
     :alt: Statistics from OpenHub
 
-Supports python 2 and 3:
-
 .. image:: https://img.shields.io/pypi/pyversions/fastkml.svg
     :target: https://pypi.python.org/pypi/fastkml/
     :alt: Supported Python versions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # FastKML documentation build configuration file, created by
 # sphinx-quickstart on Mon Oct 13 22:24:07 2014.
@@ -44,8 +43,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'FastKML'
-copyright = u'2014, Christian Ledermann & Ian Lee'
+project = 'FastKML'
+copyright = '2014, Christian Ledermann & Ian Lee'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -203,8 +202,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'FastKML.tex', u'FastKML Documentation',
-   u'Christian Ledermann \\& Ian Lee', 'manual'),
+  ('index', 'FastKML.tex', 'FastKML Documentation',
+   'Christian Ledermann \\& Ian Lee', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -233,8 +232,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'fastkml', u'FastKML Documentation',
-     [u'Christian Ledermann & Ian Lee'], 1)
+    ('index', 'fastkml', 'FastKML Documentation',
+     ['Christian Ledermann & Ian Lee'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -247,8 +246,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'FastKML', u'FastKML Documentation',
-   u'Christian Ledermann & Ian Lee', 'FastKML', 'One line description of project.',
+  ('index', 'FastKML', 'FastKML Documentation',
+   'Christian Ledermann & Ian Lee', 'FastKML', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -31,7 +31,7 @@ You can make use of tox_ >= 1.8 to test the entire matrix of options:
 
 * with / without lxml
 * pygeoif vs shapely
-* py26,py27,py32,py33,py34
+* py33,py34,py35
 
 as well as pep8 style checking in a single call (this approximates what happens
 when the package is run through Travis-CI)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,9 +32,6 @@ Follows best practises:
    :target: https://landscape.io/github/cleder/fastkml/master
    :alt: Code Health
 
-
-Supports python 2 and 3:
-
 .. image:: https://pypip.in/py_versions/fastkml/badge.svg
     :target: https://pypi.python.org/pypi/fastkml/
     :alt: Supported Python versions

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-fastkml works with CPython version 2.6, 2.7, 3.2, 3.3, 3.4 and is
+fastkml works with CPython version 3.2, 3.3, 3.4 and is
 continually tested with TravisCI for these version. The tests break
 intermittently for pypy and pypy3 so they are not tested but *should* work,
 Jython and IronPython are not tested but *should* work.

--- a/examples/CreateKml.py
+++ b/examples/CreateKml.py
@@ -29,7 +29,7 @@ p.geometry =  Polygon([(0, 0, 0), (1, 1, 0), (1, 0, 1)])
 f2.append(p)
 
 # Print out the KML Object as a string
-print k.to_string(prettyprint=True)
+print(k.to_string(prettyprint=True))
 
 expected = """<kml:kml xmlns:ns0="http://www.opengis.net/kml/2.2">
   <kml:Document id="docid">

--- a/examples/ReadKml.py
+++ b/examples/ReadKml.py
@@ -39,28 +39,28 @@ k.from_string(doc)
 # Check that the number of features is correct
 # This corresponds to the single ``Document``
 features = list(k.features())
-print len(features)
+print(len(features))
 
 # Check that we can access the features as a generator
 # (The two Placemarks of the Document)
-print features[0].features()
+print(features[0].features())
 
 f2 = list(features[0].features())
-print len(f2)
+print(len(f2))
 
 
 # Check specifics of the first Placemark in the Document
-print f2[0]
-print f2[0].description
-print f2[0].name
+print(f2[0])
+print(f2[0].description)
+print(f2[0].name)
 
 # Check specifics of the second Placemark in the Document
-print f2[1].name
+print(f2[1].name)
 f2[1].name = "ANOTHER NAME"
-print f2[1].name
+print(f2[1].name)
 
 # Verify that we can print back out the KML object as a string
-print k.to_string(prettyprint=True)
+print(k.to_string(prettyprint=True))
 
 expected = """<kml:kml xmlns:ns0="http://www.opengis.net/kml/2.2">
   <kml:Document>

--- a/examples/UsageExamples.py
+++ b/examples/UsageExamples.py
@@ -7,7 +7,7 @@ def print_child_features(element):
     if not getattr(element, 'features', None):
         return
     for feature in element.features():
-        print feature.name
+        print(feature.name)
         print_child_features(feature)
 
 if __name__ == '__main__':

--- a/examples/UsageExamples.py
+++ b/examples/UsageExamples.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 from fastkml import kml
 

--- a/fastkml/__init__.py
+++ b/fastkml/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012  Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under

--- a/fastkml/atom.py
+++ b/fastkml/atom.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012  Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under
@@ -44,7 +43,7 @@ regex = r"^[a-zA-Z0-9._%-]+@([a-zA-Z0-9-]+\.)*[a-zA-Z]{2,4}$"
 check_email = re.compile(regex).match
 
 
-class Link(object):
+class Link:
     """
     Identifies a related Web page. The type of relation is defined by
     the rel attribute. A feed is limited to one alternate per type and
@@ -154,7 +153,7 @@ class Link(object):
             )
 
 
-class _Person(object):
+class _Person:
     """
     <author> and <contributor> describe a person, corporation, or similar
     entity. It has one required element, name, and two optional elements:

--- a/fastkml/base.py
+++ b/fastkml/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012  Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under
@@ -21,7 +20,7 @@ import fastkml.config as config
 from fastkml.config import etree
 
 
-class _XMLObject(object):
+class _XMLObject:
     """XML Baseclass"""
 
     __name__ = None
@@ -70,12 +69,12 @@ class _BaseObject(_XMLObject):
     targetId = None
 
     def __init__(self, ns=None, id=None):
-        super(_BaseObject, self).__init__(ns)
+        super().__init__(ns)
         self.id = id
         self.ns = config.KMLNS if ns is None else ns
 
     def etree_element(self):
-        element = super(_BaseObject, self).etree_element()
+        element = super().etree_element()
         if self.id:
             element.set("id", self.id)
         if self.targetId:
@@ -83,7 +82,7 @@ class _BaseObject(_XMLObject):
         return element
 
     def from_element(self, element):
-        super(_BaseObject, self).from_element(element)
+        super().from_element(element)
         if element.get("id"):
             self.id = element.get("id")
         if element.get("targetId"):

--- a/fastkml/config.py
+++ b/fastkml/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012  Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under

--- a/fastkml/geometry.py
+++ b/fastkml/geometry.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012  Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under
@@ -119,7 +118,7 @@ class Geometry(_BaseObject):
                     elevated above the terrain by 7 meters. A typical use
                     of this mode is for aircraft placement.
         """
-        super(Geometry, self).__init__(ns, id)
+        super().__init__(ns, id)
         self.extrude = extrude
         self.tessellate = tessellate
         self.altitude_mode = altitude_mode

--- a/fastkml/gx.py
+++ b/fastkml/gx.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012  Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under
@@ -104,7 +103,7 @@ class GxGeometry(Geometry):
         gxgeometry: a read-only subclass of geometry supporting gx: features,
         like gx:Track
         """
-        super(GxGeometry, self).__init__(ns, id)
+        super().__init__(ns, id)
         self.ns = NS if ns is None else ns
 
     def _get_geometry(self, element):

--- a/fastkml/kml.py
+++ b/fastkml/kml.py
@@ -301,7 +301,7 @@ class _Feature(_BaseObject):
     def timeStamp(self, dt):
         self._time_stamp = None if dt is None else TimeStamp(timestamp=dt)
         if self._time_span is not None:
-            logger.warn("Setting a TimeStamp, TimeSpan deleted")
+            logger.warning("Setting a TimeStamp, TimeSpan deleted")
             self._time_span = None
 
     @property
@@ -335,7 +335,7 @@ class _Feature(_BaseObject):
         else:
             self._time_span.end[0] = dt
         if self._time_stamp is not None:
-            logger.warn("Setting a TimeSpan, TimeStamp deleted")
+            logger.warning("Setting a TimeSpan, TimeStamp deleted")
             self._time_stamp = None
 
     @property
@@ -1082,7 +1082,7 @@ class Placemark(_Feature):
             self._geometry = geom
             return
 
-        logger.warn("No geometries found")
+        logger.warning("No geometries found")
         logger.debug(f"Problem with element: {etree.tostring(element)}")
         # raise ValueError('No geometries found')
 

--- a/fastkml/kml.py
+++ b/fastkml/kml.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012  Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under
@@ -67,7 +66,7 @@ except NameError:
 logger = logging.getLogger(__name__)
 
 
-class KML(object):
+class KML:
     """represents a KML File"""
 
     _features = []
@@ -272,7 +271,7 @@ class _Feature(_BaseObject):
         styleUrl=None,
         extended_data=None,
     ):
-        super(_Feature, self).__init__(ns, id)
+        super().__init__(ns, id)
         self.name = name
         self.description = description
         self.styleUrl = styleUrl
@@ -465,7 +464,7 @@ class _Feature(_BaseObject):
             raise ValueError
 
     def etree_element(self):
-        element = super(_Feature, self).etree_element()
+        element = super().etree_element()
         if self.name:
             name = etree.SubElement(element, "%sname" % self.ns)
             name.text = self.name
@@ -511,7 +510,7 @@ class _Feature(_BaseObject):
         return element
 
     def from_element(self, element):
-        super(_Feature, self).from_element(element)
+        super().from_element(element)
         name = element.find("%sname" % self.ns)
         if name is not None:
             self.name = name.text
@@ -597,7 +596,7 @@ class _Container(_Feature):
     def __init__(
         self, ns=None, id=None, name=None, description=None, styles=None, styleUrl=None
     ):
-        super(_Container, self).__init__(ns, id, name, description, styles, styleUrl)
+        super().__init__(ns, id, name, description, styles, styleUrl)
         self._features = []
 
     def features(self):
@@ -611,7 +610,7 @@ class _Container(_Feature):
                 )
 
     def etree_element(self):
-        element = super(_Container, self).etree_element()
+        element = super().etree_element()
         for feature in self.features():
             element.append(feature.etree_element())
         return element
@@ -658,7 +657,7 @@ class _Overlay(_Feature):
     def __init__(
         self, ns=None, id=None, name=None, description=None, styles=None, styleUrl=None
     ):
-        super(_Overlay, self).__init__(ns, id, name, description, styles, styleUrl)
+        super().__init__(ns, id, name, description, styles, styleUrl)
 
     @property
     def color(self):
@@ -704,7 +703,7 @@ class _Overlay(_Feature):
             raise ValueError
 
     def etree_element(self):
-        element = super(_Overlay, self).etree_element()
+        element = super().etree_element()
         if self._color:
             color = etree.SubElement(element, "%scolor" % self.ns)
             color.text = self._color
@@ -717,7 +716,7 @@ class _Overlay(_Feature):
         return element
 
     def from_element(self, element):
-        super(_Overlay, self).from_element(element)
+        super().from_element(element)
         color = element.find("%scolor" % self.ns)
         if color is not None:
             self.color = color.text
@@ -889,7 +888,7 @@ class GroundOverlay(_Overlay):
         self.rotation = rotation
 
     def etree_element(self):
-        element = super(GroundOverlay, self).etree_element()
+        element = super().etree_element()
         if self._altitude:
             altitude = etree.SubElement(element, "%saltitude" % self.ns)
             altitude.text = self._altitude
@@ -913,7 +912,7 @@ class GroundOverlay(_Overlay):
         return element
 
     def from_element(self, element):
-        super(GroundOverlay, self).from_element(element)
+        super().from_element(element)
         altitude = element.find("%saltitude" % self.ns)
         if altitude is not None:
             self.altitude = altitude.text
@@ -951,8 +950,7 @@ class Document(_Container):
 
     def schemata(self):
         if self._schemata:
-            for schema in self._schemata:
-                yield schema
+            yield from self._schemata
 
     def append_schema(self, schema):
         if self._schemata is None:
@@ -964,7 +962,7 @@ class Document(_Container):
             self._schemata.append(s)
 
     def from_element(self, element):
-        super(Document, self).from_element(element)
+        super().from_element(element)
         documents = element.findall("%sDocument" % self.ns)
         for document in documents:
             feature = Document(self.ns)
@@ -987,7 +985,7 @@ class Document(_Container):
             self.append_schema(s)
 
     def etree_element(self):
-        element = super(Document, self).etree_element()
+        element = super().etree_element()
         if self._schemata is not None:
             for schema in self._schemata:
                 element.append(schema.etree_element())
@@ -1009,7 +1007,7 @@ class Folder(_Container):
     __name__ = "Folder"
 
     def from_element(self, element):
-        super(Folder, self).from_element(element)
+        super().from_element(element)
         folders = element.findall("%sFolder" % self.ns)
         for folder in folders:
             feature = Folder(self.ns)
@@ -1050,7 +1048,7 @@ class Placemark(_Feature):
             self._geometry = Geometry(ns=self.ns, geometry=geometry)
 
     def from_element(self, element):
-        super(Placemark, self).from_element(element)
+        super().from_element(element)
         point = element.find("%sPoint" % self.ns)
         if point is not None:
             geom = Geometry(ns=self.ns)
@@ -1095,11 +1093,11 @@ class Placemark(_Feature):
             return
 
         logger.warn("No geometries found")
-        logger.debug("Problem with element: {}".format(etree.tostring(element)))
+        logger.debug(f"Problem with element: {etree.tostring(element)}")
         # raise ValueError('No geometries found')
 
     def etree_element(self):
-        element = super(Placemark, self).etree_element()
+        element = super().etree_element()
         if self._geometry is not None:
             element.append(self._geometry.etree_element())
         else:
@@ -1191,18 +1189,18 @@ class TimeStamp(_TimePrimitive):
     timestamp = None
 
     def __init__(self, ns=None, id=None, timestamp=None, resolution=None):
-        super(TimeStamp, self).__init__(ns, id)
+        super().__init__(ns, id)
         resolution = self.get_resolution(timestamp, resolution)
         self.timestamp = [timestamp, resolution]
 
     def etree_element(self):
-        element = super(TimeStamp, self).etree_element()
+        element = super().etree_element()
         when = etree.SubElement(element, "%swhen" % self.ns)
         when.text = self.date_to_string(*self.timestamp)
         return element
 
     def from_element(self, element):
-        super(TimeStamp, self).from_element(element)
+        super().from_element(element)
         when = element.find("%swhen" % self.ns)
         if when is not None:
             self.timestamp = self.parse_str(when.text)
@@ -1218,7 +1216,7 @@ class TimeSpan(_TimePrimitive):
     def __init__(
         self, ns=None, id=None, begin=None, begin_res=None, end=None, end_res=None
     ):
-        super(TimeSpan, self).__init__(ns, id)
+        super().__init__(ns, id)
         if begin:
             resolution = self.get_resolution(begin, begin_res)
             self.begin = [begin, resolution]
@@ -1227,7 +1225,7 @@ class TimeSpan(_TimePrimitive):
             self.end = [end, resolution]
 
     def from_element(self, element):
-        super(TimeSpan, self).from_element(element)
+        super().from_element(element)
         begin = element.find("%sbegin" % self.ns)
         if begin is not None:
             self.begin = self.parse_str(begin.text)
@@ -1236,7 +1234,7 @@ class TimeSpan(_TimePrimitive):
             self.end = self.parse_str(end.text)
 
     def etree_element(self):
-        element = super(TimeSpan, self).etree_element()
+        element = super().etree_element()
         if self.begin is not None:
             text = self.date_to_string(*self.begin)
             if text:
@@ -1272,7 +1270,7 @@ class Schema(_BaseObject):
     def __init__(self, ns=None, id=None, name=None, fields=None):
         if id is None:
             raise ValueError("Id is required for schema")
-        super(Schema, self).__init__(ns, id)
+        super().__init__(ns, id)
         self.simple_fields = fields
         self.name = name
 
@@ -1338,7 +1336,7 @@ class Schema(_BaseObject):
         ]
         if type not in allowed_types:
             raise TypeError(
-                "{0} has the type {1} which is invalid. ".format(name, type)
+                f"{name} has the type {type} which is invalid. "
                 + "The type must be one of "
                 + "'string', 'int', 'uint', 'short', "
                 + "'ushort', 'float', 'double', 'bool'"
@@ -1348,7 +1346,7 @@ class Schema(_BaseObject):
         )
 
     def from_element(self, element):
-        super(Schema, self).from_element(element)
+        super().from_element(element)
         self.name = element.get("name")
         simple_fields = element.findall("%sSimpleField" % self.ns)
         self.simple_fields = None
@@ -1360,7 +1358,7 @@ class Schema(_BaseObject):
             self.append(sftype, sfname, sfdisplay_name)
 
     def etree_element(self):
-        element = super(Schema, self).etree_element()
+        element = super().etree_element()
         if self.name:
             element.set("name", self.name)
         for simple_field in self.simple_fields:
@@ -1385,17 +1383,17 @@ class ExtendedData(_XMLObject):
     __name__ = "ExtendedData"
 
     def __init__(self, ns=None, elements=None):
-        super(ExtendedData, self).__init__(ns)
+        super().__init__(ns)
         self.elements = elements or []
 
     def etree_element(self):
-        element = super(ExtendedData, self).etree_element()
+        element = super().etree_element()
         for subelement in self.elements:
             element.append(subelement.etree_element())
         return element
 
     def from_element(self, element):
-        super(ExtendedData, self).from_element(element)
+        super().from_element(element)
         self.elements = []
         untyped_data = element.findall("%sData" % self.ns)
         for ud in untyped_data:
@@ -1411,7 +1409,7 @@ class ExtendedData(_XMLObject):
 
 class UntypedExtendedData(ExtendedData):
     def __init__(self, ns=None, elements=None):
-        super(UntypedExtendedData, self).__init__(ns, elements)
+        super().__init__(ns, elements)
         warnings.warn(
             "UntypedExtendedData is deprecated use ExtendedData instead",
             DeprecationWarning,
@@ -1424,14 +1422,14 @@ class Data(_XMLObject):
     __name__ = "Data"
 
     def __init__(self, ns=None, name=None, value=None, display_name=None):
-        super(Data, self).__init__(ns)
+        super().__init__(ns)
 
         self.name = name
         self.value = value
         self.display_name = display_name
 
     def etree_element(self):
-        element = super(Data, self).etree_element()
+        element = super().etree_element()
         element.set("name", self.name)
         value = etree.SubElement(element, "%svalue" % self.ns)
         value.text = self.value
@@ -1441,7 +1439,7 @@ class Data(_XMLObject):
         return element
 
     def from_element(self, element):
-        super(Data, self).from_element(element)
+        super().from_element(element)
         self.name = element.get("name")
         tmp_value = element.find("%svalue" % self.ns)
         if tmp_value is not None:
@@ -1453,7 +1451,7 @@ class Data(_XMLObject):
 
 class UntypedExtendedDataElement(Data):
     def __init__(self, ns=None, name=None, value=None, display_name=None):
-        super(UntypedExtendedDataElement, self).__init__(ns, name, value, display_name)
+        super().__init__(ns, name, value, display_name)
         warnings.warn(
             "UntypedExtendedDataElement is deprecated use Data instead",
             DeprecationWarning,
@@ -1478,7 +1476,7 @@ class SchemaData(_XMLObject):
     _data = None
 
     def __init__(self, ns=None, schema_url=None, data=None):
-        super(SchemaData, self).__init__(ns)
+        super().__init__(ns)
         if (not isinstance(schema_url, basestring)) or (not schema_url):
             raise ValueError("required parameter schema_url missing")
         self.schema_url = schema_url
@@ -1510,7 +1508,7 @@ class SchemaData(_XMLObject):
             raise TypeError("name must be a nonempty string")
 
     def etree_element(self):
-        element = super(SchemaData, self).etree_element()
+        element = super().etree_element()
         element.set("schemaUrl", self.schema_url)
         for data in self.data:
             sd = etree.SubElement(element, "%sSimpleData" % self.ns)
@@ -1519,7 +1517,7 @@ class SchemaData(_XMLObject):
         return element
 
     def from_element(self, element):
-        super(SchemaData, self).from_element(element)
+        super().from_element(element)
         self.data = []
         self.schema_url = element.get("schemaUrl")
         simple_data = element.findall("%sSimpleData" % self.ns)

--- a/fastkml/kml.py
+++ b/fastkml/kml.py
@@ -24,12 +24,8 @@ The complete XML schema for KML is located at
 http://schemas.opengis.net/kml/.
 
 """
-try:
-    import urlparse
-except ImportError:
-    import urllib.parse as urlparse  # Python 3
-
 import logging
+import urllib.parse as urlparse
 import warnings
 from datetime import date
 from datetime import datetime
@@ -56,12 +52,6 @@ from .styles import Style
 from .styles import StyleMap
 from .styles import StyleUrl
 from .styles import _StyleSelector
-
-try:
-    unicode
-except NameError:
-    # Python 3
-    basestring = unicode = str
 
 logger = logging.getLogger(__name__)
 
@@ -293,7 +283,7 @@ class _Feature(_BaseObject):
         """you may pass a StyleUrl Object, a string or None"""
         if isinstance(styleurl, StyleUrl):
             self._styleUrl = styleurl
-        elif isinstance(styleurl, basestring):
+        elif isinstance(styleurl, str):
             s = StyleUrl(self.ns, url=styleurl)
             self._styleUrl = s
         elif styleurl is None:
@@ -354,7 +344,7 @@ class _Feature(_BaseObject):
 
     @link.setter
     def link(self, url):
-        if isinstance(url, basestring):
+        if isinstance(url, str):
             self._atom_link = atom.Link(href=url)
         elif isinstance(url, atom.Link):
             self._atom_link = url
@@ -372,7 +362,7 @@ class _Feature(_BaseObject):
     def author(self, name):
         if isinstance(name, atom.Author):
             self._atom_author = name
-        elif isinstance(name, basestring):
+        elif isinstance(name, str):
             if self._atom_author is None:
                 self._atom_author = atom.Author(name=name)
             else:
@@ -404,14 +394,14 @@ class _Feature(_BaseObject):
         if isinstance(self._snippet, dict):
             text = self._snippet.get("text")
             if text:
-                assert isinstance(text, basestring)
+                assert isinstance(text, str)
                 max_lines = self._snippet.get("maxLines", None)
                 if max_lines is None:
                     return {"text": text}
                 elif int(max_lines) > 0:
                     # if maxLines <=0 ignore it
                     return {"text": text, "maxLines": max_lines}
-        elif isinstance(self._snippet, basestring):
+        elif isinstance(self._snippet, str):
             return self._snippet
         else:
             raise ValueError(
@@ -426,7 +416,7 @@ class _Feature(_BaseObject):
             max_lines = snip.get("maxLines")
             if max_lines is not None:
                 self._snippet["maxLines"] = int(snip["maxLines"])
-        elif isinstance(snip, basestring):
+        elif isinstance(snip, str):
             self._snippet["text"] = snip
         elif snip is None:
             self._snippet = None
@@ -442,7 +432,7 @@ class _Feature(_BaseObject):
 
     @address.setter
     def address(self, address):
-        if isinstance(address, basestring):
+        if isinstance(address, str):
             self._address = address
         elif address is None:
             self._address = None
@@ -456,7 +446,7 @@ class _Feature(_BaseObject):
 
     @phoneNumber.setter
     def phoneNumber(self, phoneNumber):
-        if isinstance(phoneNumber, basestring):
+        if isinstance(phoneNumber, str):
             self._phoneNumber = phoneNumber
         elif phoneNumber is None:
             self._phoneNumber = None
@@ -482,10 +472,10 @@ class _Feature(_BaseObject):
             element.append(style.etree_element())
         if self.snippet:
             snippet = etree.SubElement(element, "%sSnippet" % self.ns)
-            if isinstance(self.snippet, basestring):
+            if isinstance(self.snippet, str):
                 snippet.text = self.snippet
             else:
-                assert isinstance(self.snippet["text"], basestring)
+                assert isinstance(self.snippet["text"], str)
                 snippet.text = self.snippet["text"]
                 if self.snippet.get("maxLines"):
                     snippet.set("maxLines", str(self.snippet["maxLines"]))
@@ -665,7 +655,7 @@ class _Overlay(_Feature):
 
     @color.setter
     def color(self, color):
-        if isinstance(color, basestring):
+        if isinstance(color, str):
             self._color = color
         elif color is None:
             self._color = None
@@ -678,7 +668,7 @@ class _Overlay(_Feature):
 
     @drawOrder.setter
     def drawOrder(self, value):
-        if isinstance(value, (basestring, int, float)):
+        if isinstance(value, (str, int, float)):
             self._drawOrder = str(value)
         elif value is None:
             self._drawOrder = None
@@ -691,7 +681,7 @@ class _Overlay(_Feature):
 
     @icon.setter
     def icon(self, url):
-        if isinstance(url, basestring):
+        if isinstance(url, str):
             if not url.startswith("<href>"):
                 url = "<href>" + url
             if not url.endswith("</href>"):
@@ -796,7 +786,7 @@ class GroundOverlay(_Overlay):
 
     @altitude.setter
     def altitude(self, value):
-        if isinstance(value, (basestring, int, float)):
+        if isinstance(value, (str, int, float)):
             self._altitude = str(value)
         elif value is None:
             self._altitude = None
@@ -820,7 +810,7 @@ class GroundOverlay(_Overlay):
 
     @north.setter
     def north(self, value):
-        if isinstance(value, (basestring, int, float)):
+        if isinstance(value, (str, int, float)):
             self._north = str(value)
         elif value is None:
             self._north = None
@@ -833,7 +823,7 @@ class GroundOverlay(_Overlay):
 
     @south.setter
     def south(self, value):
-        if isinstance(value, (basestring, int, float)):
+        if isinstance(value, (str, int, float)):
             self._south = str(value)
         elif value is None:
             self._south = None
@@ -846,7 +836,7 @@ class GroundOverlay(_Overlay):
 
     @east.setter
     def east(self, value):
-        if isinstance(value, (basestring, int, float)):
+        if isinstance(value, (str, int, float)):
             self._east = str(value)
         elif value is None:
             self._east = None
@@ -859,7 +849,7 @@ class GroundOverlay(_Overlay):
 
     @west.setter
     def west(self, value):
-        if isinstance(value, (basestring, int, float)):
+        if isinstance(value, (str, int, float)):
             self._west = str(value)
         elif value is None:
             self._west = None
@@ -872,7 +862,7 @@ class GroundOverlay(_Overlay):
 
     @rotation.setter
     def rotation(self, value):
-        if isinstance(value, (basestring, int, float)):
+        if isinstance(value, (str, int, float)):
             self._rotation = str(value)
         elif value is None:
             self._rotation = None
@@ -1477,7 +1467,7 @@ class SchemaData(_XMLObject):
 
     def __init__(self, ns=None, schema_url=None, data=None):
         super().__init__(ns)
-        if (not isinstance(schema_url, basestring)) or (not schema_url):
+        if (not isinstance(schema_url, str)) or (not schema_url):
             raise ValueError("required parameter schema_url missing")
         self.schema_url = schema_url
         self._data = []
@@ -1502,7 +1492,7 @@ class SchemaData(_XMLObject):
             raise TypeError("data must be of type tuple or list")
 
     def append_data(self, name, value):
-        if isinstance(name, basestring) and name:
+        if isinstance(name, str) and name:
             self._data.append({"name": name, "value": value})
         else:
             raise TypeError("name must be a nonempty string")

--- a/fastkml/styles.py
+++ b/fastkml/styles.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012  Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under
@@ -40,19 +39,19 @@ class StyleUrl(_BaseObject):
     url = None
 
     def __init__(self, ns=None, id=None, url=None):
-        super(StyleUrl, self).__init__(ns, id)
+        super().__init__(ns, id)
         self.url = url
 
     def etree_element(self):
         if self.url:
-            element = super(StyleUrl, self).etree_element()
+            element = super().etree_element()
             element.text = self.url
             return element
         else:
             raise ValueError("No url given for styleUrl")
 
     def from_element(self, element):
-        super(StyleUrl, self).from_element(element)
+        super().from_element(element)
         self.url = element.text
 
 
@@ -80,7 +79,7 @@ class Style(_StyleSelector):
     _styles = None
 
     def __init__(self, ns=None, id=None, styles=None):
-        super(Style, self).__init__(ns, id)
+        super().__init__(ns, id)
         self._styles = []
         if styles:
             for style in styles:
@@ -100,7 +99,7 @@ class Style(_StyleSelector):
                 raise TypeError
 
     def from_element(self, element):
-        super(Style, self).from_element(element)
+        super().from_element(element)
         style = element.find("%sIconStyle" % self.ns)
         if style is not None:
             thestyle = IconStyle(self.ns)
@@ -128,7 +127,7 @@ class Style(_StyleSelector):
             self.append_style(thestyle)
 
     def etree_element(self):
-        element = super(Style, self).etree_element()
+        element = super().etree_element()
         for style in self.styles():
             element.append(style.etree_element())
         return element
@@ -147,12 +146,12 @@ class StyleMap(_StyleSelector):
     highlight = None
 
     def __init__(self, ns=None, id=None, normal=None, highlight=None):
-        super(StyleMap, self).__init__(ns, id)
+        super().__init__(ns, id)
         self.normal = normal
         self.highlight = highlight
 
     def from_element(self, element):
-        super(StyleMap, self).from_element(element)
+        super().from_element(element)
         pairs = element.findall("%sPair" % self.ns)
         for pair in pairs:
             key = pair.find("%skey" % self.ns)
@@ -182,7 +181,7 @@ class StyleMap(_StyleSelector):
                 raise ValueError
 
     def etree_element(self):
-        element = super(StyleMap, self).etree_element()
+        element = super().etree_element()
         if self.normal and isinstance(self.normal, (Style, StyleUrl)):
             pair = etree.SubElement(element, "%sPair" % self.ns)
             key = etree.SubElement(pair, "%skey" % self.ns)
@@ -219,12 +218,12 @@ class _ColorStyle(_BaseObject):
     # A value of random applies a random linear scale to the base <color>
 
     def __init__(self, ns=None, id=None, color=None, colorMode=None):
-        super(_ColorStyle, self).__init__(ns, id)
+        super().__init__(ns, id)
         self.color = color
         self.colorMode = colorMode
 
     def etree_element(self):
-        element = super(_ColorStyle, self).etree_element()
+        element = super().etree_element()
         if self.color:
             color = etree.SubElement(element, "%scolor" % self.ns)
             color.text = self.color
@@ -234,7 +233,7 @@ class _ColorStyle(_BaseObject):
         return element
 
     def from_element(self, element):
-        super(_ColorStyle, self).from_element(element)
+        super().from_element(element)
         colorMode = element.find("%scolorMode" % self.ns)
         if colorMode is not None:
             self.colorMode = colorMode.text
@@ -265,13 +264,13 @@ class IconStyle(_ColorStyle):
         heading=None,
         icon_href=None,
     ):
-        super(IconStyle, self).__init__(ns, id, color, colorMode)
+        super().__init__(ns, id, color, colorMode)
         self.scale = scale
         self.heading = heading
         self.icon_href = icon_href
 
     def etree_element(self):
-        element = super(IconStyle, self).etree_element()
+        element = super().etree_element()
         if self.scale is not None:
             scale = etree.SubElement(element, "%sscale" % self.ns)
             scale.text = str(self.scale)
@@ -285,7 +284,7 @@ class IconStyle(_ColorStyle):
         return element
 
     def from_element(self, element):
-        super(IconStyle, self).from_element(element)
+        super().from_element(element)
         scale = element.find("%sscale" % self.ns)
         if scale is not None:
             self.scale = float(scale.text)
@@ -312,18 +311,18 @@ class LineStyle(_ColorStyle):
     # Width of the line, in pixels.
 
     def __init__(self, ns=None, id=None, color=None, colorMode=None, width=1):
-        super(LineStyle, self).__init__(ns, id, color, colorMode)
+        super().__init__(ns, id, color, colorMode)
         self.width = width
 
     def etree_element(self):
-        element = super(LineStyle, self).etree_element()
+        element = super().etree_element()
         if self.width is not None:
             width = etree.SubElement(element, "%swidth" % self.ns)
             width.text = str(self.width)
         return element
 
     def from_element(self, element):
-        super(LineStyle, self).from_element(element)
+        super().from_element(element)
         width = element.find("%swidth" % self.ns)
         if width is not None:
             self.width = float(width.text)
@@ -344,12 +343,12 @@ class PolyStyle(_ColorStyle):
     # Polygon outlines use the current LineStyle.
 
     def __init__(self, ns=None, id=None, color=None, colorMode=None, fill=1, outline=1):
-        super(PolyStyle, self).__init__(ns, id, color, colorMode)
+        super().__init__(ns, id, color, colorMode)
         self.fill = fill
         self.outline = outline
 
     def etree_element(self):
-        element = super(PolyStyle, self).etree_element()
+        element = super().etree_element()
         if self.fill is not None:
             fill = etree.SubElement(element, "%sfill" % self.ns)
             fill.text = str(self.fill)
@@ -359,7 +358,7 @@ class PolyStyle(_ColorStyle):
         return element
 
     def from_element(self, element):
-        super(PolyStyle, self).from_element(element)
+        super().from_element(element)
         fill = element.find("%sfill" % self.ns)
         if fill is not None:
             self.fill = int(float(fill.text))
@@ -378,18 +377,18 @@ class LabelStyle(_ColorStyle):
     # Resizes the label.
 
     def __init__(self, ns=None, id=None, color=None, colorMode=None, scale=1.0):
-        super(LabelStyle, self).__init__(ns, id, color, colorMode)
+        super().__init__(ns, id, color, colorMode)
         self.scale = scale
 
     def etree_element(self):
-        element = super(LabelStyle, self).etree_element()
+        element = super().etree_element()
         if self.scale is not None:
             scale = etree.SubElement(element, "%sscale" % self.ns)
             scale.text = str(self.scale)
         return element
 
     def from_element(self, element):
-        super(LabelStyle, self).from_element(element)
+        super().from_element(element)
         scale = element.find("%sscale" % self.ns)
         if scale is not None:
             self.scale = float(scale.text)
@@ -455,14 +454,14 @@ class BalloonStyle(_BaseObject):
         text=None,
         displayMode=None,
     ):
-        super(BalloonStyle, self).__init__(ns, id)
+        super().__init__(ns, id)
         self.bgColor = bgColor
         self.textColor = textColor
         self.text = text
         self.displayMode = displayMode
 
     def from_element(self, element):
-        super(BalloonStyle, self).from_element(element)
+        super().from_element(element)
         bgColor = element.find("%sbgColor" % self.ns)
         if bgColor is not None:
             self.bgColor = bgColor.text
@@ -481,7 +480,7 @@ class BalloonStyle(_BaseObject):
             self.displayMode = displayMode.text
 
     def etree_element(self):
-        element = super(BalloonStyle, self).etree_element()
+        element = super().etree_element()
         if self.bgColor is not None:
             elem = etree.SubElement(element, "%sbgColor" % self.ns)
             elem.text = self.bgColor

--- a/fastkml/test_main.py
+++ b/fastkml/test_main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012  Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under
@@ -308,7 +307,7 @@ class BuildKmlTestCase(unittest.TestCase):
         f2.append(p)
         nf.append(p2)
         self.assertEqual(len(list(k.features())), 1)
-        self.assertEqual(len(list((list(k.features())[0].features()))), 2)
+        self.assertEqual(len(list(list(k.features())[0].features())), 2)
         k2 = kml.KML()
         k2.from_string(k.to_string())
         self.assertEqual(k.to_string(), k2.to_string())
@@ -1181,7 +1180,7 @@ class StyleFromStringTestCase(unittest.TestCase):
 
         k = kml.KML()
         k.from_string(doc)
-        self.assertEqual(len(list((k.features()))), 1)
+        self.assertEqual(len(list(k.features())), 1)
         self.assertTrue(
             isinstance(list(list(k.features())[0].styles())[0], styles.Style)
         )

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,6 @@ setup(
     classifiers=[
         "Topic :: Scientific/Engineering :: GIS",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    {py27,py33,py34,py35},
-    {py27,py33,py34,py35}-{shapely,lxml},
-    {py27,py33,py34,py35}-shapely-lxml,
+    {py33,py34,py35},
+    {py33,py34,py35}-{shapely,lxml},
+    {py33,py34,py35}-shapely-lxml,
     pep8,docs
 
 [testenv]


### PR DESCRIPTION
Hello! This pull request drops Python 2 support, as per #132 python2 would be dropped anyway, and python2 is EOL for quite some time

I made the upgrade by first running automated fixers: pyupgrade and lib2to3, and then manually removing references.
I edited almost all places where python2 is referenced in the docs too, but it looks like tox is not used anymore? Should I drop it or add new envlist?
Also am I right that the project now supports python >= 3.6 only? If so I can also remove references for python versions less than 3.6