### PR TITLE
Fix bug when fill or outline are boolean strings

### DIFF
--- a/fastkml/styles.py
+++ b/fastkml/styles.py
@@ -20,6 +20,7 @@ code Google Earth generates, you'll notice how styles are an important
 part of how your data is displayed.
 """
 
+import distutils
 import logging
 
 from fastkml.base import _BaseObject
@@ -362,10 +363,16 @@ class PolyStyle(_ColorStyle):
         super().from_element(element)
         fill = element.find(f"{self.ns}fill")
         if fill is not None:
-            self.fill = int(float(fill.text))
-        outline = element.find(f"{self.ns}outline")
+            try:
+                self.fill = distutils.util.strtobool(fill.text)
+            except ValueError:
+                self.fill = int(float(fill.text))
+        outline = element.find("%soutline" % self.ns)
         if outline is not None:
-            self.outline = int(float(outline.text))
+            try:
+                self.outline = distutils.util.strtobool(outline.text)
+            except ValueError:
+                self.outline = int(float(outline.text))
 
 
 class LabelStyle(_ColorStyle):

--- a/fastkml/styles.py
+++ b/fastkml/styles.py
@@ -20,7 +20,6 @@ code Google Earth generates, you'll notice how styles are an important
 part of how your data is displayed.
 """
 
-import distutils
 import logging
 
 from fastkml.base import _BaseObject
@@ -360,19 +359,21 @@ class PolyStyle(_ColorStyle):
         return element
 
     def from_element(self, element):
+        def strtobool (val):
+            val = val.lower()
+            if val == 'false':
+                return 0
+            if val == 'true':
+                return 1
+            return int(float(val))
+
         super().from_element(element)
         fill = element.find(f"{self.ns}fill")
         if fill is not None:
-            try:
-                self.fill = distutils.util.strtobool(fill.text)
-            except ValueError:
-                self.fill = int(float(fill.text))
-        outline = element.find("%soutline" % self.ns)
+            self.fill = strtobool(fill.text)
+        outline = element.find(f"{self.ns}outline")
         if outline is not None:
-            try:
-                self.outline = distutils.util.strtobool(outline.text)
-            except ValueError:
-                self.outline = int(float(outline.text))
+            self.outline = strtobool(outline.text)
 
 
 class LabelStyle(_ColorStyle):

--- a/fastkml/styles.py
+++ b/fastkml/styles.py
@@ -359,7 +359,7 @@ class PolyStyle(_ColorStyle):
         return element
 
     def from_element(self, element):
-        def strtobool (val):
+        def strtobool(val):
             val = val.lower()
             if val == 'false':
                 return 0

--- a/fastkml/test_main.py
+++ b/fastkml/test_main.py
@@ -1228,6 +1228,50 @@ class StyleFromStringTestCase(unittest.TestCase):
         k2.from_string(k.to_string())
         self.assertEqual(k.to_string(), k2.to_string())
 
+    def test_polystyle_boolean_fill(self):
+        doc = """<kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <name>PolygonStyle.kml</name>
+          <open>1</open>
+          <Style id="examplePolyStyle">
+            <PolyStyle>
+              <fill>false</fill>
+            </PolyStyle>
+          </Style>
+        </Document>
+        </kml>"""
+
+        k = kml.KML()
+        k.from_string(doc)
+        style = list(list(list(k.features())[0].styles())[0].styles())[0]
+        self.assertIsInstance(style, styles.PolyStyle)
+        self.assertEqual(style.fill, 0)
+        k2 = kml.KML()
+        k2.from_string(k.to_string())
+        self.assertEqual(k.to_string(), k2.to_string())
+
+    def test_polystyle_boolean_outline(self):
+        doc = """<kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <name>PolygonStyle.kml</name>
+          <open>1</open>
+          <Style id="examplePolyStyle">
+            <PolyStyle>
+              <outline>false</outline>
+            </PolyStyle>
+          </Style>
+        </Document>
+        </kml>"""
+
+        k = kml.KML()
+        k.from_string(doc)
+        style = list(list(list(k.features())[0].styles())[0].styles())[0]
+        self.assertIsInstance(style, styles.PolyStyle)
+        self.assertEqual(style.outline, 0)
+        k2 = kml.KML()
+        k2.from_string(k.to_string())
+        self.assertEqual(k.to_string(), k2.to_string())
+
     def test_polystyle_float_fill(self):
         doc = """<kml xmlns="http://www.opengis.net/kml/2.2">
         <Document>


### PR DESCRIPTION
When either the `fill` or `outline` tags of `PolyStyle` are represented by boolean strings, I get a ValueError saying strings 'false' or 'true' are not valid float values.

Since [these attributes are defined as boolean](https://developers.google.com/kml/documentation/kmlreference#elements-specific-to-polystyle), this pull request first tries to evaluate them as strings 'true' or 'false' (returning 1 or 0, respectively), then it falls back to the previous method: `int(float(...))`