### PR TITLE
Remove mistake from the usage_guide.rst

### DIFF
--- a/docs/usage_guide.rst
+++ b/docs/usage_guide.rst
@@ -104,7 +104,7 @@ You can create a KML object by reading a KML file as a string
     >>> from fastkml import kml
     
     #Read file into string and convert to UTF-8 (Python3 style)
-    >>> with open(kml_file, 'rt', encoding="utf-8") as myfile:
+    >>> with open(kml_file, 'rb') as myfile:
     ...     doc=myfile.read()
     
     # OR


### PR DESCRIPTION
This PR suggests changing file opening in KML file reading example from `open(kml_file, 'rt', encoding="utf-8")` to opening file in binary mode `open(kml_file, 'rb')`. Otherwise the latest version of fastkml throws exception "Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration."