### PR TITLE
Replaced TypeError with warning log for invalid schema type

### DIFF
--- a/fastkml/data.py
+++ b/fastkml/data.py
@@ -14,6 +14,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 """Add Custom Data"""
+import logging
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -27,6 +28,8 @@ import fastkml.config as config
 from fastkml.base import _BaseObject
 from fastkml.base import _XMLObject
 from fastkml.types import Element
+
+logger = logging.getLogger(__name__)
 
 
 class SimpleField(TypedDict):
@@ -150,7 +153,7 @@ class Schema(_BaseObject):
             "bool",
         ]
         if type not in allowed_types:
-            raise TypeError(
+            logger.warning(
                 f"{name} has the type {type} which is invalid. "
                 "The type must be one of "
                 "'string', 'int', 'uint', 'short', "

--- a/tests/oldunit_test.py
+++ b/tests/oldunit_test.py
@@ -198,6 +198,8 @@ class TestBuildKml:
         assert list(s.simple_fields)[1]["type"] == "float"
         assert list(s.simple_fields)[1]["name"] == "Float"
         assert list(s.simple_fields)[1]["displayName"] is None
+        # 'long' is an invalid value, logs a warning but does not error
+        s.append("long", "Long", "A Long")
 
     def test_schema_data(self):
         ns = "{http://www.opengis.net/kml/2.2}"  # noqa: FS003


### PR DESCRIPTION
Fixes #48 

Reading a KML string with a `Schema` containing an [invalid type](https://developers.google.com/kml/documentation/extendeddata#adding-typed-data-to-a-feature) raised a `TypeError`. 

As suggested in #48, I have changed the `kml.Schema.append` method to log a warning instead of raising an error. I added a line to one of the existing test schema methods to check this behaviour, although the file is called `oldunit_test.py`, so not sure if I should place this elsewhere..

_N.B.: This is my first contribution to this project so plz let me know if I missed sth 😅 Thank uuu!_ 