### PR TITLE
Add `to_dict()` to ExtendedData

### DIFF
--- a/fastkml/data.py
+++ b/fastkml/data.py
@@ -371,6 +371,9 @@ class ExtendedData(_XMLObject):
     def __bool__(self) -> bool:
         return bool(self.elements)
 
+    def to_dict(self) -> Dict[any, any]:
+        return {data.name: data.value for data in self.elements}
+
 
 registry.register(
     ExtendedData,


### PR DESCRIPTION
## **User description**
I'm always monkey patching that in my projects, I would be glad to have it merged
Let me know if you want anything changed - Thanks in advance


___

## **Type**
enhancement


___

## **Description**
- Added a `to_dict()` method to the `ExtendedData` class in `fastkml/data.py`, allowing for easy conversion of `ExtendedData` elements to a dictionary format. This enhancement facilitates the manipulation and access of KML extended data.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data.py</strong><dd><code>Add `to_dict()` Method to ExtendedData Class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
fastkml/data.py

<li>Added a <code>to_dict()</code> method to the <code>ExtendedData</code> class.<br> <li> This method converts the <code>ExtendedData</code> elements to a dictionary.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/308/files#diff-75b88feeb935943fd77fa8d3cf174304b93e3830a00abfc48fcc99c69234c072">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a feature to convert ExtendedData elements to a dictionary format for easier data handling and manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->