### PR TITLE
add docstrings and fixes for ruff

### DIFF
--- a/fastkml/atom.py
+++ b/fastkml/atom.py
@@ -90,13 +90,13 @@ class Link(_AtomObject):
     title: Optional[str]
     length: Optional[int]
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         ns: Optional[str] = None,
         name_spaces: Optional[Dict[str, str]] = None,
         href: Optional[str] = None,
         rel: Optional[str] = None,
-        type: Optional[str] = None,  # noqa: A002
+        type: Optional[str] = None,
         hreflang: Optional[str] = None,
         title: Optional[str] = None,
         length: Optional[int] = None,
@@ -292,7 +292,7 @@ class _Person(_AtomObject):
     uri: Optional[str]
     email: Optional[str]
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         ns: Optional[str] = None,
         name_spaces: Optional[Dict[str, str]] = None,

--- a/fastkml/atom.py
+++ b/fastkml/atom.py
@@ -15,6 +15,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 
 """
+Basic Atom support for KML.
+
 KML 2.2 supports new elements for including data about the author and related
 website in your KML file. This information is displayed in geo search results,
 both in Earth browsers such as Google Earth, and in other applications such as
@@ -72,7 +74,9 @@ class _AtomObject(_XMLObject):
 
 class Link(_AtomObject):
     """
-    Identifies a related Web page. The rel attribute defines the type of relation.
+    Identifies a related Web page.
+
+    The rel attribute defines the type of relation.
     A feed is limited to one alternate per type and hreflang.
     <link> is patterned after html's link element. It has one required
     attribute, href, and five optional attributes: rel, type, hreflang,
@@ -80,44 +84,55 @@ class Link(_AtomObject):
     """
 
     href: Optional[str]
-    # href is the URI of the referenced resource
-
     rel: Optional[str]
-    # rel contains a single link relationship type.
-    # It can be a full URI, or one of the following predefined values
-    # (default=alternate):
-    # alternate: an alternate representation
-    # enclosure: a related resource which is potentially large in size
-    # and might require special handling, for example an audio or video
-    # recording.
-    # related: an document related to the entry or feed.
-    # self: the feed itself.
-    # via: the source of the information provided in the entry.
-
     type: Optional[str]
-    # indicates the media type of the resource
-
     hreflang: Optional[str]
-    # indicates the language of the referenced resource
-
     title: Optional[str]
-    # human readable information about the link
-
     length: Optional[int]
-    # the length of the resource, in bytes
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         ns: Optional[str] = None,
         name_spaces: Optional[Dict[str, str]] = None,
         href: Optional[str] = None,
         rel: Optional[str] = None,
-        type: Optional[str] = None,
+        type: Optional[str] = None,  # noqa: A002
         hreflang: Optional[str] = None,
         title: Optional[str] = None,
         length: Optional[int] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Link object.
+
+        Parameters
+        ----------
+        ns : str, optional
+            The namespace of the Link object.
+        name_spaces : dict, optional
+            The dictionary of namespace prefixes and URIs.
+        href : str, optional
+            The URI of the referenced resource.
+        rel : str, optional
+            The link relationship type. It can be a full URI or one of the
+            following predefined values: 'alternate', 'enclosure', 'related',
+            'self', or 'via'.
+        type : str, optional
+            The media type of the resource.
+        hreflang : str, optional
+            The language of the referenced resource.
+        title : str, optional
+            Human-readable information about the link.
+        length : int, optional
+            The length of the resource in bytes.
+        kwargs : dict, optional
+            Additional keyword arguments.
+
+        Returns
+        -------
+        None
+
+        """
         super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.href = href
         self.rel = rel
@@ -127,7 +142,15 @@ class Link(_AtomObject):
         self.length = length
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for Link."""
+        """
+        Return a string representation of the Link object.
+
+        Returns
+        -------
+        str
+            The string representation of the Link object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -143,11 +166,34 @@ class Link(_AtomObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the Link object is truthy.
+
+        Returns
+        -------
+        bool
+            True if the Link object has a href attribute, False otherwise.
+
+        """
         return bool(self.href)
 
     def __eq__(self, other: object) -> bool:
+        """
+        Check if the Link object is equal to another object.
+
+        Parameters
+        ----------
+        other : object
+            The object to compare with.
+
+        Returns
+        -------
+        bool
+            True if the Link object is equal to the other object, False otherwise.
+
+        """
         try:
-            assert isinstance(other, type(self))
+            assert isinstance(other, type(self))  # noqa: S101
         except AssertionError:
             return False
         return (
@@ -232,21 +278,21 @@ registry.register(
 
 class _Person(_AtomObject):
     """
-    <author> and <contributor> describe a person, corporation, or similar
-    entity. It has one required element, name, and two optional elements:
-    uri, email.
+    Represents a person, corporation, or similar entity.
+
+    Attributes
+    ----------
+        name (Optional[str]): A human-readable name for the person.
+        uri (Optional[str]): A home page for the person.
+        email (Optional[str]): An email address for the person.
+
     """
 
     name: Optional[str]
-    # conveys a human-readable name for the person.
-
     uri: Optional[str]
-    # contains a home page for the person.
-
     email: Optional[str]
-    # contains an email address for the person.
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         ns: Optional[str] = None,
         name_spaces: Optional[Dict[str, str]] = None,
@@ -255,13 +301,33 @@ class _Person(_AtomObject):
         email: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new instance of the _Person class.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the XML element.
+            name_spaces (Optional[Dict[str, str]]): The namespace dictionary.
+            name (Optional[str]): A human-readable name for the person.
+            uri (Optional[str]): A home page for the person.
+            email (Optional[str]): An email address for the person.
+            **kwargs: Additional keyword arguments.
+
+        """
         super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.name = name
         self.uri = uri
         self.email = email
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for _Person."""
+        """
+        Return a string representation of the _Person object.
+
+        Returns
+        -------
+            str: The string representation of the _Person object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -274,11 +340,32 @@ class _Person(_AtomObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the _Person object has a name.
+
+        Returns
+        -------
+            bool: True if the _Person object has a name, False otherwise.
+
+        """
         return bool(self.name)
 
     def __eq__(self, other: object) -> bool:
+        """
+        Check if the _Person object is equal to another object.
+
+        Args:
+        ----
+            other (object): The object to compare with.
+
+        Returns:
+        -------
+            bool: True if the _Person object is equal to the other object,
+            False otherwise.
+
+        """
         try:
-            assert isinstance(other, type(self))
+            assert isinstance(other, type(self))  # noqa: S101
         except AssertionError:
             return False
         return (

--- a/fastkml/containers.py
+++ b/fastkml/containers.py
@@ -63,9 +63,9 @@ KmlGeometry = Union[
 
 class _Container(_Feature):
     """
-    abstract element; do not create
-    A Container element holds one or more Features and allows the
-    creation of nested hierarchies.
+    A Container element holds one or more Features.
+
+    It allows the creation of nested hierarchies.
     subclasses are:
     Document,
     Folder.
@@ -73,11 +73,11 @@ class _Container(_Feature):
 
     features: List[_Feature]
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         ns: Optional[str] = None,
         name_spaces: Optional[Dict[str, str]] = None,
-        id: Optional[str] = None,
+        id: Optional[str] = None,  # noqa: A002
         target_id: Optional[str] = None,
         name: Optional[str] = None,
         visibility: Optional[bool] = None,
@@ -155,31 +155,33 @@ class _Container(_Feature):
         if kmlobj is self:
             msg = "Cannot append self"
             raise ValueError(msg)
-        assert self.features is not None
+        assert self.features is not None  # noqa: S101
         self.features.append(kmlobj)
 
 
 class Folder(_Container):
     """
-    A Folder is used to arrange other Features hierarchically
-    (Folders, Placemarks, #NetworkLinks, or #Overlays).
+    A Folder is used to arrange other Features hierarchically.
+
+    It may contain Folders, Placemarks, NetworkLinks, or Overlays.
     """
 
 
 class Document(_Container):
     """
-    A Document is a container for features and styles. This element is
-    required if your KML file uses shared styles or schemata for typed
+    A Document is a container for features and styles.
+
+    This element is required if your KML file uses shared styles or schemata for typed
     extended data.
     """
 
     schemata: List[Schema]
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         ns: Optional[str] = None,
         name_spaces: Optional[Dict[str, str]] = None,
-        id: Optional[str] = None,
+        id: Optional[str] = None,  # noqa: A002
         target_id: Optional[str] = None,
         name: Optional[str] = None,
         visibility: Optional[bool] = None,
@@ -200,6 +202,40 @@ class Document(_Container):
         schemata: Optional[Iterable[Schema]] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new instance of the class.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace.
+            name_spaces (Optional[Dict[str, str]]):
+                The dictionary of namespace prefixes and URIs.
+            id (Optional[str]): The ID of the container.
+            target_id (Optional[str]): The target ID.
+            name (Optional[str]): The name of the container.
+            visibility (Optional[bool]): The visibility flag.
+            isopen (Optional[bool]): The isopen flag.
+            atom_link (Optional[atom.Link]): The Atom link.
+            atom_author (Optional[atom.Author]): The Atom author.
+            address (Optional[str]): The address.
+            phone_number (Optional[str]): The phone number.
+            snippet (Optional[Snippet]): The snippet.
+            description (Optional[str]): The description.
+            view (Optional[Union[Camera, LookAt]]): The view.
+            times (Optional[Union[TimeSpan, TimeStamp]]): The times.
+            style_url (Optional[StyleUrl]): The style URL.
+            styles (Optional[Iterable[Union[Style, StyleMap]]]): The styles.
+            region (Optional[Region]): The region.
+            extended_data (Optional[ExtendedData]): The extended data.
+            features (Optional[List[_Feature]]): The list of features.
+            schemata (Optional[Iterable[Schema]]): The schemata.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -255,6 +291,20 @@ class Document(_Container):
         )
 
     def get_style_by_url(self, style_url: str) -> Optional[Union[Style, StyleMap]]:
+        """
+        Get a style by URL.
+
+        Parameters
+        ----------
+        style_url : str
+            The URL of the style.
+
+        Returns
+        -------
+        Optional[Union[Style, StyleMap]]
+            The style object if found, otherwise None.
+
+        """
         id_ = urlparse.urlparse(style_url).fragment
         return next((style for style in self.styles if style.id == id_), None)
 

--- a/fastkml/containers.py
+++ b/fastkml/containers.py
@@ -63,9 +63,9 @@ KmlGeometry = Union[
 
 class _Container(_Feature):
     """
-    A Container element holds one or more Features.
+    A Container element that holds one or more Features.
 
-    It allows the creation of nested hierarchies.
+    Supports the creation of nested hierarchies.
     subclasses are:
     Document,
     Folder.

--- a/fastkml/containers.py
+++ b/fastkml/containers.py
@@ -73,11 +73,11 @@ class _Container(_Feature):
 
     features: List[_Feature]
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         ns: Optional[str] = None,
         name_spaces: Optional[Dict[str, str]] = None,
-        id: Optional[str] = None,  # noqa: A002
+        id: Optional[str] = None,
         target_id: Optional[str] = None,
         name: Optional[str] = None,
         visibility: Optional[bool] = None,
@@ -177,11 +177,11 @@ class Document(_Container):
 
     schemata: List[Schema]
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         ns: Optional[str] = None,
         name_spaces: Optional[Dict[str, str]] = None,
-        id: Optional[str] = None,  # noqa: A002
+        id: Optional[str] = None,
         target_id: Optional[str] = None,
         name: Optional[str] = None,
         visibility: Optional[bool] = None,

--- a/fastkml/data.py
+++ b/fastkml/data.py
@@ -16,7 +16,7 @@
 """
 Add Custom Data.
 
-https://developers.google.com/kml/documentation/extendeddata#example
+https://developers.google.com/kml/documentation/extendeddata
 """
 import logging
 from typing import Any
@@ -91,6 +91,26 @@ class SimpleField(_BaseObject):
         display_name: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new instance of the Data class.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace of the data.
+            name_spaces (Optional[Dict[str, str]]):
+                The dictionary of namespace prefixes and URIs.
+            id (Optional[str]): The ID of the data.
+            target_id (Optional[str]): The target ID of the data.
+            name (Optional[str]): The name of the data.
+            type (Optional[DataType]): The type of the data.
+            display_name (Optional[str]): The display name of the data.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -103,7 +123,14 @@ class SimpleField(_BaseObject):
         self.display_name = display_name
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for SimpleField."""
+        """
+        Return a string representation of the SimpleField object.
+
+        Returns
+        -------
+            str: A string representation of the SimpleField object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -118,6 +145,14 @@ class SimpleField(_BaseObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the object is considered True or False.
+
+        Returns
+        -------
+            bool: True if both the name and type are non-empty, False otherwise.
+
+        """
         return bool(self.name) and bool(self.type)
 
 
@@ -180,6 +215,32 @@ class Schema(_BaseObject):
         fields: Optional[Iterable[SimpleField]] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Schema object.
+
+        Parameters
+        ----------
+        ns : str, optional
+            The namespace of the schema.
+        name_spaces : dict[str, str], optional
+            The dictionary of namespace prefixes and URIs.
+        id : str, optional
+            The unique identifier for the schema.
+        target_id : str, optional
+            The target identifier for the schema.
+        name : str, optional
+            The name of the schema.
+        fields : Iterable[SimpleField], optional
+            The list of fields in the schema.
+        **kwargs : Any
+            Additional keyword arguments.
+
+        Raises
+        ------
+        KMLSchemaError
+            If the id is not provided.
+
+        """
         if id is None:
             msg = "Id is required for schema"
             raise KMLSchemaError(msg)
@@ -194,7 +255,15 @@ class Schema(_BaseObject):
         self.fields = list(fields) if fields else []
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for Schema."""
+        """
+        Return a string representation of the Schema object.
+
+        Returns
+        -------
+        str
+            The string representation of the Schema object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -208,7 +277,15 @@ class Schema(_BaseObject):
         )
 
     def append(self, field: SimpleField) -> None:
-        """Append a field."""
+        """
+        Append a field to the schema.
+
+        Parameters
+        ----------
+        field : SimpleField
+            The field to be appended.
+
+        """
         self.fields.append(field)
 
 
@@ -254,6 +331,26 @@ class Data(_BaseObject):
         display_name: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new instance of the Data class.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace of the data.
+            name_spaces (Optional[Dict[str, str]]):
+                The dictionary of namespace prefixes and URIs.
+            id (Optional[str]): The ID of the data.
+            target_id (Optional[str]): The target ID of the data.
+            name (Optional[str]): The name of the data.
+            value (Optional[str]): The value of the data.
+            display_name (Optional[str]): The display name of the data.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -266,7 +363,15 @@ class Data(_BaseObject):
         self.display_name = display_name
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for Data."""
+        """
+        Create a string representation for Data.
+
+        Returns
+        -------
+        str
+            The string representation of the Data object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -281,6 +386,15 @@ class Data(_BaseObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the Data object is truthy.
+
+        Returns
+        -------
+        bool
+            True if the Data object has a name and a non-None value, False otherwise.
+
+        """
         return bool(self.name) and self.value is not None
 
 
@@ -334,6 +448,21 @@ class SimpleData(_BaseObject):
         value: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a SimpleData object.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace of the object.
+            name_spaces (Optional[Dict[str, str]]):
+                The dictionary of namespace prefixes and URIs.
+            id (Optional[str]): The ID of the object.
+            target_id (Optional[str]): The target ID of the object.
+            name (Optional[str]): The name of the object.
+            value (Optional[str]): The value of the object.
+            **kwargs: Additional keyword arguments.
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -345,7 +474,14 @@ class SimpleData(_BaseObject):
         self.value = value
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for SimpleData."""
+        """
+        Return a string representation of the SimpleData object.
+
+        Returns
+        -------
+            str: The string representation of the SimpleData object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -359,6 +495,14 @@ class SimpleData(_BaseObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the SimpleData object is truthy.
+
+        Returns
+        -------
+            bool: True if the name and the value attribute are set, False otherwise.
+
+        """
         return bool(self.name) and self.value is not None
 
 
@@ -388,15 +532,13 @@ registry.register(
 
 class SchemaData(_BaseObject):
     """
-    <SchemaData schemaUrl="anyURI">
-    This element is used in conjunction with <Schema> to add typed
+    Represents the SchemaData element in KML.
+
+    The SchemaData element is used in conjunction with Schema to add typed
     custom data to a KML Feature. The Schema element (identified by the
     schemaUrl attribute) declares the custom data type. The actual data
     objects ("instances" of the custom data) are defined using the
     SchemaData element.
-    The <schemaURL> can be a full URL, a reference to a Schema ID defined
-    in an external KML file, or a reference to a Schema ID defined
-    in the same KML file.
     """
 
     schema_url: Optional[str]
@@ -412,6 +554,25 @@ class SchemaData(_BaseObject):
         data: Optional[Iterable[SimpleData]] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new instance of the Data class.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the data.
+            name_spaces (Optional[Dict[str, str]]):
+                The dictionary of namespace prefixes and URIs.
+            id (Optional[str]): The ID of the data.
+            target_id (Optional[str]): The target ID of the data.
+            schema_url (Optional[str]): The URL of the schema for the data.
+            data (Optional[Iterable[SimpleData]]): The iterable of SimpleData objects.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -423,7 +584,7 @@ class SchemaData(_BaseObject):
         self.data = list(data) if data else []
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for SchemaData."""
+        """Create a string representation for SchemaData."""
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -437,9 +598,26 @@ class SchemaData(_BaseObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the SchemaData object contains data.
+
+        Returns
+        -------
+            bool: True if the SchemaData object contains data and a
+                schema URL, False otherwise.
+
+        """
         return bool(self.data) and bool(self.schema_url)
 
     def append_data(self, data: SimpleData) -> None:
+        """
+        Append a SimpleData object to the SchemaData.
+
+        Args:
+        ----
+            data (SimpleData): The SimpleData object to be appended.
+
+        """
         self.data.append(data)
 
 
@@ -468,13 +646,7 @@ registry.register(
 
 
 class ExtendedData(_BaseObject):
-    """
-    Represents a list of untyped name/value pairs. See docs:
-
-    -> 'Adding Untyped Name/Value Pairs'
-       https://developers.google.com/kml/documentation/extendeddata
-
-    """
+    """Represents a list of untyped name/value pairs."""
 
     elements: List[Union[Data, SchemaData]]
 
@@ -487,6 +659,25 @@ class ExtendedData(_BaseObject):
         elements: Optional[Iterable[Union[Data, SchemaData]]] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new instance of the Data class.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the data.
+            name_spaces (Optional[Dict[str, str]]):
+                The dictionary of namespace prefixes and URIs.
+            id (Optional[str]): The ID of the data.
+            target_id (Optional[str]): The target ID of the data.
+            elements (Optional[Iterable[Union[Data, SchemaData]]]):
+                The iterable of data elements.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            - None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -497,7 +688,14 @@ class ExtendedData(_BaseObject):
         self.elements = list(elements) if elements else []
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for ExtendedData."""
+        """
+        Return a string representation of the ExtendedData object.
+
+        Returns
+        -------
+            str: A string representation of the ExtendedData object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -510,6 +708,15 @@ class ExtendedData(_BaseObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the object has any elements.
+
+        Returns
+        -------
+        bool
+            True if the object has elements, False otherwise.
+
+        """
         return bool(self.elements)
 
 

--- a/fastkml/enums.py
+++ b/fastkml/enums.py
@@ -54,14 +54,16 @@ class RelaxedEnum(Enum):
 
     @classmethod
     def _missing_(cls, value: object) -> "RelaxedEnum":
-        assert isinstance(value, str)
+        assert isinstance(value, str)  # noqa: S101
         value = value.lower()
         for member in cls:
-            assert isinstance(member.value, str)
+            assert isinstance(member.value, str)  # noqa: S101
             if member.value.lower() == value.lower():
                 logger.warning(
-                    f"{cls.__name__}: "
-                    f"Found case-insensitive match for {value} in {member.value}",
+                    "%s: Found case-insensitive match for %s in %r",
+                    cls.__name__,
+                    value,
+                    member.value,
                 )
                 return member
         msg = (
@@ -140,6 +142,8 @@ class AltitudeMode(RelaxedEnum):
 
 @unique
 class DataType(RelaxedEnum):
+    """Data type for SimpleField in extended data."""
+
     string = "string"
     int_ = "int"
     uint = "uint"
@@ -251,9 +255,7 @@ class Units(RelaxedEnum):
 
 @unique
 class PairKey(RelaxedEnum):
-    """
-    Key for Pair.
-    """
+    """Key for Pair."""
 
     normal = "normal"
     highlight = "highlight"

--- a/fastkml/features.py
+++ b/fastkml/features.py
@@ -191,12 +191,13 @@ registry.register(
 
 class _Feature(TimeMixin, _BaseObject):
     """
-    Abstract element representing a feature in KML.
+    Abstract base class representing a feature in KML.
 
-    Subclasses are:
+    Direct known subclasses:
         - Container (Document, Folder)
         - Placemark
         - Overlay
+        - NetworkLink
         - NetworkLink.
     """
 

--- a/fastkml/features.py
+++ b/fastkml/features.py
@@ -83,6 +83,7 @@ KmlGeometry = Union[
 class Snippet(_XMLObject):
     """
     A short description of the feature.
+
     In Google Earth, this description is displayed in the Places panel
     under the name of the feature.
     If a Snippet is not supplied, the first two lines of the <description>
@@ -107,12 +108,40 @@ class Snippet(_XMLObject):
         max_lines: Optional[int] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Feature object.
+
+        Args:
+        ----
+            ns : str, optional
+                The namespace for the feature.
+            name_spaces : dict[str, str], optional
+                A dictionary of namespace prefixes and URIs.
+            text : str, optional
+                The text content of the feature.
+            max_lines : int, optional
+                The maximum number of lines for the feature.
+            **kwargs : Any
+                Additional keyword arguments.
+
+        Returns:
+        -------
+        None
+
+        """
         super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.text = text
         self.max_lines = max_lines
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for Snippet."""
+        """
+        Create a string representation for Snippet.
+
+        Returns
+        -------
+            str: The string representation of the Snippet object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -124,6 +153,15 @@ class Snippet(_XMLObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the feature has text.
+
+        Returns
+        -------
+        bool
+            True if the feature has text, False otherwise.
+
+        """
         return bool(self.text)
 
 
@@ -153,102 +191,29 @@ registry.register(
 
 class _Feature(TimeMixin, _BaseObject):
     """
-    abstract element; do not create
-    subclasses are:
-        * Container (Document, Folder)
-        * Placemark
-        * Overlay
-        * NetworkLink.
+    Abstract element representing a feature in KML.
+
+    Subclasses are:
+        - Container (Document, Folder)
+        - Placemark
+        - Overlay
+        - NetworkLink.
     """
 
     name: Optional[str]
-    # User-defined text displayed in the 3D viewer as the label for the
-    # object (for example, for a Placemark, Folder, or NetworkLink).
-
     visibility: Optional[bool]
-    # Boolean value. Specifies whether the feature is drawn in the 3D
-    # viewer when it is initially loaded. In order for a feature to be
-    # visible, the <visibility> tag of all its ancestors must also be
-    # set to 1.
-
     isopen: Optional[bool]
-    # Boolean value. Specifies whether a Document or Folder appears
-    # closed or open when first loaded into the Places panel.
-    # 0=collapsed (the default), 1=expanded.
-
     atom_author: Optional[atom.Author]
-    # KML 2.2 supports new elements for including data about the author
-    # and related website in your KML file. This information is displayed
-    # in geo search results, both in Earth browsers such as Google Earth,
-    # and in other applications such as Google Maps.
-
     atom_link: Optional[atom.Link]
-    # Specifies the URL of the website containing this KML or KMZ file.
-
     address: Optional[str]
-    # A string value representing an unstructured address written as a
-    # standard street, city, state address, and/or as a postal code.
-    # You can use the <address> tag to specify the location of a point
-    # instead of using latitude and longitude coordinates.
-
     phone_number: Optional[str]
-    # A string value representing a telephone number.
-    # This element is used by Google Maps Mobile only.
-
     snippet: Optional[Snippet]
-    # _snippet is either a tuple of a string Snippet.text and an integer
-    # Snippet.maxLines or a string
-    #
-    # A short description of the feature. In Google Earth, this
-    # description is displayed in the Places panel under the name of the
-    # feature. If a Snippet is not supplied, the first two lines of
-    # the <description> are used. In Google Earth, if a Placemark
-    # contains both a description and a Snippet, the <Snippet> appears
-    # beneath the Placemark in the Places panel, and the <description>
-    # appears in the Placemark's description balloon. This tag does not
-    # support HTML markup. <Snippet> has a maxLines attribute, an integer
-    # that specifies the maximum number of lines to display.
-
     description: Optional[str]
-    # User-supplied content that appears in the description balloon.
-
     style_url: Optional[StyleUrl]
-    # URL of a <Style> or <StyleMap> defined in a Document.
-    # If the style is in the same file, use a # reference.
-    # If the style is defined in an external file, use a full URL
-    # along with # referencing.
-
     styles: List[Union[Style, StyleMap]]
-    # One or more Styles and StyleMaps can be defined to customize the
-    # appearance of any element derived from Feature or of the Geometry
-    # in a Placemark.
-    # A style defined within a Feature is called an "inline style" and
-    # applies only to the Feature that contains it. A style defined as
-    # the child of a <Document> is called a "shared style." A shared
-    # style must have an id defined for it. This id is referenced by one
-    # or more Features within the <Document>. In cases where a style
-    # element is defined both in a shared style and in an inline style
-    # for a Feature—that is, a Folder, GroundOverlay, NetworkLink,
-    # Placemark, or ScreenOverlay—the value for the Feature's inline
-    # style takes precedence over the value for the shared style.
-
     view: Union[Camera, LookAt, None]
-
     region: Optional[Region]
-    # Features and geometry associated with a Region are drawn only when
-    # the Region is active.
-
     extended_data: Optional[ExtendedData]
-    # Allows you to add custom data to a KML file. This data can be
-    # (1) data that references an external XML schema,
-    # (2) untyped data/value pairs, or
-    # (3) typed data.
-    # A given KML Feature can contain a combination of these types of
-    # custom data.
-    #
-    # (2 and 3) are already implemented, see data.py for more information.
-    #
-    # <Metadata> (deprecated in KML 2.2; use <ExtendedData> instead)
 
     def __init__(
         self,
@@ -273,6 +238,42 @@ class _Feature(TimeMixin, _BaseObject):
         extended_data: Optional[ExtendedData] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize the _Feature object.
+
+        Args:
+        ----
+            ns (Optional[str]): Namespace for the element.
+            name_spaces (Optional[Dict[str, str]]):
+                Dictionary of namespace prefixes and URIs.
+            id (Optional[str]): ID of the element.
+            target_id (Optional[str]): ID of the target element.
+            name (Optional[str]): User-defined text displayed in the 3D viewer as the
+                label for the object.
+            visibility (Optional[bool]): Specifies whether the feature is drawn in the
+                3D viewer when it is initially loaded.
+            isopen (Optional[bool]): Specifies whether a Document or Folder appears
+                closed or open when first loaded into the Places panel.
+            atom_link (Optional[atom.Link]): URL of the website containing this KML or
+                KMZ file.
+            atom_author (Optional[atom.Author]): Information about the author and
+                related website in the KML file.
+            address (Optional[str]): Unstructured address written as a standard street,
+                city, state address, and/or as a postal code.
+            phone_number (Optional[str]): Telephone number associated with the feature.
+            snippet (Optional[Snippet]): Short description of the feature.
+            description (Optional[str]): User-supplied content that appears in the
+                description balloon.
+            view (Optional[Union[Camera, LookAt]]): Camera or LookAt view associated.
+            times (Optional[Union[TimeSpan, TimeStamp]]): Time information associated.
+            style_url (Optional[StyleUrl]): URL of a Style or StyleMap.
+            styles (Optional[Iterable[Union[Style, StyleMap]]]): Styles and StyleMaps
+                defined to customize the appearance of the feature.
+            region (Optional[Region]): Region associated with the feature.
+            extended_data (Optional[ExtendedData]): Custom data added to the KML file.
+            **kwargs (Any): Additional keyword arguments.
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -297,7 +298,14 @@ class _Feature(TimeMixin, _BaseObject):
         self.times = times
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for _Feature."""
+        """
+        Return a string representation of the _Feature object.
+
+        Returns
+        -------
+            str: String representation of the _Feature object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -503,6 +511,7 @@ registry.register(
 class Placemark(_Feature):
     """
     A Placemark is a Feature with associated Geometry.
+
     In Google Earth, a Placemark appears as a list item in the Places
     panel. A Placemark with a Point has an icon associated with it that
     marks a point on the Earth in the 3D viewer.
@@ -536,6 +545,62 @@ class Placemark(_Feature):
         geometry: Optional[Union[GeoType, GeoCollectionType]] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Feature object.
+
+        Parameters
+        ----------
+        ns : str, optional
+            The namespace for the feature.
+        name_spaces : dict[str, str], optional
+            The dictionary of namespace prefixes and URIs.
+        id : str, optional
+            The ID of the feature.
+        target_id : str, optional
+            The target ID of the feature.
+        name : str, optional
+            The name of the feature.
+        visibility : bool, optional
+            The visibility of the feature.
+        isopen : bool, optional
+            The open status of the feature.
+        atom_link : atom.Link, optional
+            The Atom link associated with the feature.
+        atom_author : atom.Author, optional
+            The Atom author associated with the feature.
+        address : str, optional
+            The address of the feature.
+        phone_number : str, optional
+            The phone number of the feature.
+        snippet : Snippet, optional
+            The snippet of the feature.
+        description : str, optional
+            The description of the feature.
+        view : Union[Camera, LookAt], optional
+            The view associated with the feature.
+        times : Union[TimeSpan, TimeStamp], optional
+            The times associated with the feature.
+        style_url : StyleUrl, optional
+            The style URL of the feature.
+        styles : Iterable[Union[Style, StyleMap]], optional
+            The styles associated with the feature.
+        region : Region, optional
+            The region associated with the feature.
+        extended_data : ExtendedData, optional
+            The extended data associated with the feature.
+        kml_geometry : KmlGeometry, optional
+            The KML geometry associated with the feature.
+        geometry : Union[GeoType, GeoCollectionType], optional
+            The geometry associated with the feature.
+        **kwargs : Any
+            Additional keyword arguments.
+
+        Raises
+        ------
+        ValueError
+            If both `kml_geometry` and `geometry` are specified.
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -570,7 +635,14 @@ class Placemark(_Feature):
         self.kml_geometry = kml_geometry
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for Placemark."""
+        """
+        Return a string representation of the Placemark object.
+
+        Returns
+        -------
+            str: A string representation of the Placemark object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -600,6 +672,15 @@ class Placemark(_Feature):
 
     @property
     def geometry(self) -> Optional[AnyGeometryType]:
+        """
+        Returns the geometry associated with this feature.
+
+        Returns
+        -------
+            Optional[AnyGeometryType]: The geometry associated with this feature,
+            or None if no geometry is present.
+
+        """
         return self.kml_geometry.geometry if self.kml_geometry is not None else None
 
 
@@ -698,6 +779,63 @@ class NetworkLink(_Feature):
         link: Optional[Link] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Feature object.
+
+        Parameters
+        ----------
+        ns : str, optional
+            The namespace for the feature.
+        name_spaces : dict[str, str], optional
+            The dictionary of namespace prefixes and URIs.
+        id : str, optional
+            The ID of the feature.
+        target_id : str, optional
+            The target ID of the feature.
+        name : str, optional
+            The name of the feature.
+        visibility : bool, optional
+            The visibility of the feature.
+        isopen : bool, optional
+            Whether the feature is open.
+        atom_link : atom.Link, optional
+            The Atom link associated with the feature.
+        atom_author : atom.Author, optional
+            The Atom author associated with the feature.
+        address : str, optional
+            The address of the feature.
+        phone_number : str, optional
+            The phone number of the feature.
+        snippet : Snippet, optional
+            The snippet associated with the feature.
+        description : str, optional
+            The description of the feature.
+        view : Union[Camera, LookAt], optional
+            The view associated with the feature.
+        times : Union[TimeSpan, TimeStamp], optional
+            The times associated with the feature.
+        style_url : StyleUrl, optional
+            The style URL of the feature.
+        styles : Iterable[Union[Style, StyleMap]], optional
+            The styles associated with the feature.
+        region : Region, optional
+            The region associated with the feature.
+        extended_data : ExtendedData, optional
+            The extended data associated with the feature.
+        refresh_visibility : bool, optional
+            The refresh visibility of the feature (NetworkLink specific).
+        fly_to_view : bool, optional
+            Whether to fly to the view (NetworkLink specific).
+        link : Link, optional
+            The link associated with the feature.
+        **kwargs : Any
+            Additional keyword arguments.
+
+        Returns
+        -------
+        None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -725,7 +863,14 @@ class NetworkLink(_Feature):
         self.link = link
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for NetworkLink."""
+        """
+        Return a string representation of the NetworkLink object.
+
+        Returns
+        -------
+            str: A string representation of the NetworkLink object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -755,6 +900,15 @@ class NetworkLink(_Feature):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the feature has a link.
+
+        Returns
+        -------
+        bool
+            True if the feature has a link, False otherwise.
+
+        """
         return bool(self.link)
 
 

--- a/fastkml/geometry.py
+++ b/fastkml/geometry.py
@@ -13,6 +13,17 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+"""
+Classes and functions for working with geometries in KML files.
+
+The classes in this module represent different types of geometries, such as points,
+lines, polygons, and multi-geometries.
+These geometries can be used to define the shape and location of features in KML files.
+
+The module also provides functions for handling coordinates and extracting them from XML
+elements.
+
+"""
 
 import logging
 import re
@@ -89,6 +100,24 @@ def handle_invalid_geometry_error(
     element: Element,
     strict: bool,
 ) -> None:
+    """
+    Handle an invalid geometry error.
+
+    Args:
+    ----
+        error (Exception): The exception that occurred.
+        element (Element): The XML element that caused the error.
+        strict (bool): Flag indicating whether to raise an exception or not.
+
+    Returns:
+    -------
+        None
+
+    Raises:
+    ------
+        KMLParseError: If `strict` is True, raise a KMLParseError.
+
+    """
     error_in_xml = config.etree.tostring(
         element,
         encoding="UTF-8",
@@ -106,9 +135,9 @@ def coordinates_subelement(
     *,
     element: Element,
     attr_name: str,
-    node_name: str,
+    node_name: str,  # noqa: ARG001
     precision: Optional[int],
-    verbosity: Optional[Verbosity],
+    verbosity: Optional[Verbosity],  # noqa: ARG001
 ) -> None:
     """
     Set the value of an attribute from a subelement with a text node.
@@ -130,9 +159,9 @@ def coordinates_subelement(
     if getattr(obj, attr_name, None):
         p = precision if precision is not None else 6
         coords = getattr(obj, attr_name)
-        if len(coords[0]) == 2:
+        if len(coords[0]) == 2:  # noqa: PLR2004
             tuples = (f"{c[0]:.{p}f},{c[1]:.{p}f}" for c in coords)
-        elif len(coords[0]) == 3:
+        elif len(coords[0]) == 3:  # noqa: PLR2004
             tuples = (f"{c[0]:.{p}f},{c[1]:.{p}f},{c[2]:.{p}f}" for c in coords)
         else:
             msg = f"Invalid dimensions in coordinates '{coords}'"
@@ -143,15 +172,15 @@ def coordinates_subelement(
 def subelement_coordinates_kwarg(
     *,
     element: Element,
-    ns: str,
-    name_spaces: Dict[str, str],
-    node_name: str,
+    ns: str,  # noqa: ARG001
+    name_spaces: Dict[str, str],  # noqa: ARG001
+    node_name: str,  # noqa: ARG001
     kwarg: str,
-    classes: Tuple[known_types, ...],
+    classes: Tuple[known_types, ...],  # noqa: ARG001
     strict: bool,
 ) -> Dict[str, LineType]:
     """
-    Extracts coordinates from a subelement and returns them as a dictionary.
+    Extract coordinates from a subelement and returns them as a dictionary.
 
     Args:
     ----
@@ -215,7 +244,22 @@ class Coordinates(_XMLObject):
         name_spaces: Optional[Dict[str, str]] = None,
         coords: Optional[LineType] = None,
         **kwargs: Any,
-    ):
+    ) -> None:
+        """
+        Initialize a Geometry object.
+
+        Parameters
+        ----------
+        ns : str, optional
+            The namespace for the element.
+        name_spaces : dict, optional
+            A dictionary of namespace prefixes and URIs.
+        coords : LineType, optional
+            The coordinates of the geometry.
+        **kwargs : dict
+            Additional keyword arguments.
+
+        """
         super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.coords = coords or []
 
@@ -231,6 +275,15 @@ class Coordinates(_XMLObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the geometry has any coordinates.
+
+        Returns
+        -------
+        bool
+            True if the geometry has coordinates, False otherwise.
+
+        """
         return bool(self.coords)
 
     @classmethod
@@ -282,16 +335,19 @@ class _Geometry(_BaseObject):
         **kwargs: Any,
     ) -> None:
         """
+        Initialize a _Geometry object.
 
         Args:
         ----
-            ns: Namespace of the object
-            id: Id of the object
-            target_id: Target id of the object
+            ns: Namespace of the object.
+            name_spaces: Name spaces of the object.
+            id: Id of the object.
+            target_id: Target id of the object.
             extrude: Specifies whether to connect the feature to the ground with a line.
             tessellate: Specifies whether to allow the LineString to follow the terrain.
             altitude_mode: Specifies how altitude components in the <coordinates>
                            element are interpreted.
+            **kwargs: Additional keyword arguments.
 
         """
         super().__init__(
@@ -533,7 +589,7 @@ class LineString(_Geometry):
             tessellate (Optional[bool]): Whether to tessellate the geometry.
             altitude_mode (Optional[AltitudeMode]): The altitude mode of the geometry.
             geometry (Optional[geo.LineString]): The LineString geometry.
-            kml_coordinates (Optional[Coordinates]): The KML coordinates of the geometry.
+            kml_coordinates (Optional[Coordinates]): The coordinates of the geometry.
             **kwargs (Any): Additional keyword arguments.
 
         Raises:
@@ -641,6 +697,37 @@ class LinearRing(LineString):
         kml_coordinates: Optional[Coordinates] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Geometry object.
+
+        Parameters
+        ----------
+        ns : str, optional
+            The namespace for the element.
+        name_spaces : dict[str, str], optional
+            A dictionary of namespace prefixes and URIs.
+        id : str, optional
+            The ID of the element.
+        target_id : str, optional
+            The target ID of the element.
+        extrude : bool, optional
+            Whether to extrude the geometry.
+        tessellate : bool, optional
+            Whether to tessellate the geometry.
+        altitude_mode : AltitudeMode, optional
+            The altitude mode of the geometry.
+        geometry : geo.LinearRing, optional
+            The geometry object.
+        kml_coordinates : Coordinates, optional
+            The KML coordinates.
+        **kwargs : Any
+            Additional keyword arguments.
+
+        Returns
+        -------
+        None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -698,8 +785,8 @@ class OuterBoundaryIs(_XMLObject):
 
     Attributes
     ----------
-        kml_geometry (Optional[LinearRing]): The KML geometry representing the outer
-        boundary.
+    kml_geometry : Optional[LinearRing]
+        The KML geometry representing the outer boundary.
 
     """
 
@@ -715,6 +802,33 @@ class OuterBoundaryIs(_XMLObject):
         kml_geometry: Optional[LinearRing] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Boundary object.
+
+        Parameters
+        ----------
+        ns : str, optional
+            The namespace for the KML element.
+        name_spaces : dict, optional
+            A dictionary of namespace prefixes and URIs.
+        geometry : fastkml.geometry.LinearRing, optional
+            The geometry object.
+        kml_geometry : fastkml.geometry.LinearRing, optional
+            The KML geometry object.
+        **kwargs : Any
+            Additional keyword arguments.
+
+        Raises
+        ------
+        GeometryError
+            If both `geometry` and `kml_geometry` are provided.
+
+        Notes
+        -----
+        If `kml_geometry` is not provided, it will be created based on the `geometry`
+        parameter.
+
+        """
         if geometry is not None and kml_geometry is not None:
             raise GeometryError(MsgMutualExclusive)
         if kml_geometry is None:
@@ -731,15 +845,41 @@ class OuterBoundaryIs(_XMLObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the OuterBoundaryIs object is valid.
+
+        Returns
+        -------
+        bool
+            True if the object has a valid geometry, False otherwise.
+
+        """
         return bool(self.geometry)
 
     @classmethod
     def get_tag_name(cls) -> str:
-        """Return the tag name."""
+        """
+        Get the tag name for the OuterBoundaryIs object.
+
+        Returns
+        -------
+        str
+            The tag name.
+
+        """
         return "outerBoundaryIs"
 
     @property
     def geometry(self) -> Optional[geo.LinearRing]:
+        """
+        Get the geometry of the OuterBoundaryIs object.
+
+        Returns
+        -------
+        Optional[geo.LinearRing]
+            The geometry object representing the outer boundary.
+
+        """
         return self.kml_geometry.geometry if self.kml_geometry else None
 
 
@@ -771,6 +911,34 @@ class InnerBoundaryIs(_XMLObject):
         kml_geometries: Optional[Iterable[LinearRing]] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Geometry object.
+
+        Parameters
+        ----------
+        ns : Optional[str], optional
+            The namespace for the KML element, by default None.
+        name_spaces : Optional[Dict[str, str]], optional
+            The namespace dictionary for the KML element, by default None.
+        geometries : Optional[Iterable[geo.LinearRing]], optional
+            The geometries to be converted to KML geometries, by default None.
+        kml_geometries : Optional[Iterable[LinearRing]], optional
+            The KML geometries, by default None.
+        **kwargs : Any
+            Additional keyword arguments.
+
+        Raises
+        ------
+        GeometryError
+            If both `geometries` and `kml_geometries` are provided.
+
+        Notes
+        -----
+        - If `geometries` is provided, it will be converted to KML geometries and
+            stored in `kml_geometries`.
+        - If `geometries` is not provided, `kml_geometries` will be an empty list.
+
+        """
         if geometries is not None and kml_geometries is not None:
             raise GeometryError(MsgMutualExclusive)
         if kml_geometries is None:
@@ -790,22 +958,19 @@ class InnerBoundaryIs(_XMLObject):
         )
 
     def __bool__(self) -> bool:
-        """
-        Returns True if any of the inner boundary geometries exist, False otherwise.
-        """
+        """Return True if any of the inner boundary geometries exist."""
         return any(b.geometry for b in self.kml_geometries)
 
     @classmethod
     def get_tag_name(cls) -> str:
-        """
-        Returns the tag name of the element.
-        """
+        """Return the tag name of the element."""
         return "innerBoundaryIs"
 
     @property
     def geometries(self) -> Optional[Iterable[geo.LinearRing]]:
         """
-        Returns the list of LinearRing objects representing the inner boundary.
+        Return the list of LinearRing objects representing the inner boundary.
+
         If no inner boundary geometries exist, returns None.
         """
         if not self.kml_geometries:
@@ -847,7 +1012,8 @@ class Polygon(_Geometry):
 
     Example usage:
     ```
-    polygon = Polygon(outer_boundary_is=outer_boundary, inner_boundary_is=inner_boundary)
+    polygon = Polygon(outer_boundary_is=outer_boundary,
+        inner_boundary_is=inner_boundary)
     print(polygon.geometry)
     ```
 
@@ -872,6 +1038,44 @@ class Polygon(_Geometry):
         geometry: Optional[geo.Polygon] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Geometry object.
+
+        Parameters
+        ----------
+        ns : Optional[str]
+            The namespace of the element.
+        name_spaces : Optional[Dict[str, str]]
+            The dictionary of namespace prefixes and URIs.
+        id : Optional[str]
+            The ID of the element.
+        target_id : Optional[str]
+            The target ID of the element.
+        extrude : Optional[bool]
+            The extrude flag of the element.
+        tessellate : Optional[bool]
+            The tessellate flag of the element.
+        altitude_mode : Optional[AltitudeMode]
+            The altitude mode of the element.
+        outer_boundary_is : Optional[OuterBoundaryIs]
+            The outer boundary of the element.
+        inner_boundary_is : Optional[InnerBoundaryIs]
+            The inner boundaries of the element.
+        geometry : Optional[geo.Polygon]
+            The geometry object of the element.
+        **kwargs : Any
+            Additional keyword arguments.
+
+        Raises
+        ------
+        GeometryError
+            If both outer_boundary_is and geometry are provided.
+
+        Returns
+        -------
+        None
+
+        """
         if outer_boundary_is is not None and geometry is not None:
             raise GeometryError(MsgMutualExclusive)
         if geometry is not None:
@@ -891,10 +1095,28 @@ class Polygon(_Geometry):
         )
 
     def __bool__(self) -> bool:
+        """
+        Return True if the outer boundary is defined, False otherwise.
+
+        Returns
+        -------
+        bool
+            True if the outer boundary is defined, False otherwise.
+
+        """
         return bool(self.outer_boundary_is)
 
     @property
     def geometry(self) -> Optional[geo.Polygon]:
+        """
+        Get the geometry object representing the geometry of the Polygon.
+
+        Returns
+        -------
+        Optional[geo.Polygon]
+            The geometry object representing the geometry of the Polygon.
+
+        """
         if not self.outer_boundary_is:
             return None
         if not self.inner_boundary_is:
@@ -907,7 +1129,15 @@ class Polygon(_Geometry):
         )
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for Polygon."""
+        """
+        Create a string representation for Polygon.
+
+        Returns
+        -------
+        str
+            The string representation for Polygon.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -999,6 +1229,7 @@ def create_kml_geometry(
     ----
         geometry: Geometry object.
         ns: Namespace of the object
+        name_spaces: Name spaces of the object
         id: Id of the object
         target_id: Target id of the object
         extrude: Specifies whether to connect the feature to the ground with a line.
@@ -1043,9 +1274,7 @@ def create_kml_geometry(
 
 
 class MultiGeometry(_Geometry):
-    """
-    A container for zero or more geometry primitives associated with the same feature.
-    """
+    """A container for zero or more geometry primitives."""
 
     kml_geometries: List[Union[Point, LineString, Polygon, LinearRing, Self]]
 
@@ -1065,6 +1294,44 @@ class MultiGeometry(_Geometry):
         geometry: Optional[MultiGeometryType] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Geometry object.
+
+        Parameters
+        ----------
+        ns : str, optional
+            The namespace for the KML element.
+        name_spaces : dict, optional
+            A dictionary of namespace prefixes and URIs.
+        id : str, optional
+            The ID of the KML element.
+        target_id : str, optional
+            The target ID of the KML element.
+        extrude : bool, optional
+            Specifies whether to extend the geometry to the ground.
+        tessellate : bool, optional
+            Specifies whether to allow the geometry to follow the terrain.
+        altitude_mode : AltitudeMode, optional
+            The altitude mode of the geometry.
+        kml_geometries : iterable of Point, LineString, Polygon, LinearRing,
+            MultiGeometry
+            A collection of KML geometries.
+        geometry : MultiGeometryType, optional
+            A multi-geometry object.
+        **kwargs : any
+            Additional keyword arguments.
+
+        Raises
+        ------
+        GeometryError
+            If both `kml_geometries` and `geometry` are provided.
+
+        Notes
+        -----
+        - If `geometry` is provided, it will be converted into a collection of KML
+            geometries.
+
+        """
         if kml_geometries is not None and geometry is not None:
             raise GeometryError(MsgMutualExclusive)
         if geometry is not None:
@@ -1092,15 +1359,11 @@ class MultiGeometry(_Geometry):
         )
 
     def __bool__(self) -> bool:
-        """
-        Returns True if the MultiGeometry has a geometry, False otherwise.
-        """
+        """Return True if the MultiGeometry has a geometry, False otherwise."""
         return bool(self.geometry)
 
     def __repr__(self) -> str:
-        """
-        Returns a string representation of the MultiGeometry.
-        """
+        """Return a string representation of the MultiGeometry."""
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -1117,9 +1380,7 @@ class MultiGeometry(_Geometry):
 
     @property
     def geometry(self) -> Optional[MultiGeometryType]:
-        """
-        Returns the geometry of the MultiGeometry.
-        """
+        """Return the geometry of the MultiGeometry."""
         return create_multigeometry(
             [geom.geometry for geom in self.kml_geometries if geom.geometry],
         )

--- a/fastkml/gx.py
+++ b/fastkml/gx.py
@@ -15,6 +15,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 
 """
+KML Extension Namespace and the gx prefix.
+
 With the launch of Google Earth 5.0, Google has provided extensions to KML
 to support a number of new features. These extensions use the gx prefix
 and the following namespace URI::
@@ -141,10 +143,24 @@ class TrackItem:
     def etree_elements(
         self,
         *,
-        precision: Optional[int] = None,
-        verbosity: Verbosity = Verbosity.normal,
+        precision: Optional[int] = None,  # noqa: ARG002
+        verbosity: Verbosity = Verbosity.normal,  # noqa: ARG002
         name_spaces: Optional[Dict[str, str]] = None,
     ) -> Iterator[Element]:
+        """
+        Generate XML elements for the gx:when, gx:coord, and gx:angles elements.
+
+        Args:
+        ----
+            precision (Optional[int]): The precision of the coordinates.
+            verbosity (Verbosity): The verbosity level. Defaults to Verbosity.normal.
+            name_spaces (Optional[Dict[str, str]]): Additional XML namespaces.
+
+        Yields:
+        ------
+            Element: The generated XML elements.
+
+        """
         name_spaces = name_spaces or {}
         name_spaces = {**config.NAME_SPACES, **name_spaces}
         element: Element = config.etree.Element(
@@ -174,12 +190,38 @@ class TrackItem:
 
 
 def track_items_to_geometry(track_items: Iterable[TrackItem]) -> geo.LineString:
+    """
+    Convert a sequence of TrackItems to a LineString geometry.
+
+    Args:
+    ----
+        track_items : Iterable[TrackItem]
+            A sequence of TrackItems.
+
+    Returns:
+    -------
+        geo.LineString
+            A LineString geometry representing the track.
+
+    """
     return geo.LineString.from_points(
         *[item.coord for item in track_items if item.coord is not None],
     )
 
 
 def linestring_to_track_items(linestring: geo.LineString) -> List[TrackItem]:
+    """
+    Convert a LineString to a list of TrackItems.
+
+    Args:
+    ----
+        linestring (LineString): The LineString to convert.
+
+    Returns:
+    -------
+        List[TrackItem]: A list of TrackItems representing the points in the LineString.
+
+    """
     return [TrackItem(coord=point) for point in linestring.geoms]
 
 
@@ -215,6 +257,38 @@ class Track(_Geometry):
         track_items: Optional[Iterable[TrackItem]] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a GX object.
+
+        Parameters
+        ----------
+        ns : Optional[str], optional
+            The namespace for the GX object, by default None
+        name_spaces : Optional[Dict[str, str]], optional
+            A dictionary of namespace prefixes and URIs, by default None
+        id : Optional[str], optional
+            The ID of the GX object, by default None
+        target_id : Optional[str], optional
+            The target ID of the GX object, by default None
+        extrude : Optional[bool], optional
+            Whether to extrude the GX object, by default None
+        tessellate : Optional[bool], optional
+            Whether to tessellate the GX object, by default None
+        altitude_mode : Optional[AltitudeMode], optional
+            The altitude mode of the GX object, by default None
+        geometry : Optional[geo.LineString], optional
+            The geometry of the GX object, by default None
+        track_items : Optional[Iterable[TrackItem]], optional
+            The track items of the GX object, by default None
+        **kwargs : Any, optional
+            Additional keyword arguments.
+
+        Raises
+        ------
+        ValueError
+            If both `geometry` and `track_items` are specified.
+
+        """
         if geometry and track_items:
             msg = "Cannot specify both geometry and track_items"
             raise ValueError(msg)
@@ -233,7 +307,15 @@ class Track(_Geometry):
         )
 
     def __repr__(self) -> str:
-        """Create a string (c)representation for Track."""
+        """
+        Create a string representation for Track.
+
+        Returns
+        -------
+        str
+            The string representation of the Track object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
@@ -251,9 +333,27 @@ class Track(_Geometry):
 
     @property
     def geometry(self) -> Optional[geo.LineString]:
+        """
+        Get the geometry of the track.
+
+        Returns
+        -------
+        Optional[geo.LineString]
+            The geometry of the track.
+
+        """
         return track_items_to_geometry(self.track_items)
 
     def __bool__(self) -> bool:
+        """
+        Check if the track has any track items.
+
+        Returns
+        -------
+        bool
+            True if the track has track items, False otherwise.
+
+        """
         return bool(self.track_items)
 
     def etree_element(
@@ -262,6 +362,24 @@ class Track(_Geometry):
         verbosity: Verbosity = Verbosity.normal,
         name_spaces: Optional[Dict[str, str]] = None,
     ) -> Element:
+        """
+        Get the ElementTree element representation of the track.
+
+        Parameters
+        ----------
+        precision : Optional[int], optional
+            The precision for floating-point values, by default None
+        verbosity : Verbosity, optional
+            The verbosity level for the element, by default Verbosity.normal
+        name_spaces : Optional[Dict[str, str]], optional
+            A dictionary of namespace prefixes and URIs, by default None
+
+        Returns
+        -------
+        Element
+            The ElementTree element representation of the track.
+
+        """
         element = super().etree_element(precision=precision, verbosity=verbosity)
         if self.track_items:
             for track_item in self.track_items:
@@ -275,6 +393,20 @@ class Track(_Geometry):
 
     @classmethod
     def _get_timestamps(cls, element: Element) -> List[Optional[datetime.datetime]]:
+        """
+        Get the timestamps from the XML element.
+
+        Parameters
+        ----------
+        element : Element
+            The XML element.
+
+        Returns
+        -------
+        List[Optional[datetime.datetime]]
+            The list of timestamps.
+
+        """
         time_stamps: List[Optional[datetime.datetime]] = []
         for time_stamp in element.findall(f"{config.KMLNS}when"):
             if time_stamp is not None and time_stamp.text:
@@ -285,6 +417,20 @@ class Track(_Geometry):
 
     @classmethod
     def _get_coords(cls, element: Element) -> List[Optional[geo.Point]]:
+        """
+        Get the coordinates from the XML element.
+
+        Parameters
+        ----------
+        element : Element
+            The XML element.
+
+        Returns
+        -------
+        List[Optional[geo.Point]]
+            The list of coordinates.
+
+        """
         coords: List[Optional[geo.Point]] = []
         for coord in element.findall(f"{config.GXNS}coord"):
             if coord is not None and coord.text:
@@ -297,6 +443,20 @@ class Track(_Geometry):
 
     @classmethod
     def _get_angles(cls, element: Element) -> List[Optional[Angle]]:
+        """
+        Get the angles from the XML element.
+
+        Parameters
+        ----------
+        element : Element
+            The XML element.
+
+        Returns
+        -------
+        List[Optional[Angle]]
+            The list of angles.
+
+        """
         angles: List[Optional[Angle]] = []
         for angle in element.findall(f"{config.GXNS}angles"):
             if angle is not None and angle.text:
@@ -309,10 +469,28 @@ class Track(_Geometry):
     def track_items_kwargs_from_element(
         cls,
         *,
-        ns: str,
+        ns: str,  # noqa: ARG003
         element: Element,
-        strict: bool,
+        strict: bool,  # noqa: ARG003
     ) -> List[TrackItem]:
+        """
+        Get the track item keyword arguments from the XML element.
+
+        Parameters
+        ----------
+        ns : str
+            The namespace for the GX object.
+        element : Element
+            The XML element.
+        strict : bool
+            Whether to enforce strict parsing.
+
+        Returns
+        -------
+        List[TrackItem]
+            The list of track items.
+
+        """
         time_stamps = cls._get_timestamps(element)
         coords = cls._get_coords(element)
         angles = cls._get_angles(element)
@@ -330,6 +508,26 @@ class Track(_Geometry):
         element: Element,
         strict: bool,
     ) -> Dict[str, Any]:
+        """
+        Get the keyword arguments for the track.
+
+        Parameters
+        ----------
+        ns : str
+            The namespace for the GX object.
+        name_spaces : Optional[Dict[str, str]], optional
+            A dictionary of namespace prefixes and URIs, by default None
+        element : Element
+            The XML element.
+        strict : bool
+            Whether to enforce strict parsing.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The keyword arguments for the track.
+
+        """
         kwargs = super()._get_kwargs(
             ns=ns,
             name_spaces=name_spaces,
@@ -348,16 +546,63 @@ def multilinestring_to_tracks(
     multilinestring: geo.MultiLineString,
     ns: Optional[str],
 ) -> List[Track]:
+    """
+    Convert a MultiLineString to a list of Track objects.
+
+    Args:
+    ----
+        multilinestring : geo.MultiLineString:
+            The MultiLineString to convert.
+        ns : str, optional:
+            The namespace for the Track objects.
+
+    Returns:
+    -------
+        List[Track]:
+            A list of Track objects.
+
+    """
     return [Track(ns=ns, geometry=linestring) for linestring in multilinestring.geoms]
 
 
 def tracks_to_geometry(tracks: Iterable[Track]) -> geo.MultiLineString:
+    """
+    Convert a collection of tracks to a MultiLineString geometry.
+
+    Args:
+    ----
+        tracks : Iterable[Track]
+            A collection of tracks.
+
+    Returns:
+    -------
+        geo.MultiLineString
+            A MultiLineString geometry representing the tracks.
+
+    """
     return geo.MultiLineString.from_linestrings(
         *[track.geometry for track in tracks if track.geometry],
     )
 
 
 class MultiTrack(_Geometry):
+    """
+    A MultiTrack is a collection of tracks.
+
+    A multi-track element is used to combine multiple track elements into a single
+    conceptual unit. For example, suppose you collect GPS data for a day's bike ride
+    that includes several rest stops and a stop for lunch. Because of the interruptions
+    in time, one bike ride might appear as four different tracks when the times and
+    positions are plotted.
+    Grouping these <gx:Track> elements into one <gx:MultiTrack> container causes them to
+    be displayed in Google Earth as sections of a single path.
+    When the icon reaches the end of one segment, it moves to the beginning of the next
+    segment.
+    The <gx:interpolate> element specifies whether to stop at the end of one track and
+    jump immediately to the start of the next one, or to interpolate the missing values
+    between the two tracks.
+    """
+
     _default_ns = config.GXNS
     tracks: List[Track]
 
@@ -376,6 +621,29 @@ class MultiTrack(_Geometry):
         interpolate: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a GX object.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the GX object.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespace prefixes
+                and URIs.
+            id (Optional[str]): The ID of the GX object.
+            target_id (Optional[str]): The target ID of the GX object.
+            extrude (Optional[bool]): The extrude flag of the GX object.
+            tessellate (Optional[bool]): The tessellate flag of the GX object.
+            altitude_mode (Optional[AltitudeMode]): The altitude mode of the GX object.
+            geometry (Optional[geo.MultiLineString]): The geometry of the GX object.
+            tracks (Optional[Iterable[Track]]): The tracks of the GX object.
+            interpolate (Optional[bool]): The interpolate flag of the GX object.
+            **kwargs (Any): Additional keyword arguments.
+
+        Raises:
+        ------
+            ValueError: If both geometry and tracks are specified.
+
+        """
         if geometry and tracks:
             msg = "Cannot specify both geometry and track_items"
             raise ValueError(msg)
@@ -414,9 +682,26 @@ class MultiTrack(_Geometry):
 
     @property
     def geometry(self) -> Optional[geo.MultiLineString]:
+        """
+        Get the geometry of the gx object.
+
+        Returns
+        -------
+            Optional[geo.MultiLineString]: The geometry of the gx object.
+
+        """
         return tracks_to_geometry(self.tracks)
 
     def __bool__(self) -> bool:
+        """
+        Check if the object has any tracks.
+
+        Returns
+        -------
+        bool
+            True if the object has tracks, False otherwise.
+
+        """
         return bool(self.tracks)
 
 

--- a/fastkml/helpers.py
+++ b/fastkml/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023  Christian Ledermann
+# Copyright (C) 2023 - 2024 Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -14,6 +14,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 """Helper functions for fastkml."""
+
 import logging
 from enum import Enum
 from typing import Dict
@@ -75,8 +76,7 @@ def handle_error(
     )
     if strict:
         raise KMLParseError(msg) from error
-    else:
-        logger.warning("%s, %s", error, msg)
+    logger.warning("%s, %s", error, msg)
 
 
 def node_text(
@@ -88,6 +88,30 @@ def node_text(
     precision: Optional[int],
     verbosity: Optional[Verbosity],
 ) -> None:
+    """
+    Set the text of an XML element based on the attribute value in the given object.
+
+    Parameters
+    ----------
+    obj : _XMLObject
+        The object containing the attribute value.
+    element : Element
+        The XML element to set the text content for.
+    attr_name : str
+        The name of the attribute in the object.
+    node_name : str
+        The name of the XML node (unused).
+    precision : Optional[int]
+        The precision to use when converting numeric values to text (unused).
+    verbosity : Optional[Verbosity]
+        The verbosity level for logging (unused).
+
+    Returns
+    -------
+    None
+        This function does not return anything.
+
+    """
     if getattr(obj, attr_name, None):
         element.text = getattr(obj, attr_name)
 
@@ -327,6 +351,23 @@ def xml_subelement(
     precision: Optional[int],
     verbosity: Optional[Verbosity],
 ) -> None:
+    """
+    Add a subelement to an XML element based on the value of an attribute of an object.
+
+    Args:
+    ----
+        obj (_XMLObject): The object containing the attribute.
+        element (Element): The XML element to which the subelement will be added.
+        attr_name (str): The name of the attribute in the object.
+        node_name (str): The name of the XML node for the subelement (unused).
+        precision (Optional[int]): The precision for formatting numerical values.
+        verbosity (Optional[Verbosity]): The verbosity level for the subelement.
+
+    Returns:
+    -------
+        None
+
+    """
     if getattr(obj, attr_name, None):
         element.append(
             getattr(obj, attr_name).etree_element(
@@ -345,6 +386,23 @@ def xml_subelement_list(
     precision: Optional[int],
     verbosity: Optional[Verbosity],
 ) -> None:
+    """
+    Add subelements to an XML element based on a list attribute of an object.
+
+    Args:
+    ----
+        obj (_XMLObject): The object containing the list attribute.
+        element (Element): The XML element to which the subelements will be added.
+        attr_name (str): The name of the list attribute in the object.
+        node_name (str): The name of the XML node for each subelement (unused).
+        precision (Optional[int]): The precision for floating-point values.
+        verbosity (Optional[Verbosity]): The verbosity level for the XML output.
+
+    Returns:
+    -------
+        None
+
+    """
     if getattr(obj, attr_name, None):
         for item in getattr(obj, attr_name):
             if item:
@@ -363,6 +421,26 @@ def node_text_kwarg(
     classes: Tuple[known_types, ...],
     strict: bool,
 ) -> Dict[str, str]:
+    """
+    Extract the text content of an XML element and return it as a dictionary.
+
+    Args:
+    ----
+        element (Element): The XML element to extract the text content from.
+        ns (str): The namespace of the XML element.
+        name_spaces (Dict[str, str]):
+            A dictionary mapping namespace prefixes to their URIs.
+        node_name (str): The name of the XML node.
+        kwarg (str): The name of the keyword argument to store the text content in.
+        classes (Tuple[known_types, ...]): A tuple of known types.
+        strict (bool): A flag indicating whether to enforce strict parsing rules.
+
+    Returns:
+    -------
+        Dict[str, str]: A dictionary containing the keyword argument and its
+            corresponding text content, if it exists.
+
+    """
     return (
         {kwarg: element.text.strip()} if element.text and element.text.strip() else {}
     )
@@ -378,6 +456,25 @@ def subelement_text_kwarg(
     classes: Tuple[known_types, ...],
     strict: bool,
 ) -> Dict[str, str]:
+    """
+    Extract the text content of a subelement and return it as a dictionary.
+
+    Args:
+    ----
+        element (Element): The parent element.
+        ns (str): The namespace of the subelement.
+        name_spaces (Dict[str, str]): A dictionary of namespace prefixes and URIs.
+        node_name (str): The name of the subelement.
+        kwarg (str): The key to use in the returned dictionary.
+        classes (Tuple[known_types, ...]): A tuple of known types.
+        strict (bool): A flag indicating whether to enforce strict parsing.
+
+    Returns:
+    -------
+        Dict[str, str]: A dictionary containing the extracted text content,
+            with the specified key.
+
+    """
     node = element.find(f"{ns}{node_name}")
     if node is None:
         return {}
@@ -394,11 +491,29 @@ def attribute_text_kwarg(
     classes: Tuple[known_types, ...],
     strict: bool,
 ) -> Dict[str, str]:
+    """
+    Return a dictionary representing the attribute as a keyword argument.
+
+    Args:
+    ----
+        element (Element): The XML element.
+        ns (str): The namespace of the attribute.
+        name_spaces (Dict[str, str]): A dictionary mapping namespace prefixes to URIs.
+        node_name (str): The name of the XML node.
+        kwarg (str): The name of the keyword argument.
+        classes (Tuple[known_types, ...]): A tuple of known types.
+        strict (bool): A flag indicating whether to enforce strict parsing.
+
+    Returns:
+    -------
+        Dict[str, str]: A dictionary representing the attribute as a keyword argument.
+
+    """
     attr = element.get(f"{ns}{node_name}")
     return {kwarg: attr} if attr else {}
 
 
-def _get_boolean_value(text: str, strict: bool) -> bool:
+def _get_boolean_value(*, text: str, strict: bool) -> bool:
     if not strict:
         text = text.lower()
     if text in {"1", "true"}:
@@ -407,7 +522,8 @@ def _get_boolean_value(text: str, strict: bool) -> bool:
         return False
     if not strict:
         return bool(float(text))
-    raise ValueError(f"Invalid boolean value: {text}")
+    msg = f"Value {text} is not a valid value for Boolean"
+    raise ValueError(msg)
 
 
 def subelement_bool_kwarg(
@@ -420,14 +536,36 @@ def subelement_bool_kwarg(
     classes: Tuple[known_types, ...],
     strict: bool,
 ) -> Dict[str, bool]:
-    assert len(classes) == 1
-    assert issubclass(classes[0], bool)
+    """
+    Extract a boolean value from a subelement of an XML element.
+
+    Args:
+    ----
+        element (Element): The XML element to search for the subelement.
+        ns (str): The namespace of the subelement.
+        name_spaces (Dict[str, str]): A dictionary mapping namespace prefixes to URIs.
+        node_name (str): The name of the subelement.
+        kwarg (str): The name of the keyword argument to store the boolean value.
+        classes (Tuple[known_types, ...]): A tuple of known types.
+        strict (bool): A flag indicating whether to enforce strict parsing.
+
+    Returns:
+    -------
+        Dict[str, bool]: A dictionary containing the keyword argument and its value.
+
+    Raises:
+    ------
+        ValueError: If the value of the subelement is not a valid boolean.
+
+    """
+    assert len(classes) == 1  # noqa: S101
+    assert issubclass(classes[0], bool)  # noqa: S101
     node = element.find(f"{ns}{node_name}")
     if node is None:
         return {}
     if node.text and node.text.strip():
         try:
-            return {kwarg: _get_boolean_value(node.text.strip(), strict)}
+            return {kwarg: _get_boolean_value(text=node.text.strip(), strict=strict)}
         except ValueError as exc:
             handle_error(
                 error=exc,
@@ -449,6 +587,28 @@ def subelement_int_kwarg(
     classes: Tuple[known_types, ...],
     strict: bool,
 ) -> Dict[str, int]:
+    """
+    Extract an integer value from a subelement of an XML element.
+
+    Args:
+    ----
+        element (Element): The XML element to search for the subelement.
+        ns (str): The namespace of the subelement.
+        name_spaces (Dict[str, str]): A dictionary mapping namespace prefixes to URIs.
+        node_name (str): The name of the subelement.
+        kwarg (str): The key to use in the returned dictionary.
+        classes (Tuple[known_types, ...]): A tuple of known types for error handling.
+        strict (bool): A flag indicating whether to enforce strict parsing.
+
+    Returns:
+    -------
+        Dict[str, int]: A dictionary containing the keyword argument and its value.
+
+    Raises:
+    ------
+        ValueError: If the value of the subelement is not a valid integer and strict.
+
+    """
     node = element.find(f"{ns}{node_name}")
     if node is None:
         return {}
@@ -476,6 +636,24 @@ def attribute_int_kwarg(
     classes: Tuple[known_types, ...],
     strict: bool,
 ) -> Dict[str, int]:
+    """
+    Extract an integer attribute from an XML element and return it as a dictionary.
+
+    Args:
+    ----
+        element (Element): The XML element to extract the attribute from.
+        ns (str): The namespace of the attribute.
+        name_spaces (Dict[str, str]): A dictionary mapping namespace prefixes to URIs.
+        node_name (str): The name of the XML node containing the attribute.
+        kwarg (str): The name of the keyword argument to store the extracted attribute.
+        classes (Tuple[known_types, ...]): A tuple of known types (unused).
+        strict (bool): A flag indicating whether to raise an exception (unused).
+
+    Returns:
+    -------
+        Dict[str, int]: A dictionary containing the extracted attribute value.
+
+    """
     attr = element.get(f"{ns}{node_name}")
     return {kwarg: int(attr)} if attr else {}
 
@@ -490,6 +668,28 @@ def subelement_float_kwarg(
     classes: Tuple[known_types, ...],
     strict: bool,
 ) -> Dict[str, float]:
+    """
+    Extract a float value from a subelement of an XML element.
+
+    Args:
+    ----
+        element (Element): The XML element to search for the subelement.
+        ns (str): The namespace of the subelement.
+        name_spaces (Dict[str, str]): A dictionary of namespace prefixes and URIs.
+        node_name (str): The name of the subelement.
+        kwarg (str): The name of the keyword argument to store the float value.
+        classes (Tuple[known_types, ...]): A tuple of known types for error handling.
+        strict (bool): A flag indicating whether to raise an error.
+
+    Returns:
+    -------
+        Dict[str, float]: A dictionary containing the float value as a keyword argument.
+
+    Raises:
+    ------
+        ValueError: If the value of the subelement cannot be converted and strict.
+
+    """
     node = element.find(f"{ns}{node_name}")
     if node is None:
         return {}
@@ -517,6 +717,28 @@ def attribute_float_kwarg(
     classes: Tuple[known_types, ...],
     strict: bool,
 ) -> Dict[str, float]:
+    """
+    Convert an attribute value to a float and return it as a dictionary.
+
+    Args:
+    ----
+        element (Element): The XML element containing the attribute.
+        ns (str): The namespace of the attribute.
+        name_spaces (Dict[str, str]): A dictionary of namespace prefixes and URIs.
+        node_name (str): The name of the attribute.
+        kwarg (str): The name of the keyword argument to store the converted float.
+        classes (Tuple[known_types, ...]): A tuple of known types for error handling.
+        strict (bool): A flag indicating whether to raise an error for invalid values.
+
+    Returns:
+    -------
+        Dict[str, float]: A dictionary containing the float as a keyword argument.
+
+    Raises:
+    ------
+        ValueError: If the attribute value cannot be converted to a float.
+
+    """
     attr = element.get(f"{ns}{node_name}")
     try:
         return {kwarg: float(attr)} if attr else {}
@@ -531,7 +753,7 @@ def attribute_float_kwarg(
     return {}
 
 
-def _get_enum_value(enum_class: Type[Enum], text: str, strict: bool) -> Enum:
+def _get_enum_value(*, enum_class: Type[Enum], text: str, strict: bool) -> Enum:
     value = enum_class(text)
     if strict and value.value != text:
         msg = f"Value {text} is not a valid value for Enum {enum_class.__name__}"
@@ -549,15 +771,43 @@ def subelement_enum_kwarg(
     classes: Tuple[known_types, ...],
     strict: bool,
 ) -> Dict[str, Enum]:
-    assert len(classes) == 1
-    assert issubclass(classes[0], Enum)
+    """
+    Extract an enumerated value from a subelement of an XML element.
+
+    Args:
+    ----
+        element (Element): The XML element to search for the subelement.
+        ns (str): The namespace of the subelement.
+        name_spaces (Dict[str, str]): A dictionary of namespace prefixes and URIs.
+        node_name (str): The name of the subelement.
+        kwarg (str): The name of the keyword argument to store the extracted value.
+        classes (Tuple[known_types, ...]): A tuple of enumerated value classes.
+        strict (bool): A flag indicating whether to raise an exception.
+
+    Returns:
+    -------
+        Dict[str, Enum]: A dictionary containing the extracted enumerated value.
+
+    Raises:
+    ------
+        ValueError: If the extracted value is not a valid enumerated value and strict.
+
+    """
+    assert len(classes) == 1  # noqa: S101
+    assert issubclass(classes[0], Enum)  # noqa: S101
     node = element.find(f"{ns}{node_name}")
     if node is None:
         return {}
     node_text = node.text.strip() if node.text else ""
     if node_text:
         try:
-            return {kwarg: _get_enum_value(classes[0], node_text, strict)}
+            return {
+                kwarg: _get_enum_value(
+                    enum_class=classes[0],
+                    text=node_text,
+                    strict=strict,
+                ),
+            }
         except ValueError as exc:
             handle_error(
                 error=exc,
@@ -579,18 +829,35 @@ def attribute_enum_kwarg(
     classes: Tuple[known_types, ...],
     strict: bool,
 ) -> Dict[str, Enum]:
-    assert len(classes) == 1
-    assert issubclass(classes[0], Enum)
+    """
+    Return a dictionary with the specified keyword argument and its enum value.
+
+    Args:
+    ----
+        element (Element): The XML element.
+        ns (str): The namespace of the XML element.
+        name_spaces (Dict[str, str]): A dictionary of namespace prefixes and their URIs.
+        node_name (str): The name of the XML node.
+        kwarg (str): The name of the keyword argument.
+        classes (Tuple[known_types, ...]): A tuple of enum classes.
+        strict (bool): A flag indicating whether to raise an error for invalid values.
+
+    Returns:
+    -------
+        Dict[str, Enum]: A dictionary with the specified keyword argument and its value.
+
+    """
+    assert len(classes) == 1  # noqa: S101
+    assert issubclass(classes[0], Enum)  # noqa: S101
     if raw := element.get(f"{ns}{node_name}"):
         try:
-            value = classes[0](raw)
-            if raw != value.value and strict:
-                msg = (
-                    f"Value {raw} is not a valid value for Enum "
-                    f"{classes[0].__name__}"
-                )
-                raise ValueError(msg)
-            return {kwarg: classes[0](raw)}
+            return {
+                kwarg: _get_enum_value(
+                    enum_class=classes[0],
+                    text=raw,
+                    strict=strict,
+                ),
+            }
         except ValueError as exc:
             handle_error(
                 error=exc,
@@ -612,8 +879,27 @@ def xml_subelement_kwarg(
     classes: Tuple[known_types, ...],
     strict: bool,
 ) -> Dict[str, _XMLObject]:
+    """
+    Return the subelement of the given XML element based on the provided parameters.
+
+    Args:
+    ----
+    element (Element): The XML element to search within.
+    ns (str): The namespace of the XML element.
+    name_spaces (Dict[str, str]): A dictionary mapping namespace prefixes to their URIs.
+    node_name (str): The name of the XML node to search for.
+    kwarg (str): The name of the keyword argument to store the found subelement.
+    classes (Tuple[known_types, ...]): A tuple of classes that represent the types.
+    strict (bool): A flag indicating whether to enforce strict parsing rules.
+
+    Returns:
+    -------
+    Dict[str, _XMLObject]: A dictionary containing the found subelement as the value
+        of the specified keyword argument.
+
+    """
     for cls in classes:
-        assert issubclass(cls, _XMLObject)
+        assert issubclass(cls, _XMLObject)  # noqa: S101
         subelement = element.find(f"{ns}{cls.get_tag_name()}")
         if subelement is not None:
             return {
@@ -637,11 +923,30 @@ def xml_subelement_list_kwarg(
     classes: Tuple[known_types, ...],
     strict: bool,
 ) -> Dict[str, List[_XMLObject]]:
+    """
+    Return a dictionary with the specified keyword argument and its list of subelements.
+
+    Args:
+    ----
+        element (Element): The XML element to search within.
+        ns (str): The namespace of the XML element.
+        name_spaces (Dict[str, str]): A dictionary mapping namespace prefixes to URIs.
+        node_name (str): The name of the XML node to search for.
+        kwarg (str): The name of the keyword argument to store the found subelements.
+        classes (Tuple[known_types, ...]): A tuple of classes that represent the types.
+        strict (bool): A flag indicating whether to enforce strict parsing rules.
+
+    Returns:
+    -------
+        Dict[str, List[_XMLObject]]: A dictionary containing the specified keyword
+            argument and its list of subelements.
+
+    """
     args_list = []
-    assert node_name is not None
-    assert name_spaces is not None
+    assert node_name is not None  # noqa: S101
+    assert name_spaces is not None  # noqa: S101
     for obj_class in classes:
-        assert issubclass(obj_class, _XMLObject)
+        assert issubclass(obj_class, _XMLObject)  # noqa: S101
         if subelements := element.findall(f"{ns}{obj_class.get_tag_name()}"):
             args_list.extend(
                 [

--- a/fastkml/kml_base.py
+++ b/fastkml/kml_base.py
@@ -50,7 +50,7 @@ class _BaseObject(_XMLObject):
         self,
         ns: Optional[str] = None,
         name_spaces: Optional[Dict[str, str]] = None,
-        id: Optional[str] = None,  # noqa: A002
+        id: Optional[str] = None,
         target_id: Optional[str] = None,
         **kwargs: Any,
     ) -> None:

--- a/fastkml/links.py
+++ b/fastkml/links.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
-
+"""Link and Icon elements."""
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -107,6 +107,15 @@ class Link(_BaseObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the link has a valid href.
+
+        Returns
+        -------
+        bool
+            True if the link has a valid href, False otherwise.
+
+        """
         return bool(self.href)
 
 

--- a/fastkml/mixins.py
+++ b/fastkml/mixins.py
@@ -26,17 +26,21 @@ logger = logging.getLogger(__name__)
 
 
 class TimeMixin:
+    """Mixin for classes that have a time element."""
+
     times: Optional[Union[TimeSpan, TimeStamp]] = None
 
     @property
     def time_stamp(self) -> Optional[KmlDateTime]:
-        """This just returns the datetime portion of the timestamp."""
+        """Return the timestamp."""
         return self.times.timestamp if isinstance(self.times, TimeStamp) else None
 
     @property
     def begin(self) -> Optional[KmlDateTime]:
+        """Return the start time of a time span."""
         return self.times.begin if isinstance(self.times, TimeSpan) else None
 
     @property
     def end(self) -> Optional[KmlDateTime]:
+        """Return the end time of a time span."""
         return self.times.end if isinstance(self.times, TimeSpan) else None

--- a/fastkml/overlays.py
+++ b/fastkml/overlays.py
@@ -126,6 +126,61 @@ class _Overlay(_Feature):
         draw_order: Optional[int] = None,
         icon: Optional[Icon] = None,
     ) -> None:
+        """
+        Initialize an Overlay object.
+
+        Parameters
+        ----------
+        ns : Optional[str]
+            The namespace of the element.
+        name_spaces : Optional[Dict[str, str]]
+            The dictionary of namespace prefixes and URIs.
+        id : Optional[str]
+            The ID of the element.
+        target_id : Optional[str]
+            The target ID of the element.
+        name : Optional[str]
+            The name of the element.
+        visibility : Optional[bool]
+            The visibility of the element.
+        isopen : Optional[bool]
+            The open state of the element.
+        atom_link : Optional[atom.Link]
+            The Atom link associated with the element.
+        atom_author : Optional[atom.Author]
+            The Atom author associated with the element.
+        address : Optional[str]
+            The address associated with the element.
+        phone_number : Optional[str]
+            The phone number associated with the element.
+        snippet : Optional[Snippet]
+            The snippet associated with the element.
+        description : Optional[str]
+            The description of the element.
+        view : Optional[Union[Camera, LookAt]]
+            The view associated with the element.
+        times : Optional[Union[TimeSpan, TimeStamp]]
+            The times associated with the element.
+        style_url : Optional[StyleUrl]
+            The style URL associated with the element.
+        styles : Optional[Iterable[Union[Style, StyleMap]]]
+            The styles associated with the element.
+        region : Optional[Region]
+            The region associated with the element.
+        extended_data : Optional[ExtendedData]
+            The extended data associated with the element.
+        color : Optional[str]
+            The color of the overlay.
+        draw_order : Optional[int]
+            The draw order of the overlay.
+        icon : Optional[Icon]
+            The icon associated with the overlay.
+
+        Returns
+        -------
+        None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -261,6 +316,33 @@ class ViewVolume(_XMLObject):
         near: Optional[float] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new Overlay object.
+
+        Parameters
+        ----------
+        ns : Optional[str]
+            The namespace for the Overlay element. Defaults to None.
+        name_spaces : Optional[Dict[str, str]]
+            A dictionary of namespace prefixes and URIs. Defaults to None.
+        left_fov : Optional[float]
+            The left field of view angle in degrees. Defaults to None.
+        right_fov : Optional[float]
+            The right field of view angle in degrees. Defaults to None.
+        bottom_fov : Optional[float]
+            The bottom field of view angle in degrees. Defaults to None.
+        top_fov : Optional[float]
+            The top field of view angle in degrees. Defaults to None.
+        near : Optional[float]
+            The near clipping distance in meters. Defaults to None.
+        **kwargs : Any
+            Additional keyword arguments.
+
+        Returns
+        -------
+        None
+
+        """
         super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.left_fov = left_fov
         self.right_fov = right_fov
@@ -284,6 +366,14 @@ class ViewVolume(_XMLObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if all the required attributes are not None.
+
+        Returns
+        -------
+            bool: True if all the required attributes are not None, False otherwise.
+
+        """
         return all(
             [
                 self.left_fov is not None,
@@ -401,6 +491,31 @@ class ImagePyramid(_XMLObject):
         grid_origin: Optional[GridOrigin] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new Overlay object.
+
+        Parameters
+        ----------
+        ns : Optional[str]
+            The namespace for the overlay.
+        name_spaces : Optional[Dict[str, str]]
+            A dictionary of namespace prefixes and URIs.
+        tile_size : Optional[int]
+            The size of each tile in pixels.
+        max_width : Optional[int]
+            The maximum width of the overlay.
+        max_height : Optional[int]
+            The maximum height of the overlay.
+        grid_origin : Optional[GridOrigin]
+            The origin of the grid.
+        **kwargs : Any
+            Additional keyword arguments.
+
+        Returns
+        -------
+        None
+
+        """
         super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.tile_size = tile_size
         self.max_width = max_width
@@ -422,6 +537,14 @@ class ImagePyramid(_XMLObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the overlay has all the required attributes set.
+
+        Returns
+        -------
+            bool: True if all the required attributes are set, False otherwise.
+
+        """
         return (
             self.tile_size is not None
             and self.max_width is not None
@@ -478,6 +601,8 @@ registry.register(
 
 class PhotoOverlay(_Overlay):
     """
+    PhotoOverlays are photographs that are directly embedded in the Earth's landscape.
+
     The <PhotoOverlay> element allows you to geographically locate a photograph
     on the Earth and to specify viewing parameters for this PhotoOverlay.
     The PhotoOverlay can be a simple 2D rectangle, a partial or full cylinder,
@@ -563,6 +688,73 @@ class PhotoOverlay(_Overlay):
         shape: Optional[Shape] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new Overlay object.
+
+        Args:
+        ----
+            ns : Optional[str]
+                The namespace for the element.
+            name_spaces : Optional[Dict[str, str]]
+                The dictionary of namespace prefixes and URIs.
+            id : Optional[str]
+                The ID of the element.
+            target_id : Optional[str]
+                The target ID of the element.
+            name : Optional[str]
+                The name of the element.
+            visibility : Optional[bool]
+                The visibility of the element.
+            isopen : Optional[bool]
+                The open status of the element.
+            atom_link : Optional[atom.Link]
+                The Atom link associated with the element.
+            atom_author : Optional[atom.Author]
+                The Atom author associated with the element.
+            address : Optional[str]
+                The address associated with the element.
+            phone_number : Optional[str]
+                The phone number associated with the element.
+            snippet : Optional[Snippet]
+                The snippet associated with the element.
+            description : Optional[str]
+                The description of the element.
+            view : Optional[Union[Camera, LookAt]]
+                The view associated with the element.
+            times : Optional[Union[TimeSpan, TimeStamp]]
+                The times associated with the element.
+            style_url : Optional[StyleUrl]
+                The style URL associated with the element.
+            styles : Optional[Iterable[Union[Style, StyleMap]]]
+                The styles associated with the element.
+            region : Optional[Region]
+                The region associated with the element.
+            extended_data : Optional[ExtendedData]
+                The extended data associated with the element.
+            color : Optional[str]
+                The color associated with the element.
+            draw_order : Optional[int]
+                The draw order of the element.
+            icon : Optional[Icon]
+                The icon associated with the element.
+            rotation : Optional[float]
+                The rotation of the element (specific to Photo Overlay).
+            view_volume : Optional[ViewVolume]
+                The view volume of the element (specific to Photo Overlay).
+            image_pyramid : Optional[ImagePyramid]
+                The image pyramid of the element (specific to Photo Overlay).
+            point : Optional[Point]
+                The point associated with the element (specific to Photo Overlay).
+            shape : Optional[Shape]
+                The shape associated with the element (specific to Photo Overlay).
+            kwargs : Any
+                Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -689,8 +881,8 @@ registry.register(
 
 class LatLonBox(_XMLObject):
     """
-    Specifies where the top, bottom, right, and left sides of a bounding box for the
-    ground overlay are aligned.
+    Specifies the top, bottom, right, and left sides of a bounding box for an overlay.
+
     Also, optionally the rotation of the overlay.
 
     <north> Specifies the latitude of the north edge of the bounding box,
@@ -729,6 +921,33 @@ class LatLonBox(_XMLObject):
         rotation: Optional[float] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new Overlay object.
+
+        Args:
+        ----
+            ns : Optional[str]
+                The namespace for the Overlay element.
+            name_spaces : Optional[Dict[str, str]]
+                A dictionary of namespace prefixes and URIs.
+            north : Optional[float]
+                The northern latitude of the Overlay's bounding box.
+            south : Optional[float]
+                The southern latitude of the Overlay's bounding box.
+            east : Optional[float]
+                The eastern longitude of the Overlay's bounding box.
+            west : Optional[float]
+                The western longitude of the Overlay's bounding box.
+            rotation : Optional[float]
+                The rotation angle of the Overlay.
+            **kwargs : Any
+                Additional keyword arguments.
+
+        Returns:
+        -------
+         None
+
+        """
         super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.north = north
         self.south = south
@@ -752,6 +971,14 @@ class LatLonBox(_XMLObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if all the attributes necessary for bounding box calculation are not None.
+
+        Returns
+        -------
+            bool: True if all attributes (north, south, east, west) are not None.
+
+        """
         return all(
             [
                 self.north is not None,
@@ -821,8 +1048,9 @@ registry.register(
 
 class GroundOverlay(_Overlay):
     """
-    This element draws an image overlay draped onto the terrain. The <href>
-    child of <Icon> specifies the image to be used as the overlay. This file
+    Draw an image overlay draped onto the terrain.
+
+    The <href> child of <Icon> specifies the image to be used as the overlay. This file
     can be either on a local file system or on a web server. If this element
     is omitted or contains no <href>, a rectangle is drawn using the color and
     LatLonBox bounds defined by the ground overlay.
@@ -883,6 +1111,69 @@ class GroundOverlay(_Overlay):
         lat_lon_box: Optional[LatLonBox] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new Overlay object.
+
+        Args:
+        ----
+        ns : Optional[str]
+            The namespace of the element.
+        name_spaces : Optional[Dict[str, str]]
+            The dictionary of namespace prefixes and URIs.
+        id : Optional[str]
+            The ID of the element.
+        target_id : Optional[str]
+            The target ID of the element.
+        name : Optional[str]
+            The name of the element.
+        visibility : Optional[bool]
+            The visibility of the element.
+        isopen : Optional[bool]
+            The open state of the element.
+        atom_link : Optional[atom.Link]
+            The Atom link associated with the element.
+        atom_author : Optional[atom.Author]
+            The Atom author associated with the element.
+        address : Optional[str]
+            The address of the element.
+        phone_number : Optional[str]
+            The phone number of the element.
+        snippet : Optional[Snippet]
+            The snippet associated with the element.
+        description : Optional[str]
+            The description of the element.
+        view : Optional[Union[Camera, LookAt]]
+            The view associated with the element.
+        times : Optional[Union[TimeSpan, TimeStamp]]
+            The times associated with the element.
+        style_url : Optional[StyleUrl]
+            The style URL of the element.
+        styles : Optional[Iterable[Union[Style, StyleMap]]]
+            The styles associated with the element.
+        region : Optional[Region]
+            The region associated with the element.
+        extended_data : Optional[ExtendedData]
+            The extended data associated with the element.
+        color : Optional[str]
+            The color of the element.
+        draw_order : Optional[int]
+            The draw order of the element.
+        icon : Optional[Icon]
+            The icon associated with the element.
+        altitude : Optional[float]
+            The altitude of the element.
+        altitude_mode : Optional[AltitudeMode]
+            The altitude mode of the element.
+        lat_lon_box : Optional[LatLonBox]
+            The latitude-longitude box associated with the element.
+        kwargs : Any
+            Additional keyword arguments.
+
+        Returns:
+        -------
+        None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,

--- a/fastkml/registry.py
+++ b/fastkml/registry.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+"""Registry for XML objects."""
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING

--- a/fastkml/styles.py
+++ b/fastkml/styles.py
@@ -15,6 +15,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 
 """
+KML Styles.
+
 Once you've created features within Google Earth and examined the KML
 code Google Earth generates, you'll notice how styles are an important
 part of how your data is displayed.
@@ -82,6 +84,29 @@ class StyleUrl(_BaseObject):
         url: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Style object.
+
+        Args:
+        ----
+        ns : str, optional
+            The namespace of the Style object.
+        name_spaces : dict, optional
+            A dictionary of namespace prefixes and their corresponding URIs.
+        id : str, optional
+            The ID of the Style object.
+        target_id : str, optional
+            The ID of the target object that this Style object applies to.
+        url : str, optional
+            The URL of the Style object.
+        **kwargs : Any
+            Additional keyword arguments.
+
+        Returns:
+        -------
+        None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -105,6 +130,15 @@ class StyleUrl(_BaseObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the style has a URL.
+
+        Returns
+        -------
+        bool
+            True if the style has a URL, False otherwise.
+
+        """
         return bool(self.url)
 
     @classmethod
@@ -128,7 +162,8 @@ registry.register(
 
 class _StyleSelector(_BaseObject):
     """
-    This is an abstract element and cannot be used directly in a KML file.
+    Abstract element that cannot be used directly in a KML file.
+
     It is the base type for the <Style> and <StyleMap> elements. The
     StyleMap element selects a style based on the current mode of the
     Placemark. An element derived from StyleSelector is uniquely identified
@@ -140,8 +175,8 @@ class _StyleSelector(_BaseObject):
 
 class _ColorStyle(_BaseObject):
     """
-    abstract element; do not create.
-    This is an abstract element and cannot be used directly in a KML file.
+    Abstract element that cannot be used directly in a KML file.
+
     It provides elements for specifying the color and color mode of
     extended style types.
     subclasses are: IconStyle, LabelStyle, LineStyle, PolyStyle.
@@ -170,6 +205,24 @@ class _ColorStyle(_BaseObject):
         color_mode: Optional[ColorMode] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Style object.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace of the style.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespaces.
+            id (Optional[str]): The ID of the style.
+            target_id (Optional[str]): The target ID of the style.
+            color (Optional[str]): The color of the style.
+            color_mode (Optional[ColorMode]): The color mode of the style.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -253,6 +306,25 @@ class HotSpot(_XMLObject):
         yunits: Optional[Units] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Style element.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the element.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespace prefixes
+                and URIs.
+            x (Optional[float]): The x-coordinate of the point.
+            y (Optional[float]): The y-coordinate of the point.
+            xunits (Optional[Units]): The units for the x-coordinate.
+            yunits (Optional[Units]): The units for the y-coordinate.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.x = x
         self.y = y
@@ -274,6 +346,14 @@ class HotSpot(_XMLObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if both x and y attributes are not None.
+
+        Returns
+        -------
+            bool: True if both x and y are not None, False otherwise.
+
+        """
         return all((self.x is not None, self.y is not None))
 
     @classmethod
@@ -363,6 +443,29 @@ class IconStyle(_ColorStyle):
         hot_spot: Optional[HotSpot] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Style object.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the Style object.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespace prefixes
+                and URIs.
+            id (Optional[str]): The ID of the Style object.
+            target_id (Optional[str]): The target ID of the Style object.
+            color (Optional[str]): The color of the Style object.
+            color_mode (Optional[ColorMode]): The color mode of the Style object.
+            scale (Optional[float]): The scale of the Style object.
+            heading (Optional[float]): The heading of the Style object.
+            icon (Optional[Icon]): The icon of the Style object.
+            hot_spot (Optional[HotSpot]): The hot spot of the Style object.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -397,6 +500,15 @@ class IconStyle(_ColorStyle):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the Style has an icon.
+
+        Returns
+        -------
+        bool
+            True if the Style has an icon, False otherwise.
+
+        """
         return bool(self.icon)
 
 
@@ -469,6 +581,26 @@ class LineStyle(_ColorStyle):
         width: Optional[float] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Style object.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the Style object.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespace prefixes
+                and URIs.
+            id (Optional[str]): The ID of the Style object.
+            target_id (Optional[str]): The target ID of the Style object.
+            color (Optional[str]): The color of the Style object.
+            color_mode (Optional[ColorMode]): The color mode of the Style object.
+            width (Optional[float]): The width of the Style object.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -496,6 +628,14 @@ class LineStyle(_ColorStyle):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the style has a width defined.
+
+        Returns
+        -------
+            bool: True if the width is not None, False otherwise.
+
+        """
         return self.width is not None
 
 
@@ -541,6 +681,27 @@ class PolyStyle(_ColorStyle):
         outline: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Style object.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the style.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespace prefixes
+                and URIs.
+            id (Optional[str]): The ID of the style.
+            target_id (Optional[str]): The ID of the target element.
+            color (Optional[str]): The color of the style.
+            color_mode (Optional[ColorMode]): The color mode of the style.
+            fill (Optional[bool]): Whether to fill the style.
+            outline (Optional[bool]): Whether to outline the style.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -570,6 +731,14 @@ class PolyStyle(_ColorStyle):
         )
 
     def __bool__(self) -> bool:
+        """
+        Return True if the style has a fill or outline, False otherwise.
+
+        Returns
+        -------
+            bool: True if the style has a fill or outline, False otherwise.
+
+        """
         return self.fill is not None or self.outline is not None
 
 
@@ -620,6 +789,26 @@ class LabelStyle(_ColorStyle):
         scale: Optional[float] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Style object.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the style.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespace prefixes
+                and URIs.
+            id (Optional[str]): The ID of the style.
+            target_id (Optional[str]): The ID of the target element.
+            color (Optional[str]): The color of the style.
+            color_mode (Optional[ColorMode]): The color mode of the style.
+            scale (Optional[float]): The scale of the style.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -647,6 +836,15 @@ class LabelStyle(_ColorStyle):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the Style has any non-None attributes.
+
+        Returns
+        -------
+            bool: True if any of the following attributes are not None:
+                scale, color, color_mode.
+
+        """
         return any(
             (
                 self.scale is not None,
@@ -734,6 +932,27 @@ class BalloonStyle(_BaseObject):
         display_mode: Optional[DisplayMode] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Style object.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the style.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespace prefixes
+            and URIs.
+            id (Optional[str]): The ID of the style.
+            target_id (Optional[str]): The ID of the target element.
+            bg_color (Optional[str]): The background color of the style.
+            text_color (Optional[str]): The text color of the style.
+            text (Optional[str]): The text content of the style.
+            display_mode (Optional[DisplayMode]): The display mode of the style.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -763,6 +982,19 @@ class BalloonStyle(_BaseObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the Style has any non-None attributes.
+
+        Returns
+        -------
+            bool: True if any of the following attributes are not None:
+                - bg_color
+                - text_color
+                - text
+                - display_mode
+            False otherwise.
+
+        """
         return any(
             (
                 self.bg_color is not None,
@@ -844,6 +1076,24 @@ class Style(_StyleSelector):
         styles: Optional[Iterable[AnyStyle]] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a Style element.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the element.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespace prefixes
+                and URIs.
+            id (Optional[str]): The ID of the element.
+            target_id (Optional[str]): The target ID of the element.
+            styles (Optional[Iterable[AnyStyle]]): The list of styles.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -867,6 +1117,15 @@ class Style(_StyleSelector):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the Styles object contains any styles.
+
+        Returns
+        -------
+        bool
+            True if the Styles object contains any styles, False otherwise.
+
+        """
         return any(self.styles)
 
 
@@ -919,6 +1178,31 @@ class Pair(_BaseObject):
         style: Optional[Union[StyleUrl, Style]] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a StyleSelector object.
+
+        Args:
+        ----
+            ns : Optional[str]
+                The namespace of the element.
+            name_spaces : Optional[Dict[str, str]]
+                The dictionary of namespace prefixes and URIs.
+            id : Optional[str]
+                The ID of the element.
+            target_id : Optional[str]
+                The target ID of the element.
+            key : Optional[PairKey]
+                The key of the element.
+            style : Optional[Union[StyleUrl, Style]]
+                The style or style URL of the element.
+            kwargs : Any
+                Additional keyword arguments.
+
+        Returns:
+        -------
+         None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -944,6 +1228,14 @@ class Pair(_BaseObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the StyleMap has both a key and a style.
+
+        Returns
+        -------
+            bool: True if the StyleMap has both a key and a style, False otherwise.
+
+        """
         return all((self.key is not None, self.style is not None))
 
 
@@ -977,6 +1269,7 @@ registry.register(
 class StyleMap(_StyleSelector):
     """
     A <StyleMap> maps between two different Styles.
+
     Typically a <StyleMap> element is used to provide separate normal and highlighted
     styles for a placemark, so that the highlighted version appears when
     the user mouses over the icon in Google Earth.
@@ -995,6 +1288,24 @@ class StyleMap(_StyleSelector):
         pairs: Optional[Iterable[Pair]] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new Style object.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace of the style.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespace prefixes
+                and URIs.
+            id (Optional[str]): The ID of the style.
+            target_id (Optional[str]): The ID of the target element.
+            pairs (Optional[Iterable[Pair]]): The list of pairs.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -1018,10 +1329,27 @@ class StyleMap(_StyleSelector):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the Style has any pairs.
+
+        Returns
+        -------
+        bool
+            True if the Style has any pairs, False otherwise.
+
+        """
         return bool(self.pairs)
 
     @property
     def normal(self) -> Optional[Union[StyleUrl, Style]]:
+        """
+        Get the normal style for the feature.
+
+        Returns
+        -------
+            The normal style for the feature, if available. Otherwise, returns None.
+
+        """
         return next(
             (pair.style for pair in self.pairs if pair.key == PairKey.normal),
             None,
@@ -1029,6 +1357,15 @@ class StyleMap(_StyleSelector):
 
     @property
     def highlight(self) -> Optional[Union[StyleUrl, Style]]:
+        """
+        Return the highlight style associated with this StyleMap.
+
+        Returns
+        -------
+            The highlight style, which can be either a StyleUrl or a Style object.
+            If no highlight style is found, None is returned.
+
+        """
         return next(
             (pair.style for pair in self.pairs if pair.key == PairKey.highlight),
             None,

--- a/fastkml/times.py
+++ b/fastkml/times.py
@@ -138,7 +138,7 @@ class KmlDateTime:
                 resolution = DateTimeResolution.year_month
             if year_month_day_match.group("month") is None:
                 resolution = DateTimeResolution.year
-        elif len(datestr) > 10:
+        elif len(datestr) > 10:  # noqa: PLR2004
             dt = arrow.get(datestr).datetime
             resolution = DateTimeResolution.datetime
         return cls(dt, resolution) if dt else None
@@ -146,7 +146,7 @@ class KmlDateTime:
 
 class _TimePrimitive(_BaseObject):
     """
-    This is an abstract element and cannot be used directly in a KML file.
+    Abstract element that cannot be used directly in a KML file.
 
     This element is extended by the <TimeSpan> and <TimeStamp> elements.
     https://developers.google.com/kml/documentation/kmlreference#timeprimitive
@@ -165,6 +165,29 @@ class TimeStamp(_TimePrimitive):
         timestamp: Optional[KmlDateTime] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new instance of the Times class.
+
+        Args:
+        ----
+            ns : str, optional
+                The namespace for the element, by default None.
+            name_spaces : dict[str, str], optional
+                The dictionary of namespace prefixes and URIs, by default None.
+            id : str, optional
+                The ID of the element, by default None.
+            target_id : str, optional
+                The target ID of the element, by default None.
+            timestamp : KmlDateTime, optional
+                The timestamp of the element, by default None.
+            **kwargs : Any
+                Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -196,6 +219,19 @@ class TimeStamp(_TimePrimitive):
         precision: Optional[int] = None,
         verbosity: Verbosity = Verbosity.normal,
     ) -> Element:
+        """
+        Create an ElementTree element representing the TimeStamp object.
+
+        Args:
+        ----
+            precision (Optional[int]): The precision of the timestamp.
+            verbosity (Verbosity): The verbosity level of the element.
+
+        Returns:
+        -------
+            Element: The ElementTree element representing the TimeStamp object.
+
+        """
         element = super().etree_element(precision=precision, verbosity=verbosity)
         when = config.etree.SubElement(
             element,
@@ -238,6 +274,25 @@ class TimeSpan(_TimePrimitive):
         end: Optional[KmlDateTime] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new instance of the Times class.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the element.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespace prefixes
+                and URIs.
+            id (Optional[str]): The ID of the element.
+            target_id (Optional[str]): The target ID of the element.
+            begin (Optional[KmlDateTime]): The begin time.
+            end (Optional[KmlDateTime]): The end time.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -271,15 +326,28 @@ class TimeSpan(_TimePrimitive):
         precision: Optional[int] = None,
         verbosity: Verbosity = Verbosity.normal,
     ) -> Element:
+        """
+        Create an Element object representing the time interval.
+
+        Args:
+        ----
+            precision (Optional[int]): The precision of the time values.
+            verbosity (Verbosity): The verbosity level for the element.
+
+        Returns:
+        -------
+            Element: The created Element object.
+
+        """
         element = super().etree_element(precision=precision, verbosity=verbosity)
-        if self.begin is not None:
+        if self.begin is not None:  # noqa: SIM102
             if text := str(self.begin):
                 begin = config.etree.SubElement(
                     element,
                     f"{self.ns}begin",
                 )
                 begin.text = text
-        if self.end is not None:
+        if self.end is not None:  # noqa: SIM102
             if text := str(self.end):
                 end = config.etree.SubElement(
                     element,

--- a/fastkml/views.py
+++ b/fastkml/views.py
@@ -41,18 +41,19 @@ logger = logging.getLogger(__name__)
 
 class _AbstractView(TimeMixin, _BaseObject):
     """
-    This is an abstract element and cannot be used directly in a KML file.
+    Abstract element that cannot be used directly in a KML file.
+
     This element is extended by the <Camera> and <LookAt> elements.
     """
 
     longitude: Optional[float]
     # Longitude of the virtual camera (eye point). Angular distance in degrees,
     # relative to the Prime Meridian. Values west of the Meridian range from
-    # −180 to 0 degrees. Values east of the Meridian range from 0 to 180 degrees.
+    # -180 to 0 degrees. Values east of the Meridian range from 0 to 180 degrees.
 
     latitude: Optional[float]
     # Latitude of the virtual camera. Degrees north or south of the Equator
-    # (0 degrees). Values range from −90 degrees to 90 degrees.
+    # (0 degrees). Values range from -90 degrees to 90 degrees.
 
     altitude: Optional[float]
     # Distance of the camera from the earth's surface, in meters. Interpreted
@@ -100,6 +101,41 @@ class _AbstractView(TimeMixin, _BaseObject):
         time_primitive: Union[TimeSpan, TimeStamp, None] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new View object.
+
+        Parameters
+        ----------
+        ns : Optional[str]
+            The namespace for the view.
+        name_spaces : Optional[Dict[str, str]]
+            The dictionary of namespace prefixes and URIs.
+        id : Optional[str]
+            The ID of the view.
+        target_id : Optional[str]
+            The ID of the target view.
+        longitude : Optional[float]
+            The longitude coordinate of the view.
+        latitude : Optional[float]
+            The latitude coordinate of the view.
+        altitude : Optional[float]
+            The altitude coordinate of the view.
+        heading : Optional[float]
+            The heading angle of the view.
+        tilt : Optional[float]
+            The tilt angle of the view.
+        altitude_mode : Optional[AltitudeMode]
+            The altitude mode of the view.
+        time_primitive : Union[TimeSpan, TimeStamp, None]
+            The time primitive associated with the view.
+        kwargs : Any
+            Additional keyword arguments.
+
+        Returns
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -216,9 +252,10 @@ registry.register(
 
 class Camera(_AbstractView):
     """
-    Defines the virtual camera that views the scene. This element defines
-    the position of the camera relative to the Earth's surface as well
-    as the viewing direction of the camera. The camera position is defined
+    Defines the virtual camera that views the scene.
+
+    This element defines the position of the camera relative to the Earth's surface
+    as well as the viewing direction of the camera. The camera position is defined
     by <longitude>, <latitude>, <altitude>, and either <altitudeMode> or
     <gx:altitudeMode>. The viewing direction of the camera is defined by
     <heading>, <tilt>, and <roll>. <Camera> can be a child element of any
@@ -238,7 +275,7 @@ class Camera(_AbstractView):
 
     roll: Optional[float]
     # Rotation, in degrees, of the camera around the Z axis. Values range from
-    # −180 to +180 degrees.
+    # -180 to +180 degrees.
 
     def __init__(
         self,
@@ -256,6 +293,31 @@ class Camera(_AbstractView):
         time_primitive: Union[TimeSpan, TimeStamp, None] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new View object.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the view.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespaces.
+            id (Optional[str]): The ID of the view.
+            target_id (Optional[str]): The target ID of the view.
+            longitude (Optional[float]): The longitude of the view.
+            latitude (Optional[float]): The latitude of the view.
+            altitude (Optional[float]): The altitude of the view.
+            heading (Optional[float]): The heading of the view.
+            tilt (Optional[float]): The tilt of the view.
+            roll (Optional[float]): The roll of the view.
+            altitude_mode (AltitudeMode): The altitude mode of the view.
+            time_primitive (Union[TimeSpan, TimeStamp, None]): The time primitive of the
+                view.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -307,6 +369,16 @@ registry.register(
 
 
 class LookAt(_AbstractView):
+    """
+    Defines a virtual camera that is associated with any element derived from Feature.
+
+    The LookAt element positions the "camera" in relation to the object that is being
+    viewed. In Google Earth, the view "flies to" this LookAt viewpoint when the user
+    double-clicks an item in the Places panel or double-clicks an icon in the 3D viewer.
+
+    https://developers.google.com/kml/documentation/kmlreference#lookat
+    """
+
     range: Optional[float]
     # Distance in meters from the point specified by <longitude>, <latitude>,
     # and <altitude> to the LookAt position.
@@ -327,6 +399,31 @@ class LookAt(_AbstractView):
         time_primitive: Union[TimeSpan, TimeStamp, None] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new instance of the class.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the element.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespaces.
+            id (Optional[str]): The ID of the element.
+            target_id (Optional[str]): The target ID of the element.
+            longitude (Optional[float]): The longitude value.
+            latitude (Optional[float]): The latitude value.
+            altitude (Optional[float]): The altitude value.
+            heading (Optional[float]): The heading value.
+            tilt (Optional[float]): The tilt value.
+            range (Optional[float]): The range value.
+            altitude_mode (AltitudeMode): The altitude mode. Defaults to
+                AltitudeMode.relative_to_ground.
+            time_primitive (Union[TimeSpan, TimeStamp, None]): The time primitive.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -407,6 +504,28 @@ class LatLonAltBox(_XMLObject):
         altitude_mode: Optional[AltitudeMode] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new View object.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the view.
+            name_spaces (Optional[Dict[str, str]]): A dictionary of namespace prefixes
+                and URIs.
+            north (Optional[float]): The northern latitude of the view.
+            south (Optional[float]): The southern latitude of the view.
+            east (Optional[float]): The eastern longitude of the view.
+            west (Optional[float]): The western longitude of the view.
+            min_altitude (Optional[float]): The minimum altitude of the view.
+            max_altitude (Optional[float]): The maximum altitude of the view.
+            altitude_mode (Optional[AltitudeMode]): The altitude mode of the view.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.north = north
         self.south = south
@@ -434,6 +553,14 @@ class LatLonAltBox(_XMLObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if all the attributes (north, south, east, west) are not None.
+
+        Returns
+        -------
+            bool: True if all attributes are not None, False otherwise.
+
+        """
         return all(
             (
                 self.north is not None,
@@ -526,6 +653,7 @@ registry.register(
 class Lod(_XMLObject):
     """
     Lod is an abbreviation for Level of Detail.
+
     <Lod> describes the size of the projected region on the screen that is required in
     order for the region to be considered "active."
     Also specifies the size of the pixel ramp used for fading in
@@ -551,6 +679,25 @@ class Lod(_XMLObject):
         max_fade_extent: Optional[float] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new instance of the View class.
+
+        Args:
+        ----
+            ns (Optional[str]): The namespace for the view.
+            name_spaces (Optional[Dict[str, str]]): The dictionary of namespace prefixes
+                and URIs.
+            min_lod_pixels (Optional[float]): The minimum level of detail in pixels.
+            max_lod_pixels (Optional[float]): The maximum level of detail in pixels.
+            min_fade_extent (Optional[float]): The minimum fade extent in pixels.
+            max_fade_extent (Optional[float]): The maximum fade extent in pixels.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+        -------
+            None
+
+        """
         super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.min_lod_pixels = min_lod_pixels
         self.max_lod_pixels = max_lod_pixels
@@ -572,6 +719,14 @@ class Lod(_XMLObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the object is considered True or False.
+
+        Returns
+        -------
+            bool: True if the `min_lod_pixels` attribute is not None, False otherwise.
+
+        """
         return self.min_lod_pixels is not None
 
 
@@ -623,8 +778,7 @@ registry.register(
 
 class Region(_BaseObject):
     """
-    A <Region> contains a bounding box (<LatLonAltBox>) that describes an area of
-    interest defined by geographic coordinates and altitudes.
+    A region contains a bounding box that describes an area of interest.
 
     In addition, a Region contains an LOD (level of detail) extent (<Lod>),
     which is a pair of projected coordinate bounding boxes that describe
@@ -647,6 +801,31 @@ class Region(_BaseObject):
         lod: Optional[Lod] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Initialize a new instance of the View class.
+
+        Args:
+        ----
+        ns : Optional[str]
+            The namespace of the view.
+        name_spaces : Optional[Dict[str, str]]
+            The dictionary of namespace prefixes and URIs.
+        id : Optional[str]
+            The ID of the view.
+        target_id : Optional[str]
+            The target ID of the view.
+        lat_lon_alt_box : Optional[LatLonAltBox]
+            The latitude, longitude, and altitude box of the view.
+        lod : Optional[Lod]
+            The level of detail of the view.
+        **kwargs : Any
+            Additional keyword arguments.
+
+        Returns:
+        -------
+        None
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
@@ -672,6 +851,14 @@ class Region(_BaseObject):
         )
 
     def __bool__(self) -> bool:
+        """
+        Check if the object is considered True or False.
+
+        Returns
+        -------
+            bool: True if the `lat_lon_alt_box` attribute is not empty, False otherwise.
+
+        """
         return bool(self.lat_lon_alt_box)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,10 @@ select = [
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]
+"fastkml/helpers.py" = [
+    "ARG001",
+    "PLR0913",
+]
 "tests/*.py" = [
     "D101",
     "D102",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,12 +176,14 @@ target-version = "py38"
 
 [tool.ruff.lint]
 ignore = [
+    "A002",
     "ANN101",
     "ANN102",
     "ANN401",
     "D203",
     "D212",
     "FA100",
+    "PLR0913",
 ]
 select = [
     "A",


### PR DESCRIPTION
### **User description**
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19CSBsxRIPRHJdBHFTPy4DCuJsKlhs4YE%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=9RGPoTH)


___

### **PR Type**
Documentation, Formatting, Configuration changes


___

### **Description**
- Added detailed docstrings for multiple modules, classes, and methods.
- Improved error messages and logging across various modules.
- Added type hints to enhance code clarity and type safety.
- Updated ruff linting configuration to ignore additional rules and added per-file ignores.
- Removed unnecessary `noqa` comment in `kml_base.py`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.py</strong><dd><code>Add docstrings and improve error handling in helpers.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/helpers.py

<li>Added detailed docstrings for multiple functions.<br> <li> Removed unnecessary <code>else</code> clause in <code>handle_error</code> function.<br> <li> Added type hints and improved error messages.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-b5b3941187e8c15a6401d21669f3dd0d541c710ecbb6238620a56e24305fc02c">+331/-26</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>geometry.py</strong><dd><code>Add docstrings and type hints in geometry module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/geometry.py

<li>Added module-level docstring.<br> <li> Added detailed docstrings for multiple classes and methods.<br> <li> Added type hints and improved error messages.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-47314ad0817fc0fdde5a4ccab1250d104c27d592f1dd0f9952b454a4e3cdf65d">+299/-38</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>styles.py</strong><dd><code>Add docstrings for styles module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/styles.py

<li>Added detailed docstrings for multiple classes and methods.<br> <li> Added module-level docstring.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-15dc029e50660bd7626ff50b07d669f6c6e61e0017e795aa718d8c52c27716db">+340/-3</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>features.py</strong><dd><code>Add docstrings and type hints in features module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/features.py

<li>Added detailed docstrings for multiple classes and methods.<br> <li> Added type hints and improved error messages.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-00a3c2aa0b823504cfb27c3ddc29f807d2542e48259b8f219a673393e6fa2c5c">+238/-84</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gx.py</strong><dd><code>Add docstrings for gx module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/gx.py

<li>Added detailed docstrings for multiple classes and methods.<br> <li> Added module-level docstring.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-e8a849efde73ecb6716b27ad17fa34756392e8fb8731d213e8f0070c2986bf02">+290/-5</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>overlays.py</strong><dd><code>Add docstrings for overlays module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/overlays.py

<li>Added detailed docstrings for multiple classes and methods.<br> <li> Added module-level docstring.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-53d4a4402d4b36ba24c38b2494214f2940433d433946065052596dbd37cc3565">+295/-4</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>data.py</strong><dd><code>Add docstrings for data module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/data.py

<li>Added detailed docstrings for multiple classes and methods.<br> <li> Updated module-level docstring.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-75b88feeb935943fd77fa8d3cf174304b93e3830a00abfc48fcc99c69234c072">+227/-20</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>views.py</strong><dd><code>Add docstrings and type hints in views module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/views.py

<li>Added detailed docstrings for multiple classes and methods.<br> <li> Added type hints and improved error messages.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-09542eb04d7a925a14ddd6729b4389987f7e2be8ffa6b0a8c460e38396bd2b45">+196/-9</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>times.py</strong><dd><code>Add docstrings and type hints in times module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/times.py

<li>Added detailed docstrings for multiple classes and methods.<br> <li> Added type hints and improved error messages.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-d08f0cfb2c0a85d0242f75c5991bd60a29a6b73cf9eaedfe64733b951a5cf162">+72/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>enums.py</strong><dd><code>Add docstrings and improve logging in enums module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/enums.py

<li>Added detailed docstrings for multiple enums.<br> <li> Improved logging messages.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-55933b0926fedde181c345cf41be4b57531d04696e282b2baf66f1833c98343f">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mixins.py</strong><dd><code>Add docstrings for mixins module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/mixins.py

- Added detailed docstrings for mixin methods.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-175f235d9652699fb3164807bd6ef312709913eabd439c08f9c9413715cd7bd8">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>links.py</strong><dd><code>Add docstrings for links module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/links.py

<li>Added module-level docstring.<br> <li> Added detailed docstrings for multiple methods.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-0b382a33ea64ee81cc0b4f4cea9ec48a225b0490c252ab0829d8da61d2907dd9">+10/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>atom.py</strong><dd><code>Add and improve docstrings for better documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/atom.py

<li>Added docstrings to classes and methods for better documentation.<br> <li> Reformatted comments into docstrings.<br> <li> Improved the clarity and structure of existing docstrings.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-1ea034818966c2628f91b2abf978ec5a35a5583028122ec430e57f1fc9a41464">+120/-33</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>containers.py</strong><dd><code>Enhance documentation with detailed docstrings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/containers.py

<li>Added docstrings to classes and methods for better documentation.<br> <li> Improved the clarity and structure of existing docstrings.<br> <li> Reformatted comments into docstrings.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-738931297f80e440cd189073efb0323af2ac936d1eed3f2dd130b44fa79fa003">+58/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>registry.py</strong><dd><code>Add module-level docstring for registry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/registry.py

- Added a module-level docstring.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-365d6e4b146c94c639db1b5f3f54d342a6b3458ab4a208695400b366cebd273c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>kml_base.py</strong><dd><code>Remove unnecessary noqa comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/kml_base.py

- Removed noqa comment for 'id' parameter.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-7aa4dc2ccdca17b865f5e3dde74a8bb5d4c6a93bf996744f0e91e1109e255d6f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update ruff linting configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<li>Updated ruff linting configuration to ignore additional rules.<br> <li> Added per-file ignores for specific files.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/336/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions


<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 765d36e28fbda3783e9a3b016fd7167af259c1af  | 
|--------|--------|

### Summary:
Added docstrings and fixed Ruff linter issues across multiple files for improved documentation and code quality.

**Key points**:
- Added docstrings to various classes and functions across multiple files for better documentation.
- Fixed issues identified by the Ruff linter to ensure code quality.
- Updated `fastkml/atom.py` with detailed docstrings for `Link` and `_Person` classes.
- Enhanced `fastkml/containers.py` with docstrings for `_Container`, `Folder`, and `Document` classes.
- Improved `fastkml/data.py` by adding docstrings to `Data`, `Schema`, `SchemaData`, and `ExtendedData` classes.
- Updated `fastkml/enums.py` with docstrings for `DataType` and `PairKey` enums.
- Added docstrings to `fastkml/features.py` for `Snippet`, `_Feature`, `Placemark`, and `NetworkLink` classes.
- Enhanced `fastkml/geometry.py` with docstrings for various geometry classes and functions.
- Improved `fastkml/gx.py` by adding docstrings to `Track`, `MultiTrack`, and related functions.
- Updated `fastkml/helpers.py` with detailed docstrings for helper functions.
- Added docstrings to `fastkml/kml_base.py` for `_BaseObject` class.
- Enhanced `fastkml/links.py` with docstrings for `Link` and `Icon` classes.
- Improved `fastkml/mixins.py` by adding docstrings to `TimeMixin` class.
- Updated `fastkml/overlays.py` with docstrings for `_Overlay`, `ViewVolume`, `ImagePyramid`, `PhotoOverlay`, `LatLonBox`, and `GroundOverlay` classes.
- Added docstrings to `fastkml/registry.py` for `Registry` and `RegistryItem` classes.
- Enhanced `fastkml/styles.py` with docstrings for various style classes.
- Improved `fastkml/times.py` by adding docstrings to `KmlDateTime`, `TimeStamp`, and `TimeSpan` classes.
- Updated `fastkml/views.py` with docstrings for `_AbstractView`, `Camera`, `LookAt`, `LatLonAltBox`, `Lod`, and `Region` classes.
- Modified `pyproject.toml` to include additional Ruff linter rules and ignore specific warnings.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the codebase by adding detailed docstrings to functions and classes, improving type annotations, and fixing minor bugs related to variable shadowing. It also includes updates to copyright information and standardizes docstring formatting.

- **Bug Fixes**:
    - Fixed potential issues with variable shadowing and naming conflicts by using keyword-only arguments in functions like `_get_boolean_value` and `_get_enum_value`.
- **Enhancements**:
    - Added comprehensive docstrings to multiple functions and classes across various modules to improve code documentation and readability.
    - Updated copyright year in `fastkml/helpers.py` to include 2024.
    - Removed unnecessary `else` clause in `handle_error` function in `fastkml/helpers.py`.
    - Added type hints and improved type annotations for better code clarity and type checking.
    - Reformatted and standardized docstring styles to maintain consistency across the codebase.
- **Chores**:
    - Added `# noqa` comments to suppress specific linting warnings where necessary, ensuring cleaner linting results.

<!-- Generated by sourcery-ai[bot]: end summary -->