### PR TITLE
Type annotate fastkml.data

### DIFF
--- a/fastkml/config.py
+++ b/fastkml/config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012 - 2021  Christian Ledermannconfig
+# Copyright (C) 2012 - 2021  Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/fastkml/config.py
+++ b/fastkml/config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012 - 2021  Christian Ledermann
+# Copyright (C) 2012 - 2021  Christian Ledermannconfig
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free

--- a/fastkml/data.py
+++ b/fastkml/data.py
@@ -6,9 +6,9 @@ from typing import Union
 
 from typing_extensions import TypedDict
 
+from fastkml import config as config
 from fastkml.base import _BaseObject
 from fastkml.base import _XMLObject
-from fastkml.config import etree  # type: ignore[attr-defined]
 from fastkml.types import Element
 
 
@@ -145,11 +145,15 @@ class Schema(_BaseObject):
         if self.name:
             element.set("name", self.name)
         for simple_field in self.simple_fields:
-            sf = etree.SubElement(element, f"{self.ns}SimpleField")
+            sf = config.etree.SubElement(  # type: ignore[attr-defined]
+                element, f"{self.ns}SimpleField"
+            )
             sf.set("type", simple_field["type"])
             sf.set("name", simple_field["name"])
             if simple_field.get("displayName"):
-                dn = etree.SubElement(sf, f"{self.ns}displayName")
+                dn = config.etree.SubElement(  # type: ignore[attr-defined]
+                    sf, f"{self.ns}displayName"
+                )
                 dn.text = simple_field["displayName"]
         return element
 
@@ -175,10 +179,14 @@ class Data(_XMLObject):
     def etree_element(self) -> Element:
         element = super().etree_element()
         element.set("name", self.name or "")
-        value = etree.SubElement(element, f"{self.ns}value")
+        value = config.etree.SubElement(  # type: ignore[attr-defined]
+            element, f"{self.ns}value"
+        )
         value.text = self.value
         if self.display_name:
-            display_name = etree.SubElement(element, f"{self.ns}displayName")
+            display_name = config.etree.SubElement(  # type: ignore[attr-defined]
+                element, f"{self.ns}displayName"
+            )
             display_name.text = self.display_name
         return element
 
@@ -299,7 +307,9 @@ class SchemaData(_XMLObject):
         element = super().etree_element()
         element.set("schemaUrl", self.schema_url)
         for data in self.data:
-            sd = etree.SubElement(element, f"{self.ns}SimpleData")
+            sd = config.etree.SubElement(  # type: ignore[attr-defined]
+                element, f"{self.ns}SimpleData"
+            )
             sd.set("name", data["name"])
             sd.text = data["value"]
         return element

--- a/fastkml/data.py
+++ b/fastkml/data.py
@@ -3,6 +3,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
+from typing import overload
 
 from typing_extensions import TypedDict
 
@@ -19,12 +20,11 @@ class SimpleField(TypedDict):
 
 
 SimpleFields = List[Dict[str, str]]
+SimpleFieldsListInput = List[Union[Dict[str, str], List[Dict[str, str]]]]
+SimpleFieldsTupleInput = Tuple[Union[Dict[str, str], Tuple[Dict[str, str]]]]
+SimpleFieldsDictInput = Dict[str, str]
 SimpleFieldsInput = Optional[
-    Union[
-        List[Union[Dict[str, str], List[Dict[str, str]]]],
-        Tuple[Union[Dict[str, str], Tuple[Dict[str, str]]]],
-        Dict[str, str],
-    ]
+    Union[SimpleFieldsListInput, SimpleFieldsTupleInput, SimpleFieldsDictInput]
 ]
 SimpleFieldsOutput = Tuple[SimpleField, ...]
 
@@ -70,6 +70,21 @@ class Schema(_BaseObject):
             for simple_field in self._simple_fields
             if simple_field.get("type") and simple_field.get("name")
         )
+
+    @simple_fields.setter
+    @overload
+    def simple_fields(self, fields: SimpleFieldsListInput) -> None:
+        ...
+
+    @simple_fields.setter
+    @overload
+    def simple_fields(self, fields: SimpleFieldsTupleInput) -> None:
+        ...
+
+    @simple_fields.setter
+    @overload
+    def simple_fields(self, fields: SimpleFieldsDictInput) -> None:
+        ...
 
     @simple_fields.setter
     def simple_fields(self, fields: SimpleFieldsInput) -> None:
@@ -240,14 +255,17 @@ class ExtendedData(_XMLObject):
             self.elements.append(el_schema_data)
 
 
+SchemaDataType = List[Dict[str, Union[int, str]]]
+SchemaDataListInput = List[Union[Dict[str, str], SchemaDataType]]
+SchemaDataTupleInput = Tuple[Union[Dict[str, str], Tuple[Dict[str, Union[int, str]]]]]
+SchemaDataDictInput = Dict[str, Union[int, str]]
 SchemaDataInput = Optional[
     Union[
-        List[Union[Dict[str, str], List[Dict[str, Union[int, str]]]]],
-        Tuple[Union[Dict[str, str], Tuple[Dict[str, Union[int, str]]]]],
-        Dict[str, Union[int, str]],
+        SchemaDataListInput,
+        SchemaDataTupleInput,
+        SchemaDataDictInput,
     ]
 ]
-SchemaDataType = List[Dict[str, Union[int, str]]]
 SchemaDataOutput = Tuple[Dict[str, Union[int, str]], ...]
 
 
@@ -282,6 +300,21 @@ class SchemaData(_XMLObject):
     @property
     def data(self) -> SchemaDataOutput:
         return tuple(self._data)
+
+    @data.setter
+    @overload
+    def data(self, data: SchemaDataListInput) -> None:
+        ...
+
+    @data.setter
+    @overload
+    def data(self, data: SchemaDataTupleInput) -> None:
+        ...
+
+    @data.setter
+    @overload
+    def data(self, data: SchemaDataDictInput) -> None:
+        ...
 
     @data.setter
     def data(self, data: SchemaDataInput) -> None:

--- a/fastkml/data.py
+++ b/fastkml/data.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -17,12 +18,12 @@ class SimpleField(TypedDict):
     displayName: Optional[str]  # noqa: N815
 
 
-SimpleFields = List[dict[str, Union[str, str]]]
+SimpleFields = List[Dict[str, Union[str, str]]]
 SimpleFieldsInput = Optional[
     Union[
-        List[Union[dict[str, str], List[dict[str, str]]]],
-        Tuple[Union[dict[str, str], Tuple[dict[str, str]]]],
-        dict[str, str],
+        List[Union[Dict[str, str], List[Dict[str, str]]]],
+        Tuple[Union[Dict[str, str], Tuple[Dict[str, str]]]],
+        Dict[str, str],
     ]
 ]
 SimpleFieldsOutput = Tuple[SimpleField, ...]
@@ -83,7 +84,7 @@ class Schema(_BaseObject):
         elif fields is None:
             self._simple_fields = []
         else:
-            raise ValueError("Fields must be of type list, tuple or dict")
+            raise ValueError("Fields must be of type list, tuple or Dict")
 
     def append(self, type: str, name: str, display_name: Optional[str] = None) -> None:
         """
@@ -233,13 +234,13 @@ class ExtendedData(_XMLObject):
 
 SchemaDataInput = Optional[
     Union[
-        List[Union[dict[str, str], List[dict[str, Union[int, str]]]]],
-        Tuple[Union[dict[str, str], Tuple[dict[str, Union[int, str]]]]],
-        dict[str, Union[int, str]],
+        List[Union[Dict[str, str], List[Dict[str, Union[int, str]]]]],
+        Tuple[Union[Dict[str, str], Tuple[Dict[str, Union[int, str]]]]],
+        Dict[str, Union[int, str]],
     ]
 ]
-SchemaDataType = List[dict[str, Union[int, str]]]
-SchemaDataOutput = Tuple[dict[str, Union[int, str]], ...]
+SchemaDataType = List[Dict[str, Union[int, str]]]
+SchemaDataOutput = Tuple[Dict[str, Union[int, str]], ...]
 
 
 class SchemaData(_XMLObject):
@@ -261,7 +262,7 @@ class SchemaData(_XMLObject):
         self,
         ns: Optional[str] = None,
         schema_url: Optional[str] = None,
-        data: Optional[List[dict[str, str]]] = None,
+        data: Optional[List[Dict[str, str]]] = None,
     ) -> None:
         super().__init__(ns)
         if (not isinstance(schema_url, str)) or (not schema_url):

--- a/fastkml/data.py
+++ b/fastkml/data.py
@@ -6,9 +6,9 @@ from typing import Union
 
 from typing_extensions import TypedDict
 
-import fastkml.config as config
 from fastkml.base import _BaseObject
 from fastkml.base import _XMLObject
+from fastkml.config import etree  # type: ignore[attr-defined]
 from fastkml.types import Element
 
 
@@ -145,11 +145,11 @@ class Schema(_BaseObject):
         if self.name:
             element.set("name", self.name)
         for simple_field in self.simple_fields:
-            sf = config.etree.SubElement(element, f"{self.ns}SimpleField")  # type: ignore[attr-defined]
+            sf = etree.SubElement(element, f"{self.ns}SimpleField")
             sf.set("type", simple_field["type"])
             sf.set("name", simple_field["name"])
             if simple_field.get("displayName"):
-                dn = config.etree.SubElement(sf, f"{self.ns}displayName")  # type: ignore[attr-defined]
+                dn = etree.SubElement(sf, f"{self.ns}displayName")
                 dn.text = simple_field["displayName"]
         return element
 
@@ -175,10 +175,10 @@ class Data(_XMLObject):
     def etree_element(self) -> Element:
         element = super().etree_element()
         element.set("name", self.name or "")
-        value = config.etree.SubElement(element, f"{self.ns}value")  # type: ignore[attr-defined]
+        value = etree.SubElement(element, f"{self.ns}value")
         value.text = self.value
         if self.display_name:
-            display_name = config.etree.SubElement(element, f"{self.ns}displayName")  # type: ignore[attr-defined]
+            display_name = etree.SubElement(element, f"{self.ns}displayName")
             display_name.text = self.display_name
         return element
 
@@ -299,7 +299,7 @@ class SchemaData(_XMLObject):
         element = super().etree_element()
         element.set("schemaUrl", self.schema_url)
         for data in self.data:
-            sd = config.etree.SubElement(element, f"{self.ns}SimpleData")  # type: ignore[attr-defined]
+            sd = etree.SubElement(element, f"{self.ns}SimpleData")
             sd.set("name", data["name"])
             sd.text = data["value"]
         return element

--- a/fastkml/data.py
+++ b/fastkml/data.py
@@ -18,7 +18,7 @@ class SimpleField(TypedDict):
     displayName: Optional[str]  # noqa: N815
 
 
-SimpleFields = List[Dict[str, Union[str, str]]]
+SimpleFields = List[Dict[str, str]]
 SimpleFieldsInput = Optional[
     Union[
         List[Union[Dict[str, str], List[Dict[str, str]]]],

--- a/fastkml/data.py
+++ b/fastkml/data.py
@@ -84,7 +84,7 @@ class Schema(_BaseObject):
         elif fields is None:
             self._simple_fields = []
         else:
-            raise ValueError("Fields must be of type list, tuple or Dict")
+            raise ValueError("Fields must be of type list, tuple or dict")
 
     def append(self, type: str, name: str, display_name: Optional[str] = None) -> None:
         """

--- a/fastkml/data.py
+++ b/fastkml/data.py
@@ -7,7 +7,7 @@ from typing import overload
 
 from typing_extensions import TypedDict
 
-from fastkml import config as config
+import fastkml.config as config
 from fastkml.base import _BaseObject
 from fastkml.base import _XMLObject
 from fastkml.types import Element

--- a/fastkml/tests/oldunit_test.py
+++ b/fastkml/tests/oldunit_test.py
@@ -194,12 +194,12 @@ class TestBuildKml:
         assert list(s.simple_fields)[0]["name"] == "Integer"
         assert list(s.simple_fields)[0]["displayName"] == "An Integer"
         s.simple_fields = [["float", "Float"], fields]
-        assert list(s.simple_fields)[0]["type"] == "float"
-        assert list(s.simple_fields)[0]["name"] == "Float"
-        assert list(s.simple_fields)[0]["displayName"] is None
-        assert list(s.simple_fields)[1]["type"] == "int"
-        assert list(s.simple_fields)[1]["name"] == "Integer"
-        assert list(s.simple_fields)[1]["displayName"] == "An Integer"
+        assert list(s.simple_fields)[0]["type"] == "int"
+        assert list(s.simple_fields)[0]["name"] == "Integer"
+        assert list(s.simple_fields)[0]["displayName"] == "An Integer"
+        assert list(s.simple_fields)[1]["type"] == "float"
+        assert list(s.simple_fields)[1]["name"] == "Float"
+        assert list(s.simple_fields)[1]["displayName"] is None
 
     def test_schema_data(self):
         ns = "{http://www.opengis.net/kml/2.2}"  # noqa: FS003

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ show_error_codes = true
 
 [[tool.mypy.overrides]]
 module = [
-    "fastkml.kml", "fastkml.data", "fastkml.views", "fastkml.times",
+    "fastkml.kml", "fastkml.views", "fastkml.times",
     "fastkml.tests.oldunit_test", "fastkml.tests.config_test"
 ]
 ignore_errors = true


### PR DESCRIPTION
Adds type annotations for data module and includes data module in `pyproject.toml` mypy settings.

Some warnings needed to be ignored because of how mypy deals with getters/setters annotations (see https://github.com/python/mypy/issues/3004)

Closes #189