### PR TITLE
390 network link control

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -6,6 +6,7 @@ Changelog
 
 - Add support for ScreenOverlay and Model.
 - allow parsing kml files without namespace declarations.
+- Add support for NetworkLinkControl. [Apurva Banka]
 
 
 1.0 (2024/11/19)

--- a/docs/network.kml
+++ b/docs/network.kml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:xal="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0"
+  hint="A processing hint for a KML consumer">
+    <NetworkLinkControl>
+      <minRefreshPeriod>43200</minRefreshPeriod>
+      <maxSessionLength>-1</maxSessionLength>
+      <linkSnippet>
+      <![CDATA[
+      <p xmlns="http://www.w3.org/1999/xhtml">A snippet of <a href="http://www.w3.org/TR/xhtml-basic/">XHTML</a></p>
+      ]]>
+      </linkSnippet>
+      <expires>2008-05-30</expires>
+    </NetworkLinkControl>
+</kml>

--- a/fastkml/__init__.py
+++ b/fastkml/__init__.py
@@ -58,6 +58,7 @@ from fastkml.model import Model
 from fastkml.model import Orientation
 from fastkml.model import ResourceMap
 from fastkml.model import Scale
+from fastkml.network_link_control import NetworkLinkControl
 from fastkml.overlays import GroundOverlay
 from fastkml.overlays import ImagePyramid
 from fastkml.overlays import LatLonBox
@@ -119,6 +120,7 @@ __all__ = [
     "Model",
     "MultiGeometry",
     "NetworkLink",
+    "NetworkLinkControl",
     "Orientation",
     "OuterBoundaryIs",
     "OverlayXY",

--- a/fastkml/kml.py
+++ b/fastkml/kml.py
@@ -45,13 +45,13 @@ from fastkml import config
 from fastkml import validator
 from fastkml.base import _XMLObject
 from fastkml.containers import Document
-from fastkml.network_link_control import NetworkLinkControl
 from fastkml.containers import Folder
 from fastkml.enums import Verbosity
 from fastkml.features import NetworkLink
 from fastkml.features import Placemark
 from fastkml.helpers import xml_subelement_list
 from fastkml.helpers import xml_subelement_list_kwarg
+from fastkml.network_link_control import NetworkLinkControl
 from fastkml.overlays import GroundOverlay
 from fastkml.overlays import PhotoOverlay
 from fastkml.registry import RegistryItem
@@ -61,13 +61,13 @@ from fastkml.types import Element
 logger = logging.getLogger(__name__)
 
 kml_children = Union[
-                Folder,
-                Document,
-                Placemark,
-                GroundOverlay,
-                PhotoOverlay,
-                NetworkLinkControl,
-            ]
+    Folder,
+    Document,
+    Placemark,
+    GroundOverlay,
+    PhotoOverlay,
+    NetworkLinkControl,
+]
 
 
 def lxml_parse_and_validate(

--- a/fastkml/kml.py
+++ b/fastkml/kml.py
@@ -45,6 +45,7 @@ from fastkml import config
 from fastkml import validator
 from fastkml.base import _XMLObject
 from fastkml.containers import Document
+from fastkml.network_link_control import NetworkLinkControl
 from fastkml.containers import Folder
 from fastkml.enums import Verbosity
 from fastkml.features import NetworkLink
@@ -59,7 +60,14 @@ from fastkml.types import Element
 
 logger = logging.getLogger(__name__)
 
-kml_children = Union[Folder, Document, Placemark, GroundOverlay, PhotoOverlay]
+kml_children = Union[
+                Folder,
+                Document,
+                Placemark,
+                GroundOverlay,
+                PhotoOverlay,
+                NetworkLinkControl,
+            ]
 
 
 def lxml_parse_and_validate(
@@ -285,9 +293,20 @@ class KML(_XMLObject):
 registry.register(
     KML,
     RegistryItem(
-        ns_ids=("kml", ""),
-        classes=(Document, Folder, Placemark, GroundOverlay, PhotoOverlay, NetworkLink),
-        node_name="Document,Folder,Placemark,GroundOverlay,PhotoOverlay,NetworkLink",
+        ns_ids=("kml",),
+        classes=(
+            Document,
+            Folder,
+            Placemark,
+            GroundOverlay,
+            PhotoOverlay,
+            NetworkLink,
+            NetworkLinkControl,
+        ),
+        node_name=(
+            "Document,Folder,Placemark,GroundOverlay,PhotoOverlay,NetworkLink,"
+            "NetworkLinkControl"
+        ),
         attr_name="features",
         get_kwarg=xml_subelement_list_kwarg,
         set_element=xml_subelement_list,

--- a/fastkml/network_link_control.py
+++ b/fastkml/network_link_control.py
@@ -1,0 +1,219 @@
+# Copyright (C) 2012-2024 Christian Ledermann
+#
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+import logging
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Union
+
+from fastkml import config
+from fastkml.base import _XMLObject
+from fastkml.helpers import datetime_subelement
+from fastkml.helpers import datetime_subelement_kwarg
+from fastkml.helpers import float_subelement
+from fastkml.helpers import subelement_float_kwarg
+from fastkml.helpers import subelement_text_kwarg
+from fastkml.helpers import text_subelement
+from fastkml.helpers import xml_subelement
+from fastkml.helpers import xml_subelement_kwarg
+from fastkml.registry import RegistryItem
+from fastkml.registry import registry
+from fastkml.times import KmlDateTime
+from fastkml.views import Camera
+from fastkml.views import LookAt
+
+__all__ = [
+    "NetworkLinkControl",
+]
+
+logger = logging.getLogger(__name__)
+
+
+class NetworkLinkControl(_XMLObject):
+
+    _default_nsid = config.KML
+
+    min_refresh_period: Optional[float]
+    max_session_length: Optional[float]
+    cookie: Optional[str]
+    message: Optional[str]
+    link_name: Optional[str]
+    link_description: Optional[str]
+    link_snippet: Optional[str]
+    expires: Optional[KmlDateTime]
+    view: Union[Camera, LookAt, None]  # TODO: Add Update field to the parameters
+
+    def __init__(
+        self,
+        ns: Optional[str] = None,
+        name_spaces: Optional[Dict[str, str]] = None,
+        min_refresh_period: Optional[float] = None,
+        max_session_length: Optional[float] = None,
+        cookie: Optional[str] = None,
+        message: Optional[str] = None,
+        link_name: Optional[str] = None,
+        link_description: Optional[str] = None,
+        link_snippet: Optional[str] = None,
+        expires: Optional[KmlDateTime] = None,
+        view: Optional[Union[Camera, LookAt]] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            ns=ns,
+            name_spaces=name_spaces,
+            min_refresh_period=min_refresh_period,
+            max_session_length=max_session_length,
+            cookie=cookie,
+            message=message,
+            link_name=link_name,
+            link_description=link_description,
+            link_snippet=link_snippet,
+            expires=expires,
+            view=view,
+            **kwargs,
+        )
+
+    def __repr__(self) -> str:
+        """
+        Return a string representation of the NetworkLinkControl object.
+
+        Returns
+        -------
+            str: A string representation of the NetworkLinkControl object.
+
+        """
+        return (
+            f"{self.__class__.__module__}.{self.__class__.__name__}("
+            f"ns={self.ns!r}, "
+            f"name_spaces={self.name_spaces!r}, "
+            f"min_refresh_period={self.min_refresh_period!r}, "
+            f"max_session_length={self.max_session_length!r}, "
+            f"cookie={self.cookie!r}, "
+            f"message={self.message!r}, "
+            f"link_name={self.link_name!r}, "
+            f"link_description={self.link_description!r}, "
+            f"link_snippet={self.link_snippet!r}, "
+            f"expires={self.expires!r}, "
+            f"view={self.view!r}, "
+            f"**{self._get_splat()!r},"
+            ")"
+        )
+
+
+registry.register(
+    NetworkLinkControl,
+    RegistryItem(
+        ns_ids=("kml",),
+        attr_name="min_refresh_period",
+        node_name="minRefreshPeriod",
+        classes=(float,),
+        get_kwarg=subelement_float_kwarg,
+        set_element=float_subelement,
+        default=0,
+    ),
+)
+registry.register(
+    NetworkLinkControl,
+    RegistryItem(
+        ns_ids=("kml",),
+        attr_name="max_session_length",
+        node_name="maxSessionLength",
+        classes=(float,),
+        get_kwarg=subelement_float_kwarg,
+        set_element=float_subelement,
+        default=-1,
+    ),
+)
+registry.register(
+    NetworkLinkControl,
+    RegistryItem(
+        ns_ids=("kml",),
+        attr_name="cookie",
+        node_name="cookie",
+        classes=(str,),
+        get_kwarg=subelement_text_kwarg,
+        set_element=text_subelement,
+    ),
+)
+registry.register(
+    NetworkLinkControl,
+    RegistryItem(
+        ns_ids=("kml",),
+        attr_name="message",
+        node_name="message",
+        classes=(str,),
+        get_kwarg=subelement_text_kwarg,
+        set_element=text_subelement,
+    ),
+)
+registry.register(
+    NetworkLinkControl,
+    RegistryItem(
+        ns_ids=("kml",),
+        attr_name="link_name",
+        node_name="linkName",
+        classes=(str,),
+        get_kwarg=subelement_text_kwarg,
+        set_element=text_subelement,
+    ),
+)
+registry.register(
+    NetworkLinkControl,
+    RegistryItem(
+        ns_ids=("kml",),
+        attr_name="link_description",
+        node_name="linkDescription",
+        classes=(str,),
+        get_kwarg=subelement_text_kwarg,
+        set_element=text_subelement,
+    ),
+)
+registry.register(
+    NetworkLinkControl,
+    RegistryItem(
+        ns_ids=("kml",),
+        attr_name="link_snippet",
+        node_name="linkSnippet",
+        classes=(str,),
+        get_kwarg=subelement_text_kwarg,
+        set_element=text_subelement,
+    ),
+)
+registry.register(
+    NetworkLinkControl,
+    item=RegistryItem(
+        ns_ids=("kml", ),
+        classes=(KmlDateTime,),
+        attr_name="expires",
+        node_name="expires",
+        get_kwarg=datetime_subelement_kwarg,
+        set_element=datetime_subelement,
+    ),
+)
+registry.register(
+    NetworkLinkControl,
+    RegistryItem(
+        ns_ids=("kml",),
+        attr_name="view",
+        node_name="Camera,LookAt",
+        classes=(
+            Camera,
+            LookAt,
+        ),
+        get_kwarg=xml_subelement_kwarg,
+        set_element=xml_subelement,
+    ),
+)

--- a/fastkml/network_link_control.py
+++ b/fastkml/network_link_control.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2024 Christian Ledermann
+# Copyright (C) 2024 Christian Ledermann
 #
 # This library is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free
@@ -13,6 +13,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+"""
+NetworkLinkControl class.
+
+Controls the behavior of files fetched by a <NetworkLink>.
+
+https://developers.google.com/kml/documentation/kmlreference#networklinkcontrol
+"""
+
 import logging
 from typing import Any
 from typing import Dict
@@ -21,6 +29,7 @@ from typing import Union
 
 from fastkml import config
 from fastkml.base import _XMLObject
+from fastkml.helpers import clean_string
 from fastkml.helpers import datetime_subelement
 from fastkml.helpers import datetime_subelement_kwarg
 from fastkml.helpers import float_subelement
@@ -43,6 +52,7 @@ logger = logging.getLogger(__name__)
 
 
 class NetworkLinkControl(_XMLObject):
+    """Controls the behavior of files fetched by a <NetworkLink>."""
 
     _default_nsid = config.KML
 
@@ -54,7 +64,7 @@ class NetworkLinkControl(_XMLObject):
     link_description: Optional[str]
     link_snippet: Optional[str]
     expires: Optional[KmlDateTime]
-    view: Union[Camera, LookAt, None]  # TODO: Add Update field to the parameters
+    view: Union[Camera, LookAt, None]
 
     def __init__(
         self,
@@ -71,20 +81,52 @@ class NetworkLinkControl(_XMLObject):
         view: Optional[Union[Camera, LookAt]] = None,
         **kwargs: Any,
     ) -> None:
+        """
+        Create a NetworkLinkControl object.
+
+        Parameters
+        ----------
+        ns : str, optional
+            The namespace to use for the NetworkLinkControl object.
+        name_spaces : dict, optional
+            A dictionary of namespaces to use for the NetworkLinkControl object.
+        min_refresh_period : float, optional
+            The minimum number of seconds between fetches. A value of -1 indicates that
+            the NetworkLinkControl object should be fetched only once.
+        max_session_length : float, optional
+            The maximum number of seconds that the link should be followed.
+        cookie : str, optional
+            A string value that can be used to identify the client request.
+        message : str, optional
+            A message to be displayed to the user in case of a failure.
+        link_name : str, optional
+            The name of the link.
+        link_description : str, optional
+            A description of the link.
+        link_snippet : str, optional
+            A snippet of text to be displayed in the link.
+        expires : KmlDateTime, optional
+            The time at which the link should expire.
+        view : Camera or LookAt, optional
+            The view to be used when the link is followed.
+        **kwargs : Any, optional
+            Additional keyword arguments.
+
+        """
         super().__init__(
             ns=ns,
             name_spaces=name_spaces,
-            min_refresh_period=min_refresh_period,
-            max_session_length=max_session_length,
-            cookie=cookie,
-            message=message,
-            link_name=link_name,
-            link_description=link_description,
-            link_snippet=link_snippet,
-            expires=expires,
-            view=view,
             **kwargs,
         )
+        self.min_refresh_period = min_refresh_period
+        self.max_session_length = max_session_length
+        self.cookie = clean_string(cookie)
+        self.message = clean_string(message)
+        self.link_name = clean_string(link_name)
+        self.link_description = clean_string(link_description)
+        self.link_snippet = clean_string(link_snippet)
+        self.expires = expires
+        self.view = view
 
     def __repr__(self) -> str:
         """
@@ -195,7 +237,7 @@ registry.register(
 registry.register(
     NetworkLinkControl,
     item=RegistryItem(
-        ns_ids=("kml", ),
+        ns_ids=("kml",),
         classes=(KmlDateTime,),
         attr_name="expires",
         node_name="expires",

--- a/tests/hypothesis/network_link_control_test.py
+++ b/tests/hypothesis/network_link_control_test.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2024  Christian Ledermann
+#
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+"""Hypothesis tests for the fastkml.network_link_control module."""
+
+import typing
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+import fastkml
+import fastkml.enums
+import fastkml.model
+import fastkml.views
+from tests.base import Lxml
+from tests.hypothesis.common import assert_repr_roundtrip
+from tests.hypothesis.common import assert_str_roundtrip
+from tests.hypothesis.common import assert_str_roundtrip_terse
+from tests.hypothesis.common import assert_str_roundtrip_verbose
+from tests.hypothesis.strategies import kml_datetimes
+from tests.hypothesis.strategies import xml_text
+
+
+class TestLxml(Lxml):
+    @given(
+        min_refresh_period=st.one_of(
+            st.none(),
+            st.floats(allow_nan=False, allow_infinity=False).filter(lambda x: x != 0),
+        ),
+        max_session_length=st.one_of(
+            st.none(),
+            st.floats(allow_nan=False, allow_infinity=False).filter(lambda x: x != -1),
+        ),
+        cookie=st.one_of(st.none(), xml_text()),
+        message=st.one_of(st.none(), xml_text()),
+        link_name=st.one_of(st.none(), xml_text()),
+        link_description=st.one_of(st.none(), xml_text()),
+        link_snippet=st.one_of(st.none(), xml_text()),
+        expires=st.one_of(
+            st.none(),
+            kml_datetimes(),
+        ),
+        view=st.one_of(
+            st.none(),
+            st.builds(
+                fastkml.views.Camera,
+                longitude=st.floats(
+                    allow_nan=False,
+                    allow_infinity=False,
+                    min_value=-180,
+                    max_value=180,
+                ).filter(lambda x: x != 0),
+                latitude=st.floats(
+                    allow_nan=False,
+                    allow_infinity=False,
+                    min_value=-90,
+                    max_value=90,
+                ).filter(lambda x: x != 0),
+                altitude=st.floats(allow_nan=False, allow_infinity=False).filter(
+                    lambda x: x != 0,
+                ),
+            ),
+            st.builds(
+                fastkml.views.LookAt,
+                longitude=st.floats(
+                    allow_nan=False,
+                    allow_infinity=False,
+                    min_value=-180,
+                    max_value=180,
+                ).filter(lambda x: x != 0),
+                latitude=st.floats(
+                    allow_nan=False,
+                    allow_infinity=False,
+                    min_value=-90,
+                    max_value=90,
+                ).filter(lambda x: x != 0),
+                altitude=st.floats(allow_nan=False, allow_infinity=False).filter(
+                    lambda x: x != 0,
+                ),
+            ),
+        ),
+    )
+    def test_fuzz_network_link_control(
+        self,
+        min_refresh_period: typing.Optional[float],
+        max_session_length: typing.Optional[float],
+        cookie: typing.Optional[str],
+        message: typing.Optional[str],
+        link_name: typing.Optional[str],
+        link_description: typing.Optional[str],
+        link_snippet: typing.Optional[str],
+        expires: typing.Optional[fastkml.KmlDateTime],
+        view: typing.Union[fastkml.Camera, fastkml.LookAt, None],
+    ) -> None:
+        nlc = fastkml.NetworkLinkControl(
+            min_refresh_period=min_refresh_period,
+            max_session_length=max_session_length,
+            cookie=cookie,
+            message=message,
+            link_name=link_name,
+            link_description=link_description,
+            link_snippet=link_snippet,
+            expires=expires,
+            view=view,
+        )
+
+        assert_repr_roundtrip(nlc)
+        assert_str_roundtrip(nlc)
+        assert_str_roundtrip_terse(nlc)
+        assert_str_roundtrip_verbose(nlc)

--- a/tests/network_link_control_test.py
+++ b/tests/network_link_control_test.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2021 - 2022  Christian Ledermann
+#
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+
+"""Test the Network Link Control classes."""
+
+import datetime
+
+from fastkml.network_link_control import NetworkLinkControl
+from fastkml.times import KmlDateTime
+from tests.base import StdLibrary
+from fastkml import views
+
+
+class TestStdLibrary(StdLibrary):
+    """Test with the standard library."""
+
+    def test_network_link_control_obj(self) -> None:
+        dt = datetime.datetime.now()
+        kml_datetime = KmlDateTime(dt=dt)
+        view = views.Camera()
+
+        network_control_obj = NetworkLinkControl(
+            min_refresh_period=1.1,
+            max_session_length=100.1,
+            cookie="cookie",
+            message="message",
+            link_name="link_name",
+            link_description="link_description",
+            link_snippet="link_snippet",
+            expires=kml_datetime,
+            view=view
+        )
+
+        assert network_control_obj.min_refresh_period == 1.1
+        assert network_control_obj.max_session_length == 100.1
+        assert network_control_obj.cookie == "cookie"
+        assert network_control_obj.message == "message"
+        assert network_control_obj.link_name == "link_name"
+        assert network_control_obj.link_description == "link_description"
+        assert network_control_obj.link_snippet == "link_snippet"
+        assert str(network_control_obj.expires) == str(kml_datetime)
+        assert str(network_control_obj.view) == str(view)
+
+    def test_network_link_control_kml(self) -> None:
+        doc = (
+            '<kml:NetworkLinkControl xmlns:kml="http://www.opengis.net/kml/2.2">'
+            "<kml:minRefreshPeriod>432000</kml:minRefreshPeriod>"
+            "<kml:maxSessionLength>-1</kml:maxSessionLength>"
+            "<kml:linkSnippet>A Snippet</kml:linkSnippet>"
+            "<kml:expires>2008-05-30</kml:expires>"
+            "</kml:NetworkLinkControl>"
+        )
+
+        nc = NetworkLinkControl.from_string(doc)
+
+        dt = datetime.date(2008, 5, 30)
+        kml_datetime = KmlDateTime(dt=dt)
+
+        nc_obj = NetworkLinkControl(
+            min_refresh_period=432000,
+            max_session_length=-1,
+            link_snippet="A Snippet",
+            expires=kml_datetime,
+        )
+
+        assert nc == nc_obj

--- a/tests/network_link_control_test.py
+++ b/tests/network_link_control_test.py
@@ -18,17 +18,19 @@
 
 import datetime
 
+from dateutil.tz import tzutc
+
+from fastkml import views
 from fastkml.network_link_control import NetworkLinkControl
 from fastkml.times import KmlDateTime
 from tests.base import StdLibrary
-from fastkml import views
 
 
 class TestStdLibrary(StdLibrary):
     """Test with the standard library."""
 
     def test_network_link_control_obj(self) -> None:
-        dt = datetime.datetime.now()
+        dt = datetime.datetime.now(tz=tzutc())
         kml_datetime = KmlDateTime(dt=dt)
         view = views.Camera()
 
@@ -41,7 +43,7 @@ class TestStdLibrary(StdLibrary):
             link_description="link_description",
             link_snippet="link_snippet",
             expires=kml_datetime,
-            view=view
+            view=view,
         )
 
         assert network_control_obj.min_refresh_period == 1.1


### PR DESCRIPTION
### **User description**
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1zo0AVMsilAsTx6t7mmudrFqBY79wA9m8%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=ZRm--2g)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Implemented the `NetworkLinkControl` class to manage network link behaviors in KML files.
- Integrated `NetworkLinkControl` into the KML module, including import and registry updates.
- Added comprehensive tests for `NetworkLinkControl` using both Hypothesis and standard testing methods.
- Provided a KML example file demonstrating the usage of `NetworkLinkControl`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Add NetworkLinkControl import and export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/__init__.py

<li>Added import for <code>NetworkLinkControl</code>.<br> <li> Included <code>NetworkLinkControl</code> in the list of exported symbols.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/398/files#diff-3629e121239e3f7c6ac52604b011106bd7d417fc59a153d5b3d677bbaf7b7653">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kml.py</strong><dd><code>Integrate NetworkLinkControl into KML module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/kml.py

<li>Imported <code>NetworkLinkControl</code>.<br> <li> Added <code>NetworkLinkControl</code> to <code>kml_children</code> union type.<br> <li> Registered <code>NetworkLinkControl</code> in the KML registry.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/398/files#diff-613ee78b8f0776d39e81909e8b514a8053b408d2dc58eb0830deb146a8e12141">+23/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>network_link_control.py</strong><dd><code>Implement NetworkLinkControl class with XML handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/network_link_control.py

<li>Created <code>NetworkLinkControl</code> class with various attributes.<br> <li> Implemented methods for XML serialization and deserialization.<br> <li> Registered <code>NetworkLinkControl</code> attributes in the registry.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/398/files#diff-a1f0144f852873c43333cf9c251486b149024f35c4c59ba6d034a4ab8035b43e">+261/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_link_control_test.py</strong><dd><code>Add Hypothesis tests for NetworkLinkControl</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/hypothesis/network_link_control_test.py

<li>Added Hypothesis tests for <code>NetworkLinkControl</code>.<br> <li> Tested various attributes and their serialization.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/398/files#diff-8551b9cbf62320cceb0c577d20d41e219f0980c4ecc9994a7fa5c21f7268824b">+122/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>network_link_control_test.py</strong><dd><code>Add standard tests for NetworkLinkControl functionality</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/network_link_control_test.py

<li>Added standard library tests for <code>NetworkLinkControl</code>.<br> <li> Verified object creation and XML parsing.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/398/files#diff-24d06fbe476ee02851957e7f58bbad7b2a9c5b29d47d53877b2464251e71c6df">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network.kml</strong><dd><code>Provide KML example for NetworkLinkControl</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/network.kml

<li>Added KML example for <code>NetworkLinkControl</code>.<br> <li> Demonstrated XML structure and attributes.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/398/files#diff-e79a111f68b0377b90df069563d1e6a04e5bdfd0c7b41c5b01127446c0dfc996">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new KML file for network link control, enhancing the management of KML network links.
	- Added the `NetworkLinkControl` class for better handling of network link behaviors and attributes.
	- Enhanced support for `ScreenOverlay` and `Model` in KML files.

- **Bug Fixes**
	- Improved the KML registry to recognize and manage the new `NetworkLinkControl` feature.

- **Tests**
	- Added comprehensive unit tests and hypothesis-based tests for the `NetworkLinkControl` class to ensure functionality and reliability.

- **Documentation**
	- Updated changelog to reflect new features and improvements in version 1.1.0 (unreleased).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `NetworkLinkControl` class for managing KML network link behaviors, integrates it into the KML module, and adds comprehensive tests and documentation.
> 
>   - **New Features**:
>     - Implemented `NetworkLinkControl` class in `network_link_control.py` for managing network link behaviors in KML files.
>     - Integrated `NetworkLinkControl` into `kml.py`, updating `kml_children` union type and KML registry.
>     - Added import and export for `NetworkLinkControl` in `__init__.py`.
>   - **Tests**:
>     - Added Hypothesis tests in `hypothesis/network_link_control_test.py` for `NetworkLinkControl` attributes and serialization.
>     - Added standard tests in `network_link_control_test.py` for object creation and XML parsing.
>   - **Documentation**:
>     - Added `docs/network.kml` as a KML example demonstrating `NetworkLinkControl` usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cleder%2Ffastkml&utm_source=github&utm_medium=referral)<sup> for 453ccfe17410ac90fef2a7177736c52900282351. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->