### PR TITLE
396 kml model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,8 @@ Introduction
 
 .. inclusion-marker-do-not-remove
 
-KML is an XML geospatial data format and an OGC_ standard that deserves a canonical python implementation.
+KML is an XML geospatial data format and an OGC_ standard that deserves a canonical
+python implementation.
 
 Fastkml is a library to read, write and manipulate KML files. It aims to keep
 it simple and fast (using lxml_ if available). Fast refers to the time you
@@ -19,9 +20,12 @@ For more details about the KML Specification, check out the `KML Reference
 <https://developers.google.com/kml/documentation/kmlreference>`_ on the Google
 developers site.
 
-Geometries are handled as pygeoif_ objects.
+Geometries are handled as pygeoif_ objects, which are compatible with any geometry that
+implements the ``__geo_interface__`` protocol, such as shapely_.
 
-Fastkml is continually tested
+Fastkml is tested on `CPython <https://python.org>`_ and
+`PyPy <https://www.pypy.org/>`_, but it should work on alternative
+Python implementations (that implement the language specification *>=3.8*) as well.
 
 |test| |hypothesis| |cov| |black| |mypy| |commit|
 
@@ -49,7 +53,7 @@ Fastkml is continually tested
    :target: https://github.com/pre-commit/pre-commit
    :alt: pre-commit
 
-Is Maintained and documented:
+Is maintained and documented:
 
 |pypi| |conda-forge| |status| |license| |doc| |stats| |pyversion| |pyimpl| |dependencies| |downloads|
 
@@ -134,3 +138,4 @@ Please submit a PR with the features you'd like to see implemented.
 .. _lxml: https://pypi.python.org/pypi/lxml
 .. _arrow: https://pypi.python.org/pypi/arrow
 .. _OGC: https://www.ogc.org/standard/kml/
+.. _shapely: https://shapely.readthedocs.io/

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,6 +1,7 @@
 [default.extend-words]
 lod = "lod"
 Lod = "Lod"
+id ="04AFE6060F147CE66FBD"
 
 [files]
 extend-exclude = ["tests/ogc_conformance/data/kml/*.kml"]

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,7 +1,15 @@
+[default]
+extend-ignore-identifiers-re = [
+    "04AFE6060F147CE66FBD",
+    "Lod",
+    "lod",
+]
+
+
+
 [default.extend-words]
 lod = "lod"
 Lod = "Lod"
-id ="04AFE6060F147CE66FBD"
 
 [files]
 extend-exclude = ["tests/ogc_conformance/data/kml/*.kml"]

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-1.0.0dev0 (unreleased)
+1.1.0 (unreleased)
 ----------------------
 
-- Add support for ScreenOverlay
+- Add support for ScreenOverlay and Model.
+- allow parsing kml files without namespace declarations.
 
 
 1.0 (2024/11/19)

--- a/docs/fastkml.rst
+++ b/docs/fastkml.rst
@@ -157,6 +157,15 @@ fastkml.mixins
    :undoc-members:
    :show-inheritance:
 
+fastkml.model
+--------------------
+
+.. automodule:: fastkml.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 fastkml.overlays
 -----------------------
 

--- a/docs/working_with_kml.rst
+++ b/docs/working_with_kml.rst
@@ -156,8 +156,10 @@ And register the new element with the KML Document object:
 
 The CascadingStyle object is now part of the KML document and can be accessed like any
 other element.
-When parsing the document we have to skip the validation as the ``gx:CascadingStyle`` is
-not in the XSD Schema.
+
+.. note::
+    When parsing the document we have to skip the validation by passing ``validate=False``
+    to ``KML.parse`` as the ``gx:CascadingStyle`` is not in the XSD Schema.
 
 Create a new KML object and confirm that the new element is parsed correctly:
 

--- a/docs/working_with_kml.rst
+++ b/docs/working_with_kml.rst
@@ -236,7 +236,7 @@ Now we can remove the CascadingStyle from the document and have a look at the re
           <kml:displayMode>hide</kml:displayMode>
         </kml:BalloonStyle>
       </kml:Style>
-      <kml:Placemark id="04SAFE6060F147CE66FBD">
+      <kml:Placemark id="04AFE6060F147CE66FBD">
         <kml:name>Ort1</kml:name>
         <kml:LookAt>
           <kml:longitude>10.06256752902339</kml:longitude>

--- a/docs/working_with_kml.rst
+++ b/docs/working_with_kml.rst
@@ -123,7 +123,7 @@ We need to register the attributes of the KML object to be able to parse it:
     >>> registry.register(
     ...     CascadingStyle,
     ...     RegistryItem(
-    ...         ns_ids=("kml",),
+    ...         ns_ids=("kml", ""),
     ...         attr_name="style",
     ...         node_name="Style",
     ...         classes=(Style,),

--- a/fastkml/containers.py
+++ b/fastkml/containers.py
@@ -329,7 +329,7 @@ class Document(_Container):
 registry.register(
     _Container,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="features",
         node_name=(
             "Folder,Placemark,Document,GroundOverlay,PhotoOverlay,ScreenOverlay,"
@@ -351,7 +351,7 @@ registry.register(
 registry.register(
     Document,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="schemata",
         node_name="Schema",
         classes=(Schema,),

--- a/fastkml/data.py
+++ b/fastkml/data.py
@@ -311,7 +311,7 @@ registry.register(
 registry.register(
     Schema,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="fields",
         node_name="SimpleField",
         classes=(SimpleField,),
@@ -644,7 +644,7 @@ registry.register(
 registry.register(
     SchemaData,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="data",
         node_name="SimpleData",
         classes=(SimpleData,),
@@ -725,7 +725,7 @@ class ExtendedData(_XMLObject):
 registry.register(
     ExtendedData,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="elements",
         node_name="Data,SchemaData",
         classes=(

--- a/fastkml/features.py
+++ b/fastkml/features.py
@@ -664,7 +664,7 @@ class Placemark(_Feature):
 registry.register(
     Placemark,
     RegistryItem(
-        ns_ids=("kml", "gx"),
+        ns_ids=("kml", "gx", ""),
         attr_name="kml_geometry",
         node_name=(
             "Point,LineString,LinearRing,Polygon,MultiGeometry,Model,"

--- a/fastkml/features.py
+++ b/fastkml/features.py
@@ -58,6 +58,7 @@ from fastkml.helpers import xml_subelement_list_kwarg
 from fastkml.kml_base import _BaseObject
 from fastkml.links import Link
 from fastkml.mixins import TimeMixin
+from fastkml.model import Model
 from fastkml.registry import RegistryItem
 from fastkml.registry import registry
 from fastkml.styles import Style
@@ -78,6 +79,7 @@ KmlGeometry = Union[
     LineString,
     LinearRing,
     Polygon,
+    Model,
     MultiGeometry,
     gx.MultiTrack,
     gx.Track,
@@ -665,7 +667,7 @@ registry.register(
         ns_ids=("kml", "gx"),
         attr_name="kml_geometry",
         node_name=(
-            "Point,LineString,LinearRing,Polygon,MultiGeometry,"
+            "Point,LineString,LinearRing,Polygon,MultiGeometry,Model,"
             "gx:MultiTrack,gx:Track"
         ),
         classes=(
@@ -674,6 +676,7 @@ registry.register(
             LinearRing,
             Polygon,
             MultiGeometry,
+            Model,
             gx.MultiTrack,
             gx.Track,
         ),

--- a/fastkml/features.py
+++ b/fastkml/features.py
@@ -309,7 +309,7 @@ class _Feature(TimeMixin, _BaseObject):
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="name",
         node_name="name",
         classes=(str,),
@@ -320,7 +320,7 @@ registry.register(
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="visibility",
         node_name="visibility",
         classes=(bool,),
@@ -332,7 +332,7 @@ registry.register(
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="isopen",
         node_name="open",
         classes=(bool,),
@@ -366,7 +366,7 @@ registry.register(
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="address",
         node_name="address",
         classes=(str,),
@@ -377,7 +377,7 @@ registry.register(
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="phone_number",
         node_name="phoneNumber",
         classes=(str,),
@@ -388,7 +388,7 @@ registry.register(
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="snippet",
         node_name="Snippet",
         classes=(Snippet,),
@@ -399,7 +399,7 @@ registry.register(
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="description",
         node_name="description",
         classes=(str,),
@@ -410,7 +410,7 @@ registry.register(
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="view",
         node_name="Camera,LookAt",
         classes=(
@@ -424,7 +424,7 @@ registry.register(
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="times",
         node_name="TimeSpan,TimeStamp",
         classes=(
@@ -438,7 +438,7 @@ registry.register(
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="style_url",
         node_name="styleUrl",
         classes=(StyleUrl,),
@@ -449,7 +449,7 @@ registry.register(
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="styles",
         node_name="Style,StyleMap",
         classes=(
@@ -463,7 +463,7 @@ registry.register(
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="region",
         node_name="region",
         classes=(Region,),
@@ -474,7 +474,7 @@ registry.register(
 registry.register(
     _Feature,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="extended_data",
         node_name="ExtendedData",
         classes=(ExtendedData,),
@@ -891,7 +891,7 @@ class NetworkLink(_Feature):
 registry.register(
     NetworkLink,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="refresh_visibility",
         node_name="refreshVisibility",
         classes=(bool,),
@@ -903,7 +903,7 @@ registry.register(
 registry.register(
     NetworkLink,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="fly_to_view",
         node_name="flyToView",
         classes=(bool,),
@@ -915,7 +915,7 @@ registry.register(
 registry.register(
     NetworkLink,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="link",
         node_name="Link",
         classes=(Link,),

--- a/fastkml/geometry.py
+++ b/fastkml/geometry.py
@@ -300,7 +300,7 @@ class Coordinates(_XMLObject):
 registry.register(
     Coordinates,
     item=RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(LineType,),  # type: ignore[arg-type]
         attr_name="coords",
         node_name="coordinates",
@@ -501,7 +501,7 @@ class Point(_Geometry):
 registry.register(
     Point,
     item=RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(bool,),
         attr_name="extrude",
         node_name="extrude",
@@ -525,7 +525,7 @@ registry.register(
 registry.register(
     Point,
     item=RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(Coordinates,),
         attr_name="kml_coordinates",
         node_name="coordinates",
@@ -668,7 +668,7 @@ class LineString(_Geometry):
 registry.register(
     LineString,
     item=RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(bool,),
         attr_name="extrude",
         node_name="extrude",
@@ -680,7 +680,7 @@ registry.register(
 registry.register(
     LineString,
     item=RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(bool,),
         attr_name="tessellate",
         node_name="tessellate",
@@ -704,7 +704,7 @@ registry.register(
 registry.register(
     LineString,
     item=RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(Coordinates,),
         attr_name="kml_coordinates",
         node_name="coordinates",
@@ -936,7 +936,7 @@ class InnerBoundaryIs(BoundaryIs):
 registry.register(
     BoundaryIs,
     item=RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(LinearRing,),
         attr_name="kml_geometry",
         node_name="LinearRing",
@@ -1134,7 +1134,7 @@ class Polygon(_Geometry):
 registry.register(
     Polygon,
     item=RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(bool,),
         attr_name="extrude",
         node_name="extrude",
@@ -1146,7 +1146,7 @@ registry.register(
 registry.register(
     Polygon,
     item=RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(bool,),
         attr_name="tessellate",
         node_name="tessellate",
@@ -1170,7 +1170,7 @@ registry.register(
 registry.register(
     Polygon,
     item=RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(OuterBoundaryIs,),
         attr_name="outer_boundary",
         node_name="outerBoundaryIs",
@@ -1181,7 +1181,7 @@ registry.register(
 registry.register(
     Polygon,
     item=RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(InnerBoundaryIs,),
         attr_name="inner_boundaries",
         node_name="innerBoundaryIs",
@@ -1344,7 +1344,7 @@ class MultiGeometry(_BaseObject):
 registry.register(
     MultiGeometry,
     item=RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(Point, LineString, Polygon, LinearRing, MultiGeometry),
         attr_name="kml_geometries",
         node_name="(Point|LineString|Polygon|LinearRing|MultiGeometry)",

--- a/fastkml/geometry.py
+++ b/fastkml/geometry.py
@@ -513,7 +513,7 @@ registry.register(
 registry.register(
     Point,
     item=RegistryItem(
-        ns_ids=("kml", "gx"),
+        ns_ids=("kml", "gx", ""),
         classes=(AltitudeMode,),
         attr_name="altitude_mode",
         node_name="altitudeMode",
@@ -692,7 +692,7 @@ registry.register(
 registry.register(
     LineString,
     item=RegistryItem(
-        ns_ids=("kml", "gx"),
+        ns_ids=("kml", "gx", ""),
         classes=(AltitudeMode,),
         attr_name="altitude_mode",
         node_name="altitudeMode",
@@ -1158,7 +1158,7 @@ registry.register(
 registry.register(
     Polygon,
     item=RegistryItem(
-        ns_ids=("kml", "gx"),
+        ns_ids=("kml", "gx", ""),
         classes=(AltitudeMode,),
         attr_name="altitude_mode",
         node_name="altitudeMode",

--- a/fastkml/kml.py
+++ b/fastkml/kml.py
@@ -285,7 +285,7 @@ class KML(_XMLObject):
 registry.register(
     KML,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         classes=(Document, Folder, Placemark, GroundOverlay, PhotoOverlay, NetworkLink),
         node_name="Document,Folder,Placemark,GroundOverlay,PhotoOverlay,NetworkLink",
         attr_name="features",

--- a/fastkml/links.py
+++ b/fastkml/links.py
@@ -126,7 +126,7 @@ class Link(_BaseObject):
 registry.register(
     Link,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="href",
         node_name="href",
         classes=(str,),
@@ -137,7 +137,7 @@ registry.register(
 registry.register(
     Link,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="refresh_mode",
         node_name="refreshMode",
         classes=(RefreshMode,),
@@ -149,7 +149,7 @@ registry.register(
 registry.register(
     Link,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="refresh_interval",
         node_name="refreshInterval",
         classes=(float,),
@@ -161,7 +161,7 @@ registry.register(
 registry.register(
     Link,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="view_refresh_mode",
         node_name="viewRefreshMode",
         classes=(ViewRefreshMode,),
@@ -173,7 +173,7 @@ registry.register(
 registry.register(
     Link,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="view_refresh_time",
         node_name="viewRefreshTime",
         classes=(float,),
@@ -185,7 +185,7 @@ registry.register(
 registry.register(
     Link,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="view_bound_scale",
         node_name="viewBoundScale",
         classes=(float,),
@@ -197,7 +197,7 @@ registry.register(
 registry.register(
     Link,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="view_format",
         node_name="viewFormat",
         classes=(str,),
@@ -209,7 +209,7 @@ registry.register(
 registry.register(
     Link,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="http_query",
         node_name="httpQuery",
         classes=(str,),

--- a/fastkml/model.py
+++ b/fastkml/model.py
@@ -135,6 +135,7 @@ registry.register(
         classes=(float,),
         get_kwarg=subelement_float_kwarg,
         set_element=float_subelement,
+        default=0.0,
     ),
 )
 
@@ -192,6 +193,7 @@ registry.register(
         classes=(float,),
         get_kwarg=subelement_float_kwarg,
         set_element=float_subelement,
+        default=0.0,
     ),
 )
 registry.register(
@@ -203,6 +205,7 @@ registry.register(
         classes=(float,),
         get_kwarg=subelement_float_kwarg,
         set_element=float_subelement,
+        default=0.0,
     ),
 )
 registry.register(
@@ -214,6 +217,7 @@ registry.register(
         classes=(float,),
         get_kwarg=subelement_float_kwarg,
         set_element=float_subelement,
+        default=0.0,
     ),
 )
 
@@ -269,6 +273,7 @@ registry.register(
         classes=(float,),
         get_kwarg=subelement_float_kwarg,
         set_element=float_subelement,
+        default=1.0,
     ),
 )
 registry.register(
@@ -280,6 +285,7 @@ registry.register(
         classes=(float,),
         get_kwarg=subelement_float_kwarg,
         set_element=float_subelement,
+        default=1.0,
     ),
 )
 registry.register(
@@ -291,6 +297,7 @@ registry.register(
         classes=(float,),
         get_kwarg=subelement_float_kwarg,
         set_element=float_subelement,
+        default=1.0,
     ),
 )
 
@@ -480,6 +487,7 @@ registry.register(
         classes=(AltitudeMode,),
         get_kwarg=subelement_enum_kwarg,
         set_element=enum_subelement,
+        default=AltitudeMode.clamp_to_ground,
     ),
 )
 registry.register(

--- a/fastkml/model.py
+++ b/fastkml/model.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2023 Christian Ledermann
+# Copyright (C) 2024 Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -45,6 +45,8 @@ from fastkml.kml_base import _BaseObject
 from fastkml.links import Link
 from fastkml.registry import RegistryItem
 from fastkml.registry import registry
+
+__all__ = ["Alias", "Location", "Model", "Orientation", "ResourceMap", "Scale"]
 
 
 class Location(_XMLObject):

--- a/fastkml/model.py
+++ b/fastkml/model.py
@@ -23,11 +23,13 @@ https://developers.google.com/kml/documentation/kmlreference#model
 
 """
 
+from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Optional
 
+from fastkml import config
 from fastkml.base import _XMLObject
 from fastkml.enums import AltitudeMode
 from fastkml.helpers import clean_string
@@ -52,6 +54,8 @@ __all__ = ["Alias", "Location", "Model", "Orientation", "ResourceMap", "Scale"]
 class Location(_XMLObject):
     """Represents a location in KML."""
 
+    _default_nsid = config.KML
+
     latitude: Optional[float]
     longitude: Optional[float]
     altitude: Optional[float]
@@ -63,14 +67,16 @@ class Location(_XMLObject):
         altitude: Optional[float] = None,
         latitude: Optional[float] = None,
         longitude: Optional[float] = None,
+        **kwargs: Any,
     ) -> None:
         """Create a new Location."""
-        super().__init__(ns=ns, name_spaces=name_spaces)
+        super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.altitude = altitude
         self.latitude = latitude
         self.longitude = longitude
 
     def __bool__(self) -> bool:
+        """Return True if latitude and longitude are set."""
         return all((self.latitude is not None, self.longitude is not None))
 
     def __repr__(self) -> str:
@@ -82,6 +88,7 @@ class Location(_XMLObject):
             f"altitude={self.altitude!r}, "
             f"latitude={self.latitude!r}, "
             f"longitude={self.longitude!r}, "
+            f"**{self._get_splat()!r},"
             ")"
         )
 
@@ -124,6 +131,8 @@ registry.register(
 class Orientation(_XMLObject):
     """Represents an orientation in KML."""
 
+    _default_nsid = config.KML
+
     heading: Optional[float]
     tilt: Optional[float]
     roll: Optional[float]
@@ -135,13 +144,16 @@ class Orientation(_XMLObject):
         heading: Optional[float] = None,
         tilt: Optional[float] = None,
         roll: Optional[float] = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(ns=ns, name_spaces=name_spaces)
+        """Create a new Orientation."""
+        super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.heading = heading
         self.tilt = tilt
         self.roll = roll
 
     def __bool__(self) -> bool:
+        """Return True if heading, tilt, and roll are set."""
         return any(
             (self.heading is not None, self.tilt is not None, self.roll is not None),
         )
@@ -155,6 +167,7 @@ class Orientation(_XMLObject):
             f"heading={self.heading!r}, "
             f"tilt={self.tilt!r}, "
             f"roll={self.roll!r}, "
+            f"**{self._get_splat()!r},"
             ")"
         )
 
@@ -197,6 +210,8 @@ registry.register(
 class Scale(_XMLObject):
     """Represents a scale in KML."""
 
+    _default_nsid = config.KML
+
     x: Optional[float]
     y: Optional[float]
     z: Optional[float]
@@ -208,13 +223,16 @@ class Scale(_XMLObject):
         x: Optional[float] = None,
         y: Optional[float] = None,
         z: Optional[float] = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(ns=ns, name_spaces=name_spaces)
+        """Create a new Scale."""
+        super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.x = x
         self.y = y
         self.z = z
 
     def __bool__(self) -> bool:
+        """Return True if x, y, or z are set."""
         return any((self.x is not None, self.y is not None, self.z is not None))
 
     def __repr__(self) -> str:
@@ -226,6 +244,7 @@ class Scale(_XMLObject):
             f"x={self.x!r}, "
             f"y={self.y!r}, "
             f"z={self.z!r}, "
+            f"**{self._get_splat()!r},"
             ")"
         )
 
@@ -268,6 +287,8 @@ registry.register(
 class Alias(_XMLObject):
     """Represents an alias in KML."""
 
+    _default_nsid = config.KML
+
     target_href: Optional[str]
     source_href: Optional[str]
 
@@ -277,13 +298,16 @@ class Alias(_XMLObject):
         name_spaces: Optional[Dict[str, str]] = None,
         target_href: Optional[str] = None,
         source_href: Optional[str] = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(ns=ns, name_spaces=name_spaces)
+        """Create a new Alias."""
+        super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.target_href = clean_string(target_href)
         self.source_href = clean_string(source_href)
 
     def __bool__(self) -> bool:
-        return all((self.target_href is not None, self.source_href is not None))
+        """Return True if target_href and source_href are set."""
+        return any((self.target_href is not None, self.source_href is not None))
 
     def __repr__(self) -> str:
         """Create a string (c)representation for Alias."""
@@ -293,6 +317,7 @@ class Alias(_XMLObject):
             f"name_spaces={self.name_spaces!r}, "
             f"target_href={self.target_href!r}, "
             f"source_href={self.source_href!r}, "
+            f"**{self._get_splat()!r},"
             ")"
         )
 
@@ -324,6 +349,8 @@ registry.register(
 class ResourceMap(_XMLObject):
     """Represents a resource map in KML."""
 
+    _default_nsid = config.KML
+
     aliases: List[Alias]
 
     def __init__(
@@ -331,11 +358,14 @@ class ResourceMap(_XMLObject):
         ns: Optional[str] = None,
         name_spaces: Optional[Dict[str, str]] = None,
         aliases: Optional[Iterable[Alias]] = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(ns=ns, name_spaces=name_spaces)
+        """Create a new ResourceMap."""
+        super().__init__(ns=ns, name_spaces=name_spaces, **kwargs)
         self.aliases = list(aliases) if aliases is not None else []
 
     def __bool__(self) -> bool:
+        """Return True if aliases are set."""
         return bool(self.aliases)
 
     def __repr__(self) -> str:
@@ -345,6 +375,7 @@ class ResourceMap(_XMLObject):
             f"ns={self.ns!r}, "
             f"name_spaces={self.name_spaces!r}, "
             f"aliases={self.aliases!r}, "
+            f"**{self._get_splat()!r},"
             ")"
         )
 
@@ -384,8 +415,16 @@ class Model(_BaseObject):
         scale: Optional[Scale] = None,
         link: Optional[Link] = None,
         resource_map: Optional[ResourceMap] = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(ns=ns, name_spaces=name_spaces, id=id, target_id=target_id)
+        """Create a new Model."""
+        super().__init__(
+            ns=ns,
+            name_spaces=name_spaces,
+            id=id,
+            target_id=target_id,
+            **kwargs,
+        )
         self.altitude_mode = altitude_mode
         self.location = location
         self.orientation = orientation
@@ -394,13 +433,17 @@ class Model(_BaseObject):
         self.resource_map = resource_map
 
     def __bool__(self) -> bool:
+        """Return True if link is set."""
         return bool(self.link)
 
     def __repr__(self) -> str:
+        """Create a string representation for Model."""
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
             f"name_spaces={self.name_spaces!r}, "
+            f"id={self.id!r}, "
+            f"target_id={self.target_id!r}, "
             f"altitude_mode={self.altitude_mode}, "
             f"location={self.location!r}, "
             f"orientation={self.orientation!r}, "
@@ -415,7 +458,7 @@ class Model(_BaseObject):
 registry.register(
     Model,
     RegistryItem(
-        ns_ids=("kml", ""),
+        ns_ids=("kml", "gx", ""),
         attr_name="altitude_mode",
         node_name="altitudeMode",
         classes=(AltitudeMode,),

--- a/fastkml/model.py
+++ b/fastkml/model.py
@@ -1,0 +1,153 @@
+# Copyright (C) 2012-2023 Christian Ledermann
+#
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+"""
+Model element.
+
+The Model element defines a 3D model that is attached to a Placemark.
+
+https://developers.google.com/kml/documentation/models
+https://developers.google.com/kml/documentation/kmlreference#model
+
+"""
+
+from typing import Dict
+from typing import Iterable
+from typing import Optional
+
+from fastkml.base import _XMLObject
+from fastkml.enums import AltitudeMode
+from fastkml.helpers import clean_string
+from fastkml.kml_base import _BaseObject
+from fastkml.links import Link
+
+
+class Location(_XMLObject):
+    """Represents a location in KML."""
+
+    def __init__(
+        self,
+        ns: Optional[str] = None,
+        name_spaces: Optional[Dict[str, str]] = None,
+        altitude: Optional[float] = None,
+        latitude: Optional[float] = None,
+        longitude: Optional[float] = None,
+    ) -> None:
+        super().__init__(ns=ns, name_spaces=name_spaces)
+        self.altitude = altitude
+        self.latitude = latitude
+        self.longitude = longitude
+
+
+class Orientation(_XMLObject):
+    """Represents an orientation in KML."""
+
+    def __init__(
+        self,
+        ns: Optional[str] = None,
+        name_spaces: Optional[Dict[str, str]] = None,
+        heading: Optional[float] = None,
+        tilt: Optional[float] = None,
+        roll: Optional[float] = None,
+    ) -> None:
+        super().__init__(ns=ns, name_spaces=name_spaces)
+        self.heading = heading
+        self.tilt = tilt
+        self.roll = roll
+
+
+class Scale(_XMLObject):
+    """Represents a scale in KML."""
+
+    def __init__(
+        self,
+        ns: Optional[str] = None,
+        name_spaces: Optional[Dict[str, str]] = None,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+    ) -> None:
+        super().__init__(ns=ns, name_spaces=name_spaces)
+        self.x = x
+        self.y = y
+        self.z = z
+
+
+class Alias(_XMLObject):
+    """Represents an alias in KML."""
+
+    def __init__(
+        self,
+        ns: Optional[str] = None,
+        name_spaces: Optional[Dict[str, str]] = None,
+        target_href: Optional[str] = None,
+        source_href: Optional[str] = None,
+    ) -> None:
+        super().__init__(ns=ns, name_spaces=name_spaces)
+        self.target_href = clean_string(target_href)
+        self.source_href = clean_string(source_href)
+
+
+class ResourceMap(_XMLObject):
+    """Represents a resource map in KML."""
+
+    def __init__(
+        self,
+        ns: Optional[str] = None,
+        name_spaces: Optional[Dict[str, str]] = None,
+        aliases: Optional[Iterable[Alias]] = None,
+    ) -> None:
+        super().__init__(ns=ns, name_spaces=name_spaces)
+        self.aliases = list(aliases) if aliases is not None else []
+
+
+class Model(_BaseObject):
+    """Represents a model in KML."""
+
+    def __init__(
+        self,
+        ns: Optional[str] = None,
+        name_spaces: Optional[Dict[str, str]] = None,
+        id: Optional[str] = None,
+        target_id: Optional[str] = None,
+        altitude_mode: Optional[AltitudeMode] = None,
+        location: Optional[Location] = None,
+        orientation: Optional[Orientation] = None,
+        scale: Optional[Scale] = None,
+        link: Optional[Link] = None,
+        resource_map: Optional[ResourceMap] = None,
+    ) -> None:
+        super().__init__(ns=ns, name_spaces=name_spaces, id=id, target_id=target_id)
+        self.altitude_mode = altitude_mode
+        self.location = location
+        self.orientation = orientation
+        self.scale = scale
+        self.link = link
+        self.resource_map = resource_map
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__module__}.{self.__class__.__name__}("
+            f"ns={self.ns!r}, "
+            f"name_spaces={self.name_spaces!r}, "
+            f"altitude_mode={self.altitude_mode}, "
+            f"location={self.location!r}, "
+            f"orientation={self.orientation!r}, "
+            f"scale={self.scale!r}, "
+            f"link={self.link!r}, "
+            f"resource_map={self.resource_map!r}, "
+            f"**{self._get_splat()!r},"
+            ")"
+        )

--- a/fastkml/model.py
+++ b/fastkml/model.py
@@ -45,10 +45,26 @@ class Location(_XMLObject):
         latitude: Optional[float] = None,
         longitude: Optional[float] = None,
     ) -> None:
+        """Create a new Location."""
         super().__init__(ns=ns, name_spaces=name_spaces)
         self.altitude = altitude
         self.latitude = latitude
         self.longitude = longitude
+
+    def __bool__(self) -> bool:
+        return all((self.latitude is not None, self.longitude is not None))
+
+    def __repr__(self) -> str:
+        """Create a string (c)representation for Location."""
+        return (
+            f"{self.__class__.__module__}.{self.__class__.__name__}("
+            f"ns={self.ns!r}, "
+            f"name_spaces={self.name_spaces!r}, "
+            f"altitude={self.altitude!r}, "
+            f"latitude={self.latitude!r}, "
+            f"longitude={self.longitude!r}, "
+            ")"
+        )
 
 
 class Orientation(_XMLObject):
@@ -67,6 +83,23 @@ class Orientation(_XMLObject):
         self.tilt = tilt
         self.roll = roll
 
+    def __bool__(self) -> bool:
+        return any(
+            (self.heading is not None, self.tilt is not None, self.roll is not None)
+        )
+
+    def __repr__(self) -> str:
+        """Create a string (c)representation for Orientation."""
+        return (
+            f"{self.__class__.__module__}.{self.__class__.__name__}("
+            f"ns={self.ns!r}, "
+            f"name_spaces={self.name_spaces!r}, "
+            f"heading={self.heading!r}, "
+            f"tilt={self.tilt!r}, "
+            f"roll={self.roll!r}, "
+            ")"
+        )
+
 
 class Scale(_XMLObject):
     """Represents a scale in KML."""
@@ -84,6 +117,21 @@ class Scale(_XMLObject):
         self.y = y
         self.z = z
 
+    def __bool__(self) -> bool:
+        return any((self.x is not None, self.y is not None, self.z is not None))
+
+    def __repr__(self) -> str:
+        """Create a string (c)representation for Scale."""
+        return (
+            f"{self.__class__.__module__}.{self.__class__.__name__}("
+            f"ns={self.ns!r}, "
+            f"name_spaces={self.name_spaces!r}, "
+            f"x={self.x!r}, "
+            f"y={self.y!r}, "
+            f"z={self.z!r}, "
+            ")"
+        )
+
 
 class Alias(_XMLObject):
     """Represents an alias in KML."""
@@ -99,6 +147,20 @@ class Alias(_XMLObject):
         self.target_href = clean_string(target_href)
         self.source_href = clean_string(source_href)
 
+    def __bool__(self) -> bool:
+        return all((self.target_href is not None, self.source_href is not None))
+
+    def __repr__(self) -> str:
+        """Create a string (c)representation for Alias."""
+        return (
+            f"{self.__class__.__module__}.{self.__class__.__name__}("
+            f"ns={self.ns!r}, "
+            f"name_spaces={self.name_spaces!r}, "
+            f"target_href={self.target_href!r}, "
+            f"source_href={self.source_href!r}, "
+            ")"
+        )
+
 
 class ResourceMap(_XMLObject):
     """Represents a resource map in KML."""
@@ -111,6 +173,19 @@ class ResourceMap(_XMLObject):
     ) -> None:
         super().__init__(ns=ns, name_spaces=name_spaces)
         self.aliases = list(aliases) if aliases is not None else []
+
+    def __bool__(self) -> bool:
+        return bool(self.aliases)
+
+    def __repr__(self) -> str:
+        """Create a string (c)representation for ResourceMap."""
+        return (
+            f"{self.__class__.__module__}.{self.__class__.__name__}("
+            f"ns={self.ns!r}, "
+            f"name_spaces={self.name_spaces!r}, "
+            f"aliases={self.aliases!r}, "
+            ")"
+        )
 
 
 class Model(_BaseObject):
@@ -136,6 +211,9 @@ class Model(_BaseObject):
         self.scale = scale
         self.link = link
         self.resource_map = resource_map
+
+    def __bool__(self) -> bool:
+        return bool(self.link)
 
     def __repr__(self) -> str:
         return (

--- a/fastkml/model.py
+++ b/fastkml/model.py
@@ -165,7 +165,7 @@ class Orientation(_XMLObject):
         self.roll = roll
 
     def __bool__(self) -> bool:
-        """Return True if heading, tilt, and roll are set."""
+        """Return True if heading, tilt, or roll are set."""
         return any(
             (self.heading is not None, self.tilt is not None, self.roll is not None),
         )
@@ -324,7 +324,7 @@ class Alias(_XMLObject):
         self.source_href = clean_string(source_href)
 
     def __bool__(self) -> bool:
-        """Return True if target_href and source_href are set."""
+        """Return True if target_href or source_href are set."""
         return any((self.target_href is not None, self.source_href is not None))
 
     def __repr__(self) -> str:
@@ -451,7 +451,7 @@ class Model(_BaseObject):
         self.resource_map = resource_map
 
     def __bool__(self) -> bool:
-        """Return True if link is set."""
+        """Return True if link and location are set."""
         return all((self.link, self.location))
 
     def __repr__(self) -> str:

--- a/fastkml/model.py
+++ b/fastkml/model.py
@@ -29,6 +29,8 @@ from typing import Iterable
 from typing import List
 from typing import Optional
 
+from pygeoif.geometry import Point
+
 from fastkml import config
 from fastkml.base import _XMLObject
 from fastkml.enums import AltitudeMode
@@ -91,6 +93,15 @@ class Location(_XMLObject):
             f"**{self._get_splat()!r},"
             ")"
         )
+
+    @property
+    def geometry(self) -> Optional[Point]:
+        """Return a Point representation of the geometry."""
+        if not self:
+            return None
+        assert self.longitude is not None  # noqa: S101
+        assert self.latitude is not None  # noqa: S101
+        return Point(self.longitude, self.latitude, self.altitude)
 
 
 registry.register(
@@ -434,7 +445,7 @@ class Model(_BaseObject):
 
     def __bool__(self) -> bool:
         """Return True if link is set."""
-        return bool(self.link)
+        return all((self.link, self.location))
 
     def __repr__(self) -> str:
         """Create a string representation for Model."""
@@ -453,6 +464,11 @@ class Model(_BaseObject):
             f"**{self._get_splat()!r},"
             ")"
         )
+
+    @property
+    def geometry(self) -> Optional[Point]:
+        """Return a Point representation of the geometry."""
+        return self.location.geometry if self.location else None
 
 
 registry.register(

--- a/fastkml/model.py
+++ b/fastkml/model.py
@@ -25,17 +25,34 @@ https://developers.google.com/kml/documentation/kmlreference#model
 
 from typing import Dict
 from typing import Iterable
+from typing import List
 from typing import Optional
 
 from fastkml.base import _XMLObject
 from fastkml.enums import AltitudeMode
 from fastkml.helpers import clean_string
+from fastkml.helpers import enum_subelement
+from fastkml.helpers import float_subelement
+from fastkml.helpers import subelement_enum_kwarg
+from fastkml.helpers import subelement_float_kwarg
+from fastkml.helpers import subelement_text_kwarg
+from fastkml.helpers import text_subelement
+from fastkml.helpers import xml_subelement
+from fastkml.helpers import xml_subelement_kwarg
+from fastkml.helpers import xml_subelement_list
+from fastkml.helpers import xml_subelement_list_kwarg
 from fastkml.kml_base import _BaseObject
 from fastkml.links import Link
+from fastkml.registry import RegistryItem
+from fastkml.registry import registry
 
 
 class Location(_XMLObject):
     """Represents a location in KML."""
+
+    latitude: Optional[float]
+    longitude: Optional[float]
+    altitude: Optional[float]
 
     def __init__(
         self,
@@ -67,8 +84,47 @@ class Location(_XMLObject):
         )
 
 
+registry.register(
+    Location,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="longitude",
+        node_name="longitude",
+        classes=(float,),
+        get_kwarg=subelement_float_kwarg,
+        set_element=float_subelement,
+    ),
+)
+registry.register(
+    Location,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="latitude",
+        node_name="latitude",
+        classes=(float,),
+        get_kwarg=subelement_float_kwarg,
+        set_element=float_subelement,
+    ),
+)
+registry.register(
+    Location,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="altitude",
+        node_name="altitude",
+        classes=(float,),
+        get_kwarg=subelement_float_kwarg,
+        set_element=float_subelement,
+    ),
+)
+
+
 class Orientation(_XMLObject):
     """Represents an orientation in KML."""
+
+    heading: Optional[float]
+    tilt: Optional[float]
+    roll: Optional[float]
 
     def __init__(
         self,
@@ -85,7 +141,7 @@ class Orientation(_XMLObject):
 
     def __bool__(self) -> bool:
         return any(
-            (self.heading is not None, self.tilt is not None, self.roll is not None)
+            (self.heading is not None, self.tilt is not None, self.roll is not None),
         )
 
     def __repr__(self) -> str:
@@ -101,8 +157,47 @@ class Orientation(_XMLObject):
         )
 
 
+registry.register(
+    Orientation,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="heading",
+        node_name="heading",
+        classes=(float,),
+        get_kwarg=subelement_float_kwarg,
+        set_element=float_subelement,
+    ),
+)
+registry.register(
+    Orientation,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="tilt",
+        node_name="tilt",
+        classes=(float,),
+        get_kwarg=subelement_float_kwarg,
+        set_element=float_subelement,
+    ),
+)
+registry.register(
+    Orientation,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="roll",
+        node_name="roll",
+        classes=(float,),
+        get_kwarg=subelement_float_kwarg,
+        set_element=float_subelement,
+    ),
+)
+
+
 class Scale(_XMLObject):
     """Represents a scale in KML."""
+
+    x: Optional[float]
+    y: Optional[float]
+    z: Optional[float]
 
     def __init__(
         self,
@@ -133,8 +228,46 @@ class Scale(_XMLObject):
         )
 
 
+registry.register(
+    Scale,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="x",
+        node_name="x",
+        classes=(float,),
+        get_kwarg=subelement_float_kwarg,
+        set_element=float_subelement,
+    ),
+)
+registry.register(
+    Scale,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="y",
+        node_name="y",
+        classes=(float,),
+        get_kwarg=subelement_float_kwarg,
+        set_element=float_subelement,
+    ),
+)
+registry.register(
+    Scale,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="z",
+        node_name="z",
+        classes=(float,),
+        get_kwarg=subelement_float_kwarg,
+        set_element=float_subelement,
+    ),
+)
+
+
 class Alias(_XMLObject):
     """Represents an alias in KML."""
+
+    target_href: Optional[str]
+    source_href: Optional[str]
 
     def __init__(
         self,
@@ -162,8 +295,34 @@ class Alias(_XMLObject):
         )
 
 
+registry.register(
+    Alias,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="target_href",
+        node_name="targetHref",
+        classes=(str,),
+        get_kwarg=subelement_text_kwarg,
+        set_element=text_subelement,
+    ),
+)
+registry.register(
+    Alias,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="source_href",
+        node_name="sourceHref",
+        classes=(str,),
+        get_kwarg=subelement_text_kwarg,
+        set_element=text_subelement,
+    ),
+)
+
+
 class ResourceMap(_XMLObject):
     """Represents a resource map in KML."""
+
+    aliases: List[Alias]
 
     def __init__(
         self,
@@ -188,8 +347,28 @@ class ResourceMap(_XMLObject):
         )
 
 
+registry.register(
+    ResourceMap,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="aliases",
+        node_name="Alias",
+        classes=(Alias,),
+        get_kwarg=xml_subelement_list_kwarg,
+        set_element=xml_subelement_list,
+    ),
+)
+
+
 class Model(_BaseObject):
     """Represents a model in KML."""
+
+    altitude_mode: Optional[AltitudeMode]
+    location: Optional[Location]
+    orientation: Optional[Orientation]
+    scale: Optional[Scale]
+    link: Optional[Link]
+    resource_map: Optional[ResourceMap]
 
     def __init__(
         self,
@@ -229,3 +408,71 @@ class Model(_BaseObject):
             f"**{self._get_splat()!r},"
             ")"
         )
+
+
+registry.register(
+    Model,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="altitude_mode",
+        node_name="altitudeMode",
+        classes=(AltitudeMode,),
+        get_kwarg=subelement_enum_kwarg,
+        set_element=enum_subelement,
+    ),
+)
+registry.register(
+    Model,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="location",
+        node_name="Location",
+        classes=(Location,),
+        get_kwarg=xml_subelement_kwarg,
+        set_element=xml_subelement,
+    ),
+)
+registry.register(
+    Model,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="orientation",
+        node_name="Orientation",
+        classes=(Orientation,),
+        get_kwarg=xml_subelement_kwarg,
+        set_element=xml_subelement,
+    ),
+)
+registry.register(
+    Model,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="scale",
+        node_name="Scale",
+        classes=(Scale,),
+        get_kwarg=xml_subelement_kwarg,
+        set_element=xml_subelement,
+    ),
+)
+registry.register(
+    Model,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="link",
+        node_name="Link",
+        classes=(Link,),
+        get_kwarg=xml_subelement_kwarg,
+        set_element=xml_subelement,
+    ),
+)
+registry.register(
+    Model,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="resource_map",
+        node_name="ResourceMap",
+        classes=(ResourceMap,),
+        get_kwarg=xml_subelement_kwarg,
+        set_element=xml_subelement,
+    ),
+)

--- a/fastkml/overlays.py
+++ b/fastkml/overlays.py
@@ -229,7 +229,7 @@ class _Overlay(_Feature):
 registry.register(
     _Overlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="color",
         node_name="color",
         classes=(str,),
@@ -241,7 +241,7 @@ registry.register(
 registry.register(
     _Overlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="draw_order",
         node_name="drawOrder",
         classes=(int,),
@@ -253,7 +253,7 @@ registry.register(
 registry.register(
     _Overlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="icon",
         node_name="Icon",
         classes=(Icon,),
@@ -380,7 +380,7 @@ class ViewVolume(_XMLObject):
 registry.register(
     ViewVolume,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="left_fov",
         node_name="leftFov",
         classes=(float,),
@@ -392,7 +392,7 @@ registry.register(
 registry.register(
     ViewVolume,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="right_fov",
         node_name="rightFov",
         classes=(float,),
@@ -404,7 +404,7 @@ registry.register(
 registry.register(
     ViewVolume,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="bottom_fov",
         node_name="bottomFov",
         classes=(float,),
@@ -416,7 +416,7 @@ registry.register(
 registry.register(
     ViewVolume,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="top_fov",
         node_name="topFov",
         classes=(float,),
@@ -428,7 +428,7 @@ registry.register(
 registry.register(
     ViewVolume,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="near",
         node_name="near",
         classes=(float,),
@@ -550,7 +550,7 @@ class ImagePyramid(_XMLObject):
 registry.register(
     ImagePyramid,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="tile_size",
         node_name="tileSize",
         classes=(int,),
@@ -562,7 +562,7 @@ registry.register(
 registry.register(
     ImagePyramid,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="max_width",
         node_name="maxWidth",
         classes=(int,),
@@ -573,7 +573,7 @@ registry.register(
 registry.register(
     ImagePyramid,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="max_height",
         node_name="maxHeight",
         classes=(int,),
@@ -584,7 +584,7 @@ registry.register(
 registry.register(
     ImagePyramid,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="grid_origin",
         node_name="gridOrigin",
         classes=(GridOrigin,),
@@ -821,7 +821,7 @@ class PhotoOverlay(_Overlay):
 registry.register(
     PhotoOverlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="rotation",
         node_name="rotation",
         classes=(float,),
@@ -833,7 +833,7 @@ registry.register(
 registry.register(
     PhotoOverlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="view_volume",
         node_name="ViewVolume",
         classes=(ViewVolume,),
@@ -844,7 +844,7 @@ registry.register(
 registry.register(
     PhotoOverlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="image_pyramid",
         node_name="ImagePyramid",
         classes=(ImagePyramid,),
@@ -855,7 +855,7 @@ registry.register(
 registry.register(
     PhotoOverlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="point",
         node_name="Point",
         classes=(Point,),
@@ -866,7 +866,7 @@ registry.register(
 registry.register(
     PhotoOverlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="shape",
         node_name="shape",
         classes=(Shape,),
@@ -992,7 +992,7 @@ class LatLonBox(_XMLObject):
 registry.register(
     LatLonBox,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="north",
         node_name="north",
         classes=(float,),
@@ -1003,7 +1003,7 @@ registry.register(
 registry.register(
     LatLonBox,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="south",
         node_name="south",
         classes=(float,),
@@ -1014,7 +1014,7 @@ registry.register(
 registry.register(
     LatLonBox,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="east",
         node_name="east",
         classes=(float,),
@@ -1025,7 +1025,7 @@ registry.register(
 registry.register(
     LatLonBox,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="west",
         node_name="west",
         classes=(float,),
@@ -1036,7 +1036,7 @@ registry.register(
 registry.register(
     LatLonBox,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="rotation",
         node_name="rotation",
         classes=(float,),
@@ -1241,7 +1241,7 @@ class GroundOverlay(_Overlay):
 registry.register(
     GroundOverlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="altitude",
         node_name="altitude",
         classes=(float,),
@@ -1265,7 +1265,7 @@ registry.register(
 registry.register(
     GroundOverlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="lat_lon_box",
         node_name="LatLonBox",
         classes=(LatLonBox,),
@@ -1622,7 +1622,7 @@ class ScreenOverlay(_Overlay):
 registry.register(
     ScreenOverlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="overlay_xy",
         node_name="overlayXY",
         classes=(OverlayXY,),
@@ -1633,7 +1633,7 @@ registry.register(
 registry.register(
     ScreenOverlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="screen_xy",
         node_name="screenXY",
         classes=(ScreenXY,),
@@ -1644,7 +1644,7 @@ registry.register(
 registry.register(
     ScreenOverlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="rotation_xy",
         node_name="rotationXY",
         classes=(RotationXY,),
@@ -1655,7 +1655,7 @@ registry.register(
 registry.register(
     ScreenOverlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="size",
         node_name="size",
         classes=(Size,),
@@ -1666,7 +1666,7 @@ registry.register(
 registry.register(
     ScreenOverlay,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="rotation",
         node_name="rotation",
         classes=(float,),

--- a/fastkml/styles.py
+++ b/fastkml/styles.py
@@ -156,7 +156,7 @@ class StyleUrl(_XMLObject):
 registry.register(
     StyleUrl,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="url",
         node_name="styleUrl",
         classes=(str,),
@@ -242,7 +242,7 @@ class _ColorStyle(_BaseObject):
 registry.register(
     _ColorStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="color",
         node_name="color",
         classes=(str,),
@@ -254,7 +254,7 @@ registry.register(
 registry.register(
     _ColorStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="color_mode",
         node_name="colorMode",
         classes=(ColorMode,),
@@ -526,7 +526,7 @@ class IconStyle(_ColorStyle):
 registry.register(
     IconStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="scale",
         node_name="scale",
         classes=(float,),
@@ -538,7 +538,7 @@ registry.register(
 registry.register(
     IconStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="heading",
         node_name="heading",
         classes=(float,),
@@ -550,7 +550,7 @@ registry.register(
 registry.register(
     IconStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="icon",
         node_name="Icon",
         classes=(Icon,),
@@ -561,7 +561,7 @@ registry.register(
 registry.register(
     IconStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="hot_spot",
         node_name="hotSpot",
         classes=(HotSpot,),
@@ -659,7 +659,7 @@ class LineStyle(_ColorStyle):
 registry.register(
     LineStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="width",
         node_name="width",
         classes=(float,),
@@ -768,7 +768,7 @@ class PolyStyle(_ColorStyle):
 registry.register(
     PolyStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="fill",
         node_name="fill",
         classes=(bool,),
@@ -780,7 +780,7 @@ registry.register(
 registry.register(
     PolyStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="outline",
         node_name="outline",
         classes=(bool,),
@@ -882,7 +882,7 @@ class LabelStyle(_ColorStyle):
 registry.register(
     LabelStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="scale",
         node_name="scale",
         classes=(float,),
@@ -1034,7 +1034,7 @@ class BalloonStyle(_BaseObject):
 registry.register(
     BalloonStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="bg_color",
         node_name="bgColor",
         classes=(str,),
@@ -1046,7 +1046,7 @@ registry.register(
 registry.register(
     BalloonStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="text_color",
         node_name="textColor",
         classes=(str,),
@@ -1058,7 +1058,7 @@ registry.register(
 registry.register(
     BalloonStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="text",
         node_name="text",
         classes=(str,),
@@ -1069,7 +1069,7 @@ registry.register(
 registry.register(
     BalloonStyle,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="display_mode",
         node_name="displayMode",
         classes=(DisplayMode,),
@@ -1161,7 +1161,7 @@ class Style(_StyleSelector):
 registry.register(
     Style,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="styles",
         node_name="Style",
         classes=(
@@ -1271,7 +1271,7 @@ class Pair(_BaseObject):
 registry.register(
     Pair,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="key",
         node_name="key",
         classes=(PairKey,),
@@ -1282,7 +1282,7 @@ registry.register(
 registry.register(
     Pair,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="style",
         node_name="Style",
         classes=(
@@ -1404,7 +1404,7 @@ class StyleMap(_StyleSelector):
 registry.register(
     StyleMap,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="pairs",
         node_name="Pair",
         classes=(Pair,),

--- a/fastkml/views.py
+++ b/fastkml/views.py
@@ -153,7 +153,7 @@ class _AbstractView(TimeMixin, _BaseObject):
 registry.register(
     _AbstractView,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="longitude",
         node_name="longitude",
         classes=(float,),
@@ -165,7 +165,7 @@ registry.register(
 registry.register(
     _AbstractView,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="latitude",
         node_name="latitude",
         classes=(float,),
@@ -177,7 +177,7 @@ registry.register(
 registry.register(
     _AbstractView,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="altitude",
         node_name="altitude",
         classes=(float,),
@@ -189,7 +189,7 @@ registry.register(
 registry.register(
     _AbstractView,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="heading",
         node_name="heading",
         classes=(float,),
@@ -201,7 +201,7 @@ registry.register(
 registry.register(
     _AbstractView,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="tilt",
         node_name="tilt",
         classes=(float,),
@@ -317,7 +317,7 @@ class Camera(_AbstractView):
 registry.register(
     Camera,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="roll",
         node_name="roll",
         classes=(float,),
@@ -432,7 +432,7 @@ class LookAt(_AbstractView):
 registry.register(
     LookAt,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="range",
         node_name="range",
         classes=(float,),
@@ -554,7 +554,7 @@ class LatLonAltBox(_XMLObject):
 registry.register(
     LatLonAltBox,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="north",
         node_name="north",
         classes=(float,),
@@ -565,7 +565,7 @@ registry.register(
 registry.register(
     LatLonAltBox,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="south",
         node_name="south",
         classes=(float,),
@@ -576,7 +576,7 @@ registry.register(
 registry.register(
     LatLonAltBox,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="east",
         node_name="east",
         classes=(float,),
@@ -587,7 +587,7 @@ registry.register(
 registry.register(
     LatLonAltBox,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="west",
         node_name="west",
         classes=(float,),
@@ -598,7 +598,7 @@ registry.register(
 registry.register(
     LatLonAltBox,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="min_altitude",
         node_name="minAltitude",
         classes=(float,),
@@ -610,7 +610,7 @@ registry.register(
 registry.register(
     LatLonAltBox,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="max_altitude",
         node_name="maxAltitude",
         classes=(float,),
@@ -716,7 +716,7 @@ class Lod(_XMLObject):
 registry.register(
     Lod,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="min_lod_pixels",
         node_name="minLodPixels",
         classes=(float,),
@@ -728,7 +728,7 @@ registry.register(
 registry.register(
     Lod,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="max_lod_pixels",
         node_name="maxLodPixels",
         classes=(float,),
@@ -740,7 +740,7 @@ registry.register(
 registry.register(
     Lod,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="min_fade_extent",
         node_name="minFadeExtent",
         classes=(float,),
@@ -752,7 +752,7 @@ registry.register(
 registry.register(
     Lod,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="max_fade_extent",
         node_name="maxFadeExtent",
         classes=(float,),
@@ -852,7 +852,7 @@ class Region(_BaseObject):
 registry.register(
     Region,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="lat_lon_alt_box",
         node_name="LatLonAltBox",
         classes=(LatLonAltBox,),
@@ -863,7 +863,7 @@ registry.register(
 registry.register(
     Region,
     RegistryItem(
-        ns_ids=("kml",),
+        ns_ids=("kml", ""),
         attr_name="lod",
         node_name="Lod",
         classes=(Lod,),

--- a/tests/hypothesis/feature_test.py
+++ b/tests/hypothesis/feature_test.py
@@ -445,7 +445,7 @@ class TestLxml(Lxml):
             link=st.builds(fastkml.Link, href=urls()),
         ),
     )
-    def fuzz_placemark_model(
+    def test_fuzz_placemark_model(
         self,
         model: fastkml.model.Model,
     ) -> None:

--- a/tests/hypothesis/feature_test.py
+++ b/tests/hypothesis/feature_test.py
@@ -29,6 +29,7 @@ import fastkml.enums
 import fastkml.features
 import fastkml.gx
 import fastkml.links
+import fastkml.model
 import fastkml.styles
 import fastkml.views
 from tests.base import Lxml
@@ -412,6 +413,44 @@ class TestLxml(Lxml):
         placemark = fastkml.Placemark(
             style_url=style_url,
             styles=styles,
+        )
+
+        assert_repr_roundtrip(placemark)
+        assert_str_roundtrip(placemark)
+        assert_str_roundtrip_terse(placemark)
+        assert_str_roundtrip_verbose(placemark)
+
+    @given(
+        model=st.builds(
+            fastkml.model.Model,
+            altitude_mode=st.sampled_from(fastkml.enums.AltitudeMode),
+            location=st.builds(
+                fastkml.model.Location,
+                latitude=st.floats(
+                    allow_nan=False,
+                    allow_infinity=False,
+                    min_value=-90,
+                    max_value=90,
+                ).filter(lambda x: x != 0),
+                longitude=st.floats(
+                    allow_nan=False,
+                    allow_infinity=False,
+                    min_value=-180,
+                    max_value=180,
+                ).filter(lambda x: x != 0),
+                altitude=st.floats(allow_nan=False, allow_infinity=False).filter(
+                    lambda x: x != 0,
+                ),
+            ),
+            link=st.builds(fastkml.Link, href=urls()),
+        ),
+    )
+    def fuzz_placemark_model(
+        self,
+        model: fastkml.model.Model,
+    ) -> None:
+        placemark = fastkml.Placemark(
+            kml_geometry=model,
         )
 
         assert_repr_roundtrip(placemark)

--- a/tests/hypothesis/model_test.py
+++ b/tests/hypothesis/model_test.py
@@ -1,0 +1,288 @@
+# Copyright (C) 2024  Christian Ledermann
+#
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+"""Hypothesis tests for the fastkml.model module."""
+
+import typing
+
+from hypothesis import given
+from hypothesis import strategies as st
+from hypothesis.provisional import urls
+
+import fastkml
+import fastkml.enums
+import fastkml.links
+import fastkml.model
+from tests.base import Lxml
+from tests.hypothesis.common import assert_repr_roundtrip
+from tests.hypothesis.common import assert_str_roundtrip
+from tests.hypothesis.common import assert_str_roundtrip_terse
+from tests.hypothesis.common import assert_str_roundtrip_verbose
+from tests.hypothesis.strategies import nc_name
+
+
+class TestLxml(Lxml):
+    @given(
+        altitude=st.one_of(
+            st.none(),
+            st.just(0.0),
+            st.floats(allow_nan=False, allow_infinity=False).filter(lambda x: x != 0),
+        ),
+        latitude=st.one_of(
+            st.none(),
+            st.just(0.0),
+            st.floats(
+                allow_nan=False,
+                allow_infinity=False,
+                min_value=-90,
+                max_value=90,
+            ),
+        ),
+        longitude=st.one_of(
+            st.none(),
+            st.just(0.0),
+            st.floats(
+                allow_nan=False,
+                allow_infinity=False,
+                min_value=-180,
+                max_value=180,
+            ),
+        ),
+    )
+    def test_fuzz_location(
+        self,
+        altitude: typing.Optional[float],
+        latitude: typing.Optional[float],
+        longitude: typing.Optional[float],
+    ) -> None:
+        location = fastkml.model.Location(
+            altitude=altitude,
+            latitude=latitude,
+            longitude=longitude,
+        )
+
+        assert_repr_roundtrip(location)
+        assert_str_roundtrip(location)
+        assert_str_roundtrip_terse(location)
+        assert_str_roundtrip_verbose(location)
+
+    @given(
+        heading=st.one_of(
+            st.none(),
+            st.just(0.0),
+            st.floats(
+                allow_nan=False,
+                allow_infinity=False,
+                min_value=-360,
+                max_value=360,
+            ).filter(lambda x: x != 0),
+        ),
+        tilt=st.one_of(
+            st.none(),
+            st.just(0.0),
+            st.floats(
+                allow_nan=False,
+                allow_infinity=False,
+                min_value=0,
+                max_value=180,
+            ).filter(lambda x: x != 0),
+        ),
+        roll=st.one_of(
+            st.none(),
+            st.just(0.0),
+            st.floats(
+                allow_nan=False,
+                allow_infinity=False,
+                min_value=-180,
+                max_value=180,
+            ).filter(lambda x: x != 0),
+        ),
+    )
+    def test_fuzz_orientation(
+        self,
+        heading: typing.Optional[float],
+        tilt: typing.Optional[float],
+        roll: typing.Optional[float],
+    ) -> None:
+        orientation = fastkml.model.Orientation(heading=heading, tilt=tilt, roll=roll)
+
+        assert_repr_roundtrip(orientation)
+        assert_str_roundtrip(orientation)
+        assert_str_roundtrip_terse(orientation)
+        assert_str_roundtrip_verbose(orientation)
+
+    @given(
+        x=st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False)),
+        y=st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False)),
+        z=st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False)),
+    )
+    def test_fuzz_scale(
+        self,
+        x: typing.Optional[float],
+        y: typing.Optional[float],
+        z: typing.Optional[float],
+    ) -> None:
+        scale = fastkml.model.Scale(x=x, y=y, z=z)
+
+        assert_repr_roundtrip(scale)
+        assert_str_roundtrip(scale)
+        assert_str_roundtrip_terse(scale)
+        assert_str_roundtrip_verbose(scale)
+
+    @given(
+        target_href=st.one_of(st.none(), urls()),
+        source_href=st.one_of(st.none(), urls()),
+    )
+    def test_fuzz_alias(
+        self,
+        target_href: typing.Optional[str],
+        source_href: typing.Optional[str],
+    ) -> None:
+        alias = fastkml.model.Alias(target_href=target_href, source_href=source_href)
+
+        assert_repr_roundtrip(alias)
+        assert_str_roundtrip(alias)
+        assert_str_roundtrip_terse(alias)
+        assert_str_roundtrip_verbose(alias)
+
+    @given(
+        aliases=st.one_of(
+            st.none(),
+            st.lists(
+                st.builds(
+                    fastkml.model.Alias,
+                    source_href=urls(),
+                    target_href=urls(),
+                ),
+            ),
+        ),
+    )
+    def test_fuzz_resource_map(
+        self,
+        aliases: typing.Optional[typing.Iterable[fastkml.model.Alias]],
+    ) -> None:
+        resource_map = fastkml.model.ResourceMap(aliases=aliases)
+
+        assert_repr_roundtrip(resource_map)
+        assert_str_roundtrip(resource_map)
+        assert_str_roundtrip_terse(resource_map)
+        assert_str_roundtrip_verbose(resource_map)
+
+    @given(
+        id=st.one_of(st.none(), nc_name()),
+        target_id=st.one_of(st.none(), nc_name()),
+        altitude_mode=st.one_of(st.none(), st.sampled_from(fastkml.enums.AltitudeMode)),
+        location=st.one_of(
+            st.none(),
+            st.builds(
+                fastkml.model.Location,
+                altitude=st.floats(allow_nan=False, allow_infinity=False).filter(
+                    lambda x: x != 0,
+                ),
+                latitude=st.floats(
+                    allow_nan=False,
+                    allow_infinity=False,
+                    min_value=-90,
+                    max_value=90,
+                ),
+                longitude=st.floats(
+                    allow_nan=False,
+                    allow_infinity=False,
+                    min_value=-180,
+                    max_value=180,
+                ),
+            ),
+        ),
+        orientation=st.one_of(
+            st.none(),
+            st.builds(
+                fastkml.model.Orientation,
+                heading=st.floats(
+                    allow_nan=False,
+                    allow_infinity=False,
+                    min_value=-360,
+                    max_value=360,
+                ).filter(lambda x: x != 0),
+                tilt=st.floats(
+                    allow_nan=False,
+                    allow_infinity=False,
+                    min_value=0,
+                    max_value=180,
+                ).filter(lambda x: x != 0),
+                roll=st.floats(
+                    allow_nan=False,
+                    allow_infinity=False,
+                    min_value=-180,
+                    max_value=180,
+                ).filter(lambda x: x != 0),
+            ),
+        ),
+        scale=st.one_of(
+            st.none(),
+            st.builds(
+                fastkml.model.Scale,
+                x=st.floats(allow_nan=False, allow_infinity=False).filter(
+                    lambda x: x != 0,
+                ),
+                y=st.floats(allow_nan=False, allow_infinity=False).filter(
+                    lambda x: x != 0,
+                ),
+                z=st.floats(allow_nan=False, allow_infinity=False).filter(
+                    lambda x: x != 0,
+                ),
+            ),
+        ),
+        link=st.one_of(st.none(), st.builds(fastkml.Link, href=urls())),
+        resource_map=st.one_of(
+            st.none(),
+            st.builds(
+                fastkml.model.ResourceMap,
+                aliases=st.lists(
+                    st.builds(
+                        fastkml.model.Alias,
+                        source_href=urls(),
+                        target_href=urls(),
+                    ),
+                    min_size=1,
+                ),
+            ),
+        ),
+    )
+    def test_fuzz_model(
+        self,
+        id: typing.Optional[str],
+        target_id: typing.Optional[str],
+        altitude_mode: typing.Optional[fastkml.enums.AltitudeMode],
+        location: typing.Optional[fastkml.model.Location],
+        orientation: typing.Optional[fastkml.model.Orientation],
+        scale: typing.Optional[fastkml.model.Scale],
+        link: typing.Optional[fastkml.Link],
+        resource_map: typing.Optional[fastkml.model.ResourceMap],
+    ) -> None:
+        model = fastkml.model.Model(
+            id=id,
+            target_id=target_id,
+            altitude_mode=altitude_mode,
+            location=location,
+            orientation=orientation,
+            scale=scale,
+            link=link,
+            resource_map=resource_map,
+        )
+
+        assert_repr_roundtrip(model)
+        assert_str_roundtrip(model)
+        assert_str_roundtrip_terse(model)
+        assert_str_roundtrip_verbose(model)

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -99,6 +99,31 @@ class TestModel(StdLibrary):
         assert model.geometry is None
         assert not model
 
+    def test_from_string_invalid_location(self) -> None:
+        doc = (
+            '<Model xmlns="http://www.opengis.net/kml/2.2">'
+            "<altitudeMode>absolute</altitudeMode>"
+            "<Location>"
+            "<longitude></longitude>"
+            "<latitude>49.279804095564</latitude>"
+            "<altitude>21.614010375743</altitude>"
+            "</Location>"
+            "<Scale><x>1</x><y>1</y><z>1</z></Scale>"
+            "<Link><href>http://barcelona.galdos.local/files/PublicLibrary.dae</href></Link>"
+            '<ResourceMap id="map01">'
+            "<Alias>"
+            "<targetHref>http://barcelona.galdos.local/images/Concrete2.jpg</targetHref>"
+            "<sourceHref>../images/Concrete.jpg</sourceHref>"
+            "</Alias>"
+            "</ResourceMap>"
+            "</Model>"
+        )
+
+        model = fastkml.model.Model.from_string(doc)
+        assert model.altitude_mode == AltitudeMode.absolute
+        assert model.geometry is None
+        assert not model
+
 
 class TestModelLxml(TestModel, Lxml):
     pass

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2021 - 2023  Christian Ledermann
+#
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+
+"""Test the kml overlay classes."""
+
+from pygeoif.geometry import Point
+
+import fastkml.links
+import fastkml.model
+from fastkml.enums import AltitudeMode
+from tests.base import Lxml
+from tests.base import StdLibrary
+
+
+class TestModel(StdLibrary):
+    def test_from_string(self) -> None:
+        doc = (
+            '<Model xmlns="http://www.opengis.net/kml/2.2">'
+            "<altitudeMode>absolute</altitudeMode>"
+            "<Location>"
+            "<longitude>-123.115776547816</longitude>"
+            "<latitude>49.279804095564</latitude>"
+            "<altitude>21.614010375743</altitude>"
+            "</Location>"
+            "<Scale><x>1</x><y>1</y><z>1</z></Scale>"
+            "<Link><href>http://barcelona.galdos.local/files/PublicLibrary.dae</href></Link>"
+            '<ResourceMap id="map01">'
+            "<Alias>"
+            "<targetHref>http://barcelona.galdos.local/images/Concrete2.jpg</targetHref>"
+            "<sourceHref>../images/Concrete.jpg</sourceHref>"
+            "</Alias>"
+            "</ResourceMap>"
+            "</Model>"
+        )
+
+        model = fastkml.model.Model.from_string(doc)
+        assert model.altitude_mode == AltitudeMode.absolute
+        assert model.geometry == Point(
+            -123.115776547816,
+            49.279804095564,
+            21.614010375743,
+        )
+        assert model == fastkml.model.Model(
+            altitude_mode=AltitudeMode.absolute,
+            location=fastkml.model.Location(
+                altitude=21.614010375743,
+                latitude=49.279804095564,
+                longitude=-123.115776547816,
+            ),
+            orientation=None,
+            scale=fastkml.model.Scale(
+                x=1.0,
+                y=1.0,
+                z=1.0,
+            ),
+            link=fastkml.links.Link(
+                href="http://barcelona.galdos.local/files/PublicLibrary.dae",
+            ),
+            resource_map=fastkml.model.ResourceMap(
+                aliases=[
+                    fastkml.model.Alias(
+                        target_href="http://barcelona.galdos.local/images/Concrete2.jpg",
+                        source_href="../images/Concrete.jpg",
+                    ),
+                ],
+            ),
+        )
+
+
+class TestModelLxml(TestModel, Lxml):
+    pass

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -47,6 +47,7 @@ class TestModel(StdLibrary):
         )
 
         model = fastkml.model.Model.from_string(doc)
+
         assert model.altitude_mode == AltitudeMode.absolute
         assert model.geometry == Point(
             -123.115776547816,
@@ -95,6 +96,7 @@ class TestModel(StdLibrary):
         )
 
         model = fastkml.model.Model.from_string(doc)
+
         assert model.altitude_mode == AltitudeMode.absolute
         assert model.geometry is None
         assert not model
@@ -120,9 +122,26 @@ class TestModel(StdLibrary):
         )
 
         model = fastkml.model.Model.from_string(doc)
+
         assert model.altitude_mode == AltitudeMode.absolute
         assert model.geometry is None
         assert not model
+
+    def test_location_from_string_invalid_location(self) -> None:
+        doc = (
+            '<Location xmlns="http://www.opengis.net/kml/2.2">'
+            "<longitude></longitude>"
+            "<latitude>49.279804095564</latitude>"
+            "<altitude>21.614010375743</altitude>"
+            "</Location>"
+        )
+
+        location = fastkml.model.Location.from_string(doc)
+
+        assert location.altitude == 21.614010375743
+        assert location.latitude == 49.279804095564
+        assert location.geometry is None
+        assert not location
 
 
 class TestModelLxml(TestModel, Lxml):

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -79,6 +79,26 @@ class TestModel(StdLibrary):
             ),
         )
 
+    def test_from_string_no_location(self) -> None:
+        doc = (
+            '<Model xmlns="http://www.opengis.net/kml/2.2">'
+            "<altitudeMode>absolute</altitudeMode>"
+            "<Scale><x>1</x><y>1</y><z>1</z></Scale>"
+            "<Link><href>http://barcelona.galdos.local/files/PublicLibrary.dae</href></Link>"
+            '<ResourceMap id="map01">'
+            "<Alias>"
+            "<targetHref>http://barcelona.galdos.local/images/Concrete2.jpg</targetHref>"
+            "<sourceHref>../images/Concrete.jpg</sourceHref>"
+            "</Alias>"
+            "</ResourceMap>"
+            "</Model>"
+        )
+
+        model = fastkml.model.Model.from_string(doc)
+        assert model.altitude_mode == AltitudeMode.absolute
+        assert model.geometry is None
+        assert not model
+
 
 class TestModelLxml(TestModel, Lxml):
     pass

--- a/tests/overlays_test.py
+++ b/tests/overlays_test.py
@@ -14,7 +14,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 
-"""Test the kml classes."""
+"""Test the kml overlay classes."""
 
 import contextlib
 


### PR DESCRIPTION
### **User description**
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1KThsGOSIG4AyAk6i5Y5lXDUgKUzFXU%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=lPuKUsV)


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Introduced a new `Model` class and associated classes (`Location`, `Orientation`, `Scale`, `Alias`, `ResourceMap`) for handling KML 3D models.
- Added hypothesis tests for the new `fastkml.model` module and integrated `Model` into existing tests.
- Updated documentation to include the new `fastkml.model` module and its components.
- Allowed parsing of KML files without namespace declarations by permitting empty strings in namespace identifiers.
- Updated changelog to reflect new features and enhancements for version 1.1.0.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>model.py</strong><dd><code>Add KML Model and associated classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/model.py

<li>Added new <code>Model</code> class for KML 3D models.<br> <li> Implemented associated classes like <code>Location</code>, <code>Orientation</code>, <code>Scale</code>, <br><code>Alias</code>, and <code>ResourceMap</code>.<br> <li> Registered new classes in the KML registry.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-eea6bb2678d2a80df9f8a100f4a593ee58f6e3a7efc438171c9878a00f054202">+539/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>containers.py</strong><dd><code>Allow empty string in KML namespace identifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/containers.py

- Allowed empty string in KML namespace identifiers.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-738931297f80e440cd189073efb0323af2ac936d1eed3f2dd130b44fa79fa003">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>data.py</strong><dd><code>Allow empty string in KML namespace identifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/data.py

- Allowed empty string in KML namespace identifiers.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-75b88feeb935943fd77fa8d3cf174304b93e3830a00abfc48fcc99c69234c072">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>features.py</strong><dd><code>Update KML namespace and geometry types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/features.py

<li>Allowed empty string in KML namespace identifiers.<br> <li> Added <code>Model</code> to <code>KmlGeometry</code> union.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-00a3c2aa0b823504cfb27c3ddc29f807d2542e48259b8f219a673393e6fa2c5c">+21/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>geometry.py</strong><dd><code>Allow empty string in KML namespace identifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/geometry.py

- Allowed empty string in KML namespace identifiers.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-47314ad0817fc0fdde5a4ccab1250d104c27d592f1dd0f9952b454a4e3cdf65d">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kml.py</strong><dd><code>Allow empty string in KML namespace identifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/kml.py

- Allowed empty string in KML namespace identifiers.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-613ee78b8f0776d39e81909e8b514a8053b408d2dc58eb0830deb146a8e12141">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>links.py</strong><dd><code>Allow empty string in KML namespace identifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/links.py

- Allowed empty string in KML namespace identifiers.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-0b382a33ea64ee81cc0b4f4cea9ec48a225b0490c252ab0829d8da61d2907dd9">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>overlays.py</strong><dd><code>Allow empty string in KML namespace identifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/overlays.py

- Allowed empty string in KML namespace identifiers.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-53d4a4402d4b36ba24c38b2494214f2940433d433946065052596dbd37cc3565">+29/-29</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>styles.py</strong><dd><code>Allow empty string in KML namespace identifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/styles.py

- Allowed empty string in KML namespace identifiers.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-15dc029e50660bd7626ff50b07d669f6c6e61e0017e795aa718d8c52c27716db">+19/-19</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>model_test.py</strong><dd><code>Add hypothesis tests for KML Model module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/hypothesis/model_test.py

<li>Added hypothesis tests for <code>fastkml.model</code> module.<br> <li> Tested <code>Location</code>, <code>Orientation</code>, <code>Scale</code>, <code>Alias</code>, <code>ResourceMap</code>, and <code>Model</code> <br>classes.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-6a720d19666a26507e96425da5f1d96c1332cd17c50fc7bd23dcb2350b210e6b">+288/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>feature_test.py</strong><dd><code>Add hypothesis test for Placemark with Model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/hypothesis/feature_test.py

- Added hypothesis test for `Placemark` with `Model` geometry.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-1a3ffb55b84adb9f62f9c241c630e3fc68f3af6bd1439b060d5838b4f6d42c3a">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>HISTORY.rst</strong><dd><code>Update changelog for version 1.1.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/HISTORY.rst

<li>Updated changelog for version 1.1.0.<br> <li> Documented support for ScreenOverlay and Model.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-98d733cee70f992558257d7aa263bc1c61465ae908831dddea5cac41954ab543">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fastkml.rst</strong><dd><code>Document fastkml.model module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/fastkml.rst

- Added documentation for `fastkml.model` module.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-dfca2dc06783f88351ca6d052b724da0ee1adde3e7e31e3595313821d8d138fc">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>working_with_kml.rst</strong><dd><code>Update namespace identifiers in examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/working_with_kml.rst

- Updated namespace identifiers in code examples.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-bda647e32e5df4a58dd8174b4b6f8c4931392926b4a581650772b6afe9ea5531">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>_typos.toml</strong><dd><code>Add ignore identifiers for KML namespace typos</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

_typos.toml

- Added ignore identifiers for typos in KML namespace.



</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/397/files#diff-e936c0fb5ab3dfb5a78d7e9b66fba7bada4187148866402e8cb2b585b5fc5799">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for `ScreenOverlay` and `Model` in KML.
  - Added the ability to parse KML files without namespace declarations.
  - New classes for handling KML model elements, including `Location`, `Orientation`, `Scale`, `Alias`, `ResourceMap`, and `Model`.
  - Enhanced functionality for retrieving styles and managing KML geometries.

- **Documentation**
  - Updated changelog to reflect new version `1.1.0`.
  - Enhanced documentation for working with KML files, including new examples and clarifications.
  - Added a new section for `fastkml.model` in the documentation.
  - Updated README for clarity and additional references.

- **Bug Fixes**
  - Corrected example data in KML documentation.

- **Tests**
  - Added new tests for `fastkml.model` components using Hypothesis for property-based testing.
  - Introduced a new test method for `fastkml.Placemark` focusing on the `kml_geometry` attribute.
  - Expanded test suite for KML overlay classes, including validation for invalid location data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `Model` class for KML 3D models, updates namespace parsing, and adds tests and documentation.
> 
>   - **New Features**:
>     - Added `Model` class and related classes (`Location`, `Orientation`, `Scale`, `Alias`, `ResourceMap`) in `model.py` for KML 3D models.
>     - Allowed parsing of KML files without namespace declarations in `containers.py`, `data.py`, and `features.py`.
>   - **Tests**:
>     - Added hypothesis tests for `fastkml.model` in `model_test.py`.
>     - Added test for `Placemark` with `Model` geometry in `feature_test.py`.
>   - **Documentation**:
>     - Updated `HISTORY.rst` for version 1.1.0.
>     - Documented `fastkml.model` module in `fastkml.rst`.
>     - Updated examples in `working_with_kml.rst`.
>   - **Misc**:
>     - Added ignore identifiers for KML namespace typos in `_typos.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cleder%2Ffastkml&utm_source=github&utm_medium=referral)<sup> for abcc0d9d96d4367515febd1b99cb4f8dd5003bb6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->