### PR TITLE
316 refactor geometry coordinates to be its own object

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: pyprojectsort
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.16
+    rev: v0.17
     hooks:
       - id: validate-pyproject
   - repo: https://github.com/ikamensh/flynt/
@@ -50,7 +50,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.4.3'
+    rev: 'v0.4.4'
     hooks:
       - id: ruff
   - repo: https://github.com/PyCQA/flake8

--- a/fastkml/exceptions.py
+++ b/fastkml/exceptions.py
@@ -30,3 +30,8 @@ class KMLWriteError(FastKMLError):
 
 class KMLSchemaError(FastKMLError):
     """Raised when there is an error with the KML Schema."""
+
+
+# geometry and kml_coordinates are mutually exclusive
+class GeometryError(FastKMLError):
+    """Raised when there is an error with the geometry."""

--- a/fastkml/geometry.py
+++ b/fastkml/geometry.py
@@ -647,7 +647,6 @@ registry.register(
 
 
 class Polygon(_Geometry):
-
     outer_boundary_is: Optional[OuterBoundaryIs]
     inner_boundary_is: Optional[InnerBoundaryIs]
 
@@ -835,7 +834,6 @@ def create_kml_geometry(
 
 
 class MultiGeometry(_Geometry):
-
     kml_geometries: List[Union[Point, LineString, Polygon, LinearRing, Self]]
 
     def __init__(

--- a/fastkml/gx.py
+++ b/fastkml/gx.py
@@ -225,7 +225,6 @@ class Track(_Geometry):
             extrude=extrude,
             tessellate=tessellate,
             altitude_mode=altitude_mode,
-            geometry=None,
             **kwargs,
         )
 
@@ -388,7 +387,6 @@ class MultiTrack(_Geometry):
             extrude=extrude,
             tessellate=tessellate,
             altitude_mode=altitude_mode,
-            geometry=None,
             **kwargs,
         )
 

--- a/fastkml/gx.py
+++ b/fastkml/gx.py
@@ -157,7 +157,11 @@ class TrackItem:
             f"{name_spaces.get('gx', '')}coord",
         )
         if self.coord:
-            element.text = " ".join([str(c) for c in self.coord.coords[0]])
+            element.text = " ".join(
+                [
+                    str(c) for c in self.coord.coords[0]  # type:ignore[misc]
+                ],
+            )
         yield element
         element = config.etree.Element(  # type: ignore[attr-defined]
             f"{name_spaces.get('gx', '')}angles",

--- a/fastkml/helpers.py
+++ b/fastkml/helpers.py
@@ -529,7 +529,6 @@ def attribute_float_kwarg(
 
 
 def _get_enum_value(enum_class: Type[Enum], text: str, strict: bool) -> Enum:
-
     value = enum_class(text)
     if strict and value.value != text:
         msg = f"Value {text} is not a valid value for Enum {enum_class.__name__}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "arrow",
-    "pygeoif>=1.4",
+    "pygeoif>=1.5",
     "typing-extensions>4",
 ]
 description = "Fast KML processing in python"

--- a/tests/geometries/boundaries_test.py
+++ b/tests/geometries/boundaries_test.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2023 - 2024 Christian Ledermann
+#
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+
+"""Test the Outer and Inner Boundary classes."""
+
+import pygeoif.geometry as geo
+
+from fastkml.geometry import Coordinates
+from fastkml.geometry import InnerBoundaryIs
+from fastkml.geometry import LinearRing
+from fastkml.geometry import OuterBoundaryIs
+from tests.base import Lxml
+from tests.base import StdLibrary
+
+
+class TestBoundaries(StdLibrary):
+    def test_outer_boundary(self) -> None:
+        """Test the init method."""
+        coords = ((1, 2), (2, 0), (0, 0), (1, 2))
+        outer_boundary = OuterBoundaryIs(
+            kml_geometry=LinearRing(kml_coordinates=Coordinates(coords=coords)),
+        )
+
+        assert outer_boundary.geometry == geo.LinearRing(coords)
+        assert outer_boundary.to_string(prettyprint=False).strip() == (
+            '<kml:outerBoundaryIs xmlns:kml="http://www.opengis.net/kml/2.2">'
+            "<kml:LinearRing><kml:coordinates>"
+            "1.000000,2.000000 2.000000,0.000000 0.000000,0.000000 1.000000,2.000000"
+            "</kml:coordinates></kml:LinearRing></kml:outerBoundaryIs>"
+        )
+
+    def test_read_outer_boundary(self) -> None:
+        """Test the from_string method."""
+        outer_boundary = OuterBoundaryIs.class_from_string(
+            '<kml:outerBoundaryIs xmlns:kml="http://www.opengis.net/kml/2.2">'
+            "<kml:LinearRing>"
+            "<kml:coordinates>1.0,4.0 2.0,0.0 0.0,0.0 1.0,4.0</kml:coordinates>"
+            "</kml:LinearRing>"
+            "</kml:outerBoundaryIs>",
+        )
+
+        assert outer_boundary.geometry == geo.LinearRing(
+            ((1, 4), (2, 0), (0, 0), (1, 4)),
+        )
+
+    def test_inner_boundary(self) -> None:
+        """Test the init method."""
+        coords = ((1, 2), (2, 0), (0, 0), (1, 2))
+        inner_boundary = InnerBoundaryIs(
+            kml_geometries=[LinearRing(kml_coordinates=Coordinates(coords=coords))],
+        )
+
+        assert inner_boundary.geometries == [geo.LinearRing(coords)]
+        assert inner_boundary.to_string(prettyprint=False).strip() == (
+            '<kml:innerBoundaryIs xmlns:kml="http://www.opengis.net/kml/2.2">'
+            "<kml:LinearRing><kml:coordinates>"
+            "1.000000,2.000000 2.000000,0.000000 0.000000,0.000000 1.000000,2.000000"
+            "</kml:coordinates></kml:LinearRing></kml:innerBoundaryIs>"
+        )
+
+    def test_read_inner_boundary(self) -> None:
+        """Test the from_string method."""
+        inner_boundary = InnerBoundaryIs.class_from_string(
+            '<kml:innerBoundaryIs xmlns:kml="http://www.opengis.net/kml/2.2">'
+            "<kml:LinearRing>"
+            "<kml:coordinates>1.0,4.0 2.0,0.0 0.0,0.0 1.0,4.0</kml:coordinates>"
+            "</kml:LinearRing>"
+            "<kml:LinearRing><kml:coordinates>"
+            "-122.366212,37.818977,30 -122.365424,37.819294,30 "
+            "-122.365704,37.819731,30 -122.366488,37.819402,30 -122.366212,37.818977,30"
+            "</kml:coordinates></kml:LinearRing>"
+            "</kml:innerBoundaryIs>",
+        )
+
+        assert inner_boundary.geometries == [
+            geo.LinearRing(((1, 4), (2, 0), (0, 0), (1, 4))),
+            geo.LinearRing(
+                (
+                    (-122.366212, 37.818977, 30),
+                    (-122.365424, 37.819294, 30),
+                    (-122.365704, 37.819731, 30),
+                    (-122.366488, 37.819402, 30),
+                    (-122.366212, 37.818977, 30),
+                ),
+            ),
+        ]
+
+
+class TestBoundariesLxml(Lxml, TestBoundaries):
+    pass

--- a/tests/geometries/geometry_test.py
+++ b/tests/geometries/geometry_test.py
@@ -164,7 +164,7 @@ class TestGetGeometry(StdLibrary):
 
         g = MultiGeometry.class_from_string(doc)
 
-        assert len(g.geometry) == 2
+        assert len(g.geometry) == 2  # type: ignore[arg-type]
 
     def test_multilinestring(self) -> None:
         doc = """
@@ -180,7 +180,7 @@ class TestGetGeometry(StdLibrary):
 
         g = MultiGeometry.class_from_string(doc)
 
-        assert len(g.geometry) == 2
+        assert len(g.geometry) == 2  # type: ignore[arg-type]
 
     def test_multipolygon(self) -> None:
         doc = """
@@ -212,7 +212,7 @@ class TestGetGeometry(StdLibrary):
 
         g = MultiGeometry.class_from_string(doc)
 
-        assert len(g.geometry) == 2
+        assert len(g.geometry) == 2  # type: ignore[arg-type]
 
     def test_geometrycollection(self) -> None:
         doc = """
@@ -238,7 +238,7 @@ class TestGetGeometry(StdLibrary):
 
         g = MultiGeometry.class_from_string(doc)
 
-        assert len(g.geometry) == 4
+        assert len(g.geometry) == 4  # type: ignore[arg-type]
 
     def test_geometrycollection_with_linearring(self) -> None:
         doc = """
@@ -254,7 +254,7 @@ class TestGetGeometry(StdLibrary):
 
         g = MultiGeometry.class_from_string(doc)
 
-        assert len(g.geometry) == 2
+        assert len(g.geometry) == 2  # type: ignore[arg-type]
         assert g.geometry.geom_type == "GeometryCollection"
 
 
@@ -544,9 +544,9 @@ class TestCreateKmlGeometry(StdLibrary):
 
     def test_create_kml_geometry_geometrycollection_roundtrip(self) -> None:
         multipoint = geo.MultiPoint([(0, 0), (1, 1), (1, 2), (2, 2)])
-        gc1 = geo.GeometryCollection([multipoint, geo.Point(0, 0)])
+        gc1 = geo.GeometryCollection([geo.Point(0, 0), multipoint])
         line1 = geo.LineString([(0, 0), (3, 1)])
-        gc2 = geo.GeometryCollection([gc1, line1])
+        gc2 = geo.GeometryCollection([line1, gc1])
         poly1 = geo.Polygon([(0, 0), (1, 1), (1, 0), (0, 0)])
         e = [(0, 0), (0, 2), (2, 2), (2, 0), (0, 0)]
         i = [(1, 0), (0.5, 0.5), (1, 1), (1.5, 0.5), (1, 0)]
@@ -557,13 +557,13 @@ class TestCreateKmlGeometry(StdLibrary):
         line = geo.LineString([(0, 0), (1, 1)])
         gc = geo.GeometryCollection(
             [
-                gc2,
                 p0,
                 p1,
                 line,
                 poly1,
                 poly2,
                 ring,
+                gc2,
             ],
         )
         g = create_kml_geometry(gc)

--- a/tests/geometries/linearring_test.py
+++ b/tests/geometries/linearring_test.py
@@ -67,7 +67,7 @@ class TestLinearRing(StdLibrary):
             "</kml:LinearRing>",
         )
 
-        assert linear_ring.geometry.is_empty
+        assert not linear_ring.geometry
 
     def test_no_coordinates_from_string(self) -> None:
         """Test the from_string method with an empty LinearRing."""
@@ -76,7 +76,7 @@ class TestLinearRing(StdLibrary):
             "</kml:LinearRing>",
         )
 
-        assert linear_ring.geometry.is_empty
+        assert not linear_ring.geometry
 
     def test_from_string_invalid_coordinates_non_numerical(self) -> None:
         """Test the from_string method with non numerical coordinates."""

--- a/tests/geometries/linestring_test.py
+++ b/tests/geometries/linestring_test.py
@@ -104,7 +104,7 @@ class TestLineString(StdLibrary):
             "</LineString>",
         )
 
-        assert linestring.geometry.is_empty
+        assert not linestring.geometry
 
     def test_no_coordinates_from_string(self) -> None:
         """Test the from_string method with no coordinates."""
@@ -115,7 +115,7 @@ class TestLineString(StdLibrary):
             "</LineString>",
         )
 
-        assert linestring.geometry.is_empty
+        assert not linestring.geometry
 
     def test_from_string_invalid_coordinates_non_numerical(self) -> None:
         """Test the from_string method with invalid coordinates."""

--- a/tests/geometries/linestring_test.py
+++ b/tests/geometries/linestring_test.py
@@ -65,19 +65,18 @@ class TestLineString(StdLibrary):
         )
 
     def test_mixed_2d_3d_coordinates_from_string(self) -> None:
-        with pytest.raises(
-            KMLParseError,
-            match=r"^Invalid coordinates in",
-        ):
-            LineString.class_from_string(
-                '<LineString xmlns="http://www.opengis.net/kml/2.2">'
-                "<extrude>1</extrude>"
-                "<tessellate>1</tessellate>"
-                "<coordinates>"
-                "-122.364383,37.824664 -122.364152,37.824322,0"
-                "</coordinates>"
-                "</LineString>",
-            )
+
+        linestring = LineString.class_from_string(
+            '<LineString xmlns="http://www.opengis.net/kml/2.2">'
+            "<extrude>1</extrude>"
+            "<tessellate>1</tessellate>"
+            "<coordinates>"
+            "-122.364383,37.824664 -122.364152,37.824322,0"
+            "</coordinates>"
+            "</LineString>",
+        )
+
+        assert not linestring
 
     def test_mixed_2d_3d_coordinates_from_string_relaxed(self) -> None:
         line_string = LineString.class_from_string(

--- a/tests/geometries/linestring_test.py
+++ b/tests/geometries/linestring_test.py
@@ -132,7 +132,6 @@ class TestLineString(StdLibrary):
                 "</LineString>",
             )
 
-    @pytest.mark.xfail(reason="pygeoif does not handle NaN values well")
     def test_from_string_invalid_coordinates_nan(self) -> None:
         line_string = LineString.class_from_string(
             '<LineString xmlns="http://www.opengis.net/kml/2.2">'

--- a/tests/geometries/multigeometry_test.py
+++ b/tests/geometries/multigeometry_test.py
@@ -292,7 +292,7 @@ class TestGeometryCollectionStdLibrary(StdLibrary):
             "</coordinates></LineString></MultiGeometry></MultiGeometry>"
         )
 
-        mg = MultiGeometry.class_from_string(xml, ns="")
+        mg = MultiGeometry.class_from_string(xml)
 
         assert mg.geometry == geo.GeometryCollection(
             (
@@ -360,15 +360,18 @@ class TestGeometryCollectionStdLibrary(StdLibrary):
 
     def test_empty_multi_geometries_read(self) -> None:
         xml = (
-            "<MultiGeometry><extrude>0</extrude><tessellate>0</tessellate>"
+            '<MultiGeometry xmlns="http://www.opengis.net/kml/2.2">'
+            "<extrude>0</extrude><tessellate>0</tessellate>"
             "<MultiGeometry></MultiGeometry></MultiGeometry>"
         )
 
-        mg = MultiGeometry.class_from_string(xml, ns="")
+        mg = MultiGeometry.class_from_string(xml)
 
         assert mg.geometry is None
         assert "MultiGeometry>" in mg.to_string()
         assert "coordinates>" not in mg.to_string()
+        assert mg.extrude is False
+        assert mg.tessellate is False
 
 
 class TestMultiPointLxml(Lxml, TestMultiPointStdLibrary):

--- a/tests/geometries/multigeometry_test.py
+++ b/tests/geometries/multigeometry_test.py
@@ -29,7 +29,7 @@ class TestMultiPointStdLibrary(StdLibrary):
         """Test with one point."""
         p = geo.MultiPoint([(1, 2)])
 
-        mg = MultiGeometry(ns="", geometry=p)
+        mg = MultiGeometry(geometry=p)
 
         assert "coordinates>1.000000,2.000000</" in mg.to_string()
         assert "MultiGeometry>" in mg.to_string()
@@ -39,7 +39,7 @@ class TestMultiPointStdLibrary(StdLibrary):
         """Test with two points."""
         p = geo.MultiPoint([(1, 2), (3, 4)])
 
-        mg = MultiGeometry(ns="", geometry=p)
+        mg = MultiGeometry(geometry=p)
 
         assert "coordinates>1.000000,2.000000</" in mg.to_string()
         assert "coordinates>3.000000,4.000000</" in mg.to_string()
@@ -48,12 +48,14 @@ class TestMultiPointStdLibrary(StdLibrary):
 
     def test_2_points_read(self) -> None:
         xml = (
-            "<MultiGeometry><extrude>0</extrude><tessellate>0</tessellate>"
-            "<Point><coordinates>1.000000,2.000000</coordinates></Point>"
-            "<Point><coordinates>3.000000,4.000000</coordinates></Point></MultiGeometry>"
+            '<kml:MultiGeometry xmlns:kml="http://www.opengis.net/kml/2.2">'
+            "<kml:extrude>0</kml:extrude><kml:tessellate>0</kml:tessellate>"
+            "<kml:Point><kml:coordinates>1.000000,2.000000</kml:coordinates></kml:Point>"
+            "<kml:Point><kml:coordinates>3.000000,4.000000"
+            "</kml:coordinates></kml:Point></kml:MultiGeometry>"
         )
 
-        mg = MultiGeometry.class_from_string(xml, ns="")
+        mg = MultiGeometry.class_from_string(xml)
 
         assert mg.geometry == geo.MultiPoint([(1, 2), (3, 4)])
 
@@ -63,7 +65,7 @@ class TestMultiLineStringStdLibrary(StdLibrary):
         """Test with one linestring."""
         p = geo.MultiLineString([[(1, 2), (3, 4)]])
 
-        mg = MultiGeometry(ns="", geometry=p)
+        mg = MultiGeometry(geometry=p)
 
         assert "coordinates>1.000000,2.000000 3.000000,4.000000</" in mg.to_string()
         assert "MultiGeometry>" in mg.to_string()
@@ -73,7 +75,7 @@ class TestMultiLineStringStdLibrary(StdLibrary):
         """Test with two linestrings."""
         p = geo.MultiLineString([[(1, 2), (3, 4)], [(5, 6), (7, 8)]])
 
-        mg = MultiGeometry(ns="", geometry=p)
+        mg = MultiGeometry(geometry=p)
 
         assert "coordinates>1.000000,2.000000 3.000000,4.000000</" in mg.to_string()
         assert "coordinates>5.000000,6.000000 7.000000,8.000000</" in mg.to_string()
@@ -82,11 +84,12 @@ class TestMultiLineStringStdLibrary(StdLibrary):
 
     def test_2_linestrings_read(self) -> None:
         xml = (
-            "<MultiGeometry><extrude>0</extrude><tessellate>0</tessellate>"
-            "<LineString><coordinates>1.000000,2.000000 3.000000,4.000000</coordinates>"
-            "</LineString><LineString>"
-            "<coordinates>5.000000,6.000000 7.000000,8.000000</coordinates>"
-            "</LineString></MultiGeometry>"
+            '<kml:MultiGeometry xmlns:kml="http://www.opengis.net/kml/2.2">'
+            "<kml:extrude>0</kml:extrude><kml:tessellate>0</kml:tessellate>"
+            "<kml:LineString><kml:coordinates>1.000000,2.000000 3.000000,4.000000"
+            "</kml:coordinates></kml:LineString><kml:LineString>"
+            "<kml:coordinates>5.000000,6.000000 7.000000,8.000000</kml:coordinates>"
+            "</kml:LineString></kml:MultiGeometry>"
         )
 
         mg = MultiGeometry.class_from_string(xml, ns="")
@@ -97,7 +100,9 @@ class TestMultiLineStringStdLibrary(StdLibrary):
 class TestMultiPolygonStdLibrary(StdLibrary):
     def test_1_polygon(self) -> None:
         """Test with one polygon."""
-        p = geo.MultiPolygon([[[[1, 2], [3, 4], [5, 6], [1, 2]]]])
+        p = geo.MultiPolygon(
+            [(((1, 2), (3, 4), (5, 6), (1, 2)),)],
+        )
 
         mg = MultiGeometry(ns="", geometry=p)
 
@@ -120,15 +125,15 @@ class TestMultiPolygonStdLibrary(StdLibrary):
                 ),
             ],
         )
-        mg = MultiGeometry(ns="", geometry=p)
+        mg = MultiGeometry(geometry=p)
 
         assert (
             "coordinates>0.000000,0.000000 0.000000,1.000000 1.000000,1.000000 "
-            "1.000000,0.000000 0.000000,0.000000</coordinates" in mg.to_string()
+            "1.000000,0.000000 0.000000,0.000000</" in mg.to_string()
         )
         assert (
             "coordinates>0.250000,0.250000 0.250000,0.500000 0.500000,0.500000 "
-            "0.500000,0.250000 0.250000,0.250000</coordinates" in mg.to_string()
+            "0.500000,0.250000 0.250000,0.250000</" in mg.to_string()
         )
         assert "MultiGeometry>" in mg.to_string()
         assert "Polygon>" in mg.to_string()
@@ -147,19 +152,19 @@ class TestMultiPolygonStdLibrary(StdLibrary):
             ],
         )
 
-        mg = MultiGeometry(ns="", geometry=p)
+        mg = MultiGeometry(geometry=p)
 
         assert (
             "coordinates>0.000000,0.000000 0.000000,1.000000 1.000000,1.000000 "
-            "1.000000,0.000000 0.000000,0.000000</coordinates" in mg.to_string()
+            "1.000000,0.000000 0.000000,0.000000</" in mg.to_string()
         )
         assert (
             "coordinates>0.100000,0.100000 0.100000,0.200000 0.200000,0.200000 "
-            "0.200000,0.100000 0.100000,0.100000</coordinates" in mg.to_string()
+            "0.200000,0.100000 0.100000,0.100000</" in mg.to_string()
         )
         assert (
             "coordinates>0.000000,0.000000 0.000000,2.000000 1.000000,1.000000 "
-            "1.000000,0.000000 0.000000,0.000000</coordinates" in mg.to_string()
+            "1.000000,0.000000 0.000000,0.000000</" in mg.to_string()
         )
         assert "MultiGeometry>" in mg.to_string()
         assert "Polygon>" in mg.to_string()
@@ -168,7 +173,8 @@ class TestMultiPolygonStdLibrary(StdLibrary):
 
     def test_2_polygons_read(self) -> None:
         xml = (
-            "<MultiGeometry><extrude>0</extrude><tessellate>0</tessellate>"
+            '<MultiGeometry xmlns="http://www.opengis.net/kml/2.2">'
+            "<extrude>0</extrude><tessellate>0</tessellate>"
             "<Polygon><outerBoundaryIs><LinearRing>"
             "<coordinates>0.000000,0.000000 0.000000,1.000000 1.000000,1.000000 "
             "1.000000,0.000000 0.000000,0.000000</coordinates>"
@@ -183,7 +189,7 @@ class TestMultiPolygonStdLibrary(StdLibrary):
             "</LinearRing></outerBoundaryIs></Polygon></MultiGeometry>"
         )
 
-        mg = MultiGeometry.class_from_string(xml, ns="")
+        mg = MultiGeometry.class_from_string(xml)
 
         assert mg.geometry == geo.MultiPolygon(
             [
@@ -203,7 +209,7 @@ class TestGeometryCollectionStdLibrary(StdLibrary):
         """Test with one point."""
         p = geo.GeometryCollection([geo.Point(1, 2)])
 
-        mg = MultiGeometry(ns="", geometry=p)
+        mg = MultiGeometry(geometry=p)
 
         assert "coordinates>1.000000,2.000000</" in mg.to_string()
         assert "MultiGeometry>" in mg.to_string()
@@ -219,7 +225,7 @@ class TestGeometryCollectionStdLibrary(StdLibrary):
         )
         gc = geo.GeometryCollection([p, ls, lr, poly])
 
-        mg = MultiGeometry(ns="", geometry=gc)
+        mg = MultiGeometry(geometry=gc)
 
         assert "Point>" in mg.to_string()
         assert "LineString>" in mg.to_string()
@@ -257,7 +263,8 @@ class TestGeometryCollectionStdLibrary(StdLibrary):
 
     def test_multi_geometries_read(self) -> None:
         xml = (
-            "<MultiGeometry><extrude>0</extrude><tessellate>0</tessellate>"
+            '<MultiGeometry xmlns="http://www.opengis.net/kml/2.2">'
+            "<extrude>0</extrude><tessellate>0</tessellate>"
             "<MultiGeometry><Point><coordinates>1.000000,2.000000</coordinates></Point>"
             "<LineString><coordinates>1.000000,2.000000 2.000000,0.000000</coordinates>"
             "</LineString><LinearRing><coordinates>0.000000,0.000000 0.000000,1.000000 "

--- a/tests/geometries/point_test.py
+++ b/tests/geometries/point_test.py
@@ -176,7 +176,6 @@ class TestPoint(StdLibrary):
     def test_from_string_empty_coordinates(self) -> None:
         point = Point.class_from_string(
             '<Point xmlns="http://www.opengis.net/kml/2.2"><coordinates/></Point>',
-            ns="",
         )
 
         assert not point

--- a/tests/geometries/point_test.py
+++ b/tests/geometries/point_test.py
@@ -20,7 +20,6 @@ import pygeoif.geometry as geo
 import pytest
 
 from fastkml.exceptions import KMLParseError
-from fastkml.exceptions import KMLWriteError
 from fastkml.geometry import Point
 from tests.base import Lxml
 from tests.base import StdLibrary
@@ -98,11 +97,7 @@ class TestPoint(StdLibrary):
         """Test the to_string method."""
         point = Point(geometry=geo.Point(None, None))  # type: ignore[arg-type]
 
-        with pytest.raises(
-            KMLWriteError,
-            match=r"Invalid dimensions in coordinates '\(\(\),\)'",
-        ):
-            point.to_string()
+        assert not point
 
     def test_from_string_2d(self) -> None:
         """Test the from_string method for a 2 dimensional point."""
@@ -161,14 +156,12 @@ class TestPoint(StdLibrary):
 
     def test_empty_from_string(self) -> None:
         """Test the from_string method."""
-        with pytest.raises(
-            KMLParseError,
-            match=r"^Invalid coordinates in '<Point\s*/>",
-        ):
-            Point.class_from_string(
-                "<Point/>",
-                ns="",
-            )
+        point = Point.class_from_string(
+            "<Point/>",
+            ns="",
+        )
+
+        assert not point
 
     def test_empty_from_string_relaxed(self) -> None:
         """Test that no error is raised when the geometry is empty and not strict."""
@@ -181,52 +174,39 @@ class TestPoint(StdLibrary):
         assert point.geometry is None
 
     def test_from_string_empty_coordinates(self) -> None:
-        with pytest.raises(
-            KMLParseError,
-            match=r"^Invalid coordinates in '<Point\s*><coordinates\s*/></Point>",
-        ):
-            Point.class_from_string(
-                "<Point><coordinates/></Point>",
-                ns="",
-            )
+        point = Point.class_from_string(
+            '<Point xmlns="http://www.opengis.net/kml/2.2"><coordinates/></Point>',
+            ns="",
+        )
+
+        assert not point
+        assert point.geometry is None
 
     def test_from_string_invalid_coordinates(self) -> None:
-        with pytest.raises(
-            KMLParseError,
-            match=(
-                r"^Invalid coordinates in '<Point\s*>"
-                "<coordinates>1</coordinates></Point>"
-            ),
-        ):
-            Point.class_from_string(
-                "<Point><coordinates>1</coordinates></Point>",
-                ns="",
-            )
+
+        point = Point.class_from_string(
+            '<Point xmlns="http://www.opengis.net/kml/2.2">'
+            "<coordinates>1</coordinates></Point>",
+        )
+
+        assert not point
 
     def test_from_string_invalid_coordinates_4d(self) -> None:
-        with pytest.raises(
-            KMLParseError,
-            match=(
-                r"^Invalid coordinates in '<Point\s*>"
-                "<coordinates>1,2,3,4</coordinates></Point>"
-            ),
-        ):
-            Point.class_from_string(
-                "<Point><coordinates>1,2,3,4</coordinates></Point>",
-                ns="",
-            )
+
+        point = Point.class_from_string(
+            '<Point xmlns="http://www.opengis.net/kml/2.2">'
+            "<coordinates>1,2,3,4</coordinates></Point>",
+        )
+        assert not point
 
     def test_from_string_invalid_coordinates_non_numerical(self) -> None:
         with pytest.raises(
             KMLParseError,
-            match=(
-                r"^Invalid coordinates in '<Point\s*>"
-                "<coordinates>a,b,c</coordinates></Point>"
-            ),
+            match=r"^Invalid coordinates in",
         ):
             Point.class_from_string(
-                "<Point><coordinates>a,b,c</coordinates></Point>",
-                ns="",
+                '<Point xmlns="http://www.opengis.net/kml/2.2">'
+                "<coordinates>a,b,c</coordinates></Point>",
             )
 
     def test_from_string_invalid_coordinates_nan(self) -> None:
@@ -235,8 +215,8 @@ class TestPoint(StdLibrary):
             match=r"^Invalid coordinates in",
         ):
             Point.class_from_string(
-                "<Point><coordinates>a,b</coordinates></Point>",
-                ns="",
+                '<Point xmlns="http://www.opengis.net/kml/2.2">'
+                "<coordinates>a,b</coordinates></Point>",
             )
 
 

--- a/tests/geometries/polygon_test.py
+++ b/tests/geometries/polygon_test.py
@@ -17,9 +17,7 @@
 """Test the geometry classes."""
 
 import pygeoif.geometry as geo
-import pytest
 
-from fastkml.exceptions import KMLParseError
 from fastkml.geometry import Polygon
 from tests.base import Lxml
 from tests.base import StdLibrary
@@ -89,8 +87,7 @@ class TestStdLibrary(StdLibrary):
           </kml:innerBoundaryIs>
         </kml:Polygon>"""
 
-        with pytest.raises(KMLParseError, match=r"^Missing outerBoundaryIs in <"):
-            Polygon.class_from_string(doc)
+        assert not Polygon.class_from_string(doc)
 
     def test_from_string_exterior_wo_linearring(self) -> None:
         """Test exterior when no LinearRing in outer boundary."""
@@ -101,8 +98,7 @@ class TestStdLibrary(StdLibrary):
           </kml:outerBoundaryIs>
           </kml:Polygon>"""
 
-        with pytest.raises(KMLParseError, match=r"^Missing LinearRing in <"):
-            Polygon.class_from_string(doc)
+        assert not Polygon.class_from_string(doc)
 
     def test_from_string_interior_wo_linearring(self) -> None:
         """Test interior when no LinearRing in inner boundary."""
@@ -119,8 +115,11 @@ class TestStdLibrary(StdLibrary):
         </kml:innerBoundaryIs>
         </kml:Polygon>"""
 
-        with pytest.raises(KMLParseError, match=r"^Missing LinearRing in <"):
-            Polygon.class_from_string(doc)
+        poly = Polygon.class_from_string(doc)
+
+        assert poly.geometry == geo.Polygon(
+            ((0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)),
+        )
 
     def test_from_string_exterior_interior(self) -> None:
         doc = """<kml:Polygon xmlns:kml="http://www.opengis.net/kml/2.2">

--- a/tests/geometries/polygon_test.py
+++ b/tests/geometries/polygon_test.py
@@ -171,14 +171,16 @@ class TestStdLibrary(StdLibrary):
     def test_empty_polygon(self) -> None:
         """Test empty polygon."""
         doc = (
-            "<Polygon><tessellate>1</tessellate><outerBoundaryIs>"
-            "<LinearRing><coordinates/></LinearRing></outerBoundaryIs></Polygon>"
+            '<Polygon xmlns="http://www.opengis.net/kml/2.2"><tessellate>1</tessellate>'
+            "<outerBoundaryIs><LinearRing><coordinates/></LinearRing></outerBoundaryIs>"
+            "</Polygon>"
         )
 
-        polygon = Polygon.class_from_string(doc, ns="")
+        polygon = Polygon.class_from_string(doc)
 
         assert not polygon.geometry
-        assert polygon.to_string()
+        assert polygon.outer_boundary_is is not None
+        assert "tessellate>1</" in polygon.to_string()
 
 
 class TestLxml(Lxml, TestStdLibrary):


### PR DESCRIPTION
## **User description**
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18bVWMw2LL4e3mJSHjbeLFqrgxlSdNkM%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=onKtZxc)


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Major refactor of geometry handling in `fastkml` to improve encapsulation and maintainability.
- Introduced new boundary classes (`OuterBoundaryIs`, `InnerBoundaryIs`) and updated `Polygon` class to use these for better boundary management.
- Enhanced class definitions with new methods (`__bool__`, `__repr__`, and geometry properties) for better object representation and evaluation.
- Simplified constructors in `gx.py` by removing unused parameters.
- Added and updated tests to cover new changes and ensure robustness.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>geometry.py</strong><dd><code>Refactor Geometry Handling and Enhance Class Definitions</code>&nbsp; </dd></summary>
<hr>
      
fastkml/geometry.py

<li>Refactored geometry classes to use <code>kml_coordinates</code> and <code>kml_geometries</code> <br>attributes for better encapsulation.<br> <li> Added <code>__bool__</code>, <code>__repr__</code>, and geometry property methods to classes for <br>better instance representation and boolean evaluation.<br> <li> Enhanced the <code>Polygon</code> class to handle outer and inner boundaries using <br>new boundary classes.<br> <li> Registered new geometry classes with the KML registry for proper XML <br>handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/322/files#diff-47314ad0817fc0fdde5a4ccab1250d104c27d592f1dd0f9952b454a4e3cdf65d">+279/-345</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gx.py</strong><dd><code>Simplify gx Module Constructors by Removing Unused Parameters</code></dd></summary>
<hr>
      
fastkml/gx.py

<li>Removed redundant <code>geometry</code> parameter from constructors in <code>gx.py</code> as it <br>was unused.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/322/files#diff-e8a849efde73ecb6716b27ad17fa34756392e8fb8731d213e8f0070c2986bf02">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Formatting
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.py</strong><dd><code>Code Cleanup in Helper Functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
fastkml/helpers.py

<li>Minor cleanup in helper functions, removing unnecessary blank lines.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/322/files#diff-b5b3941187e8c15a6401d21669f3dd0d541c710ecbb6238620a56e24305fc02c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>boundaries_test.py</strong><dd><code>Add Tests for Outer and Inner Boundary Classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/geometries/boundaries_test.py

<li>Added tests for <code>OuterBoundaryIs</code> and <code>InnerBoundaryIs</code> classes to ensure <br>proper initialization and XML string handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/322/files#diff-5ba398298446d0bb59786e1583aa4064ecd2aa5f437c7a4078539f2090660878">+103/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>geometry_test.py</strong><dd><code>Update Geometry Tests to Reflect Refactored Code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/geometries/geometry_test.py

<li>Updated tests to reflect changes in geometry handling, particularly <br>for multi-geometry types.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/322/files#diff-c58e16d0b9d54da03108c95fc089fb3cf98368c0a35e0807127fd57d2209fd1f">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>linearring_test.py</strong><dd><code>Adjust LinearRing Tests for Robustness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/geometries/linearring_test.py

<li>Adjusted tests to correctly handle cases where geometries are not <br>properly defined (empty or invalid).<br>


</details>
    

  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/322/files#diff-6d1fcc57a25fe46e9188e6d23ca3167c8be96dc67906286b9a9bd8b65d393be3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>linestring_test.py</strong><dd><code>Update LineString Tests for Mixed Coordinate Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/geometries/linestring_test.py

<li>Updated tests to handle mixed 2D and 3D coordinates more gracefully.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/322/files#diff-45bb62f1478c8e27bd84d343f667c902609abe57de39b34600795afe3acf4a22">+14/-15</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>multigeometry_test.py</strong><dd><code>Update MultiGeometry Tests for New Handling Methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/geometries/multigeometry_test.py

<li>Updated tests to reflect new handling of multi-geometry types in the <br>main codebase.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/322/files#diff-20ea59bd8b06dda47ff2dbecdc04e860241362564c77d3f51daa6d4a717555e9">+33/-26</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>point_test.py</strong><dd><code>Update Point Tests to Handle Undefined Points Gracefully</code>&nbsp; </dd></summary>
<hr>
      
tests/geometries/point_test.py

<li>Updated tests to handle cases where points are not properly defined, <br>removing unnecessary exception checks.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/322/files#diff-68b57f69d1b92ba994d69ef07c436d7e56a73eeb9e800d7d95b22758d8231153">+32/-52</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>polygon_test.py</strong><dd><code>Update Polygon Tests for Improved Boundary Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/geometries/polygon_test.py

<li>Updated tests to handle polygons with missing or incomplete boundary <br>definitions more robustly.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/322/files#diff-0ef5481c38be48c9edb668e71b4f2724eb62fef20501b4f46f0f4508db55ecf1">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

