### PR TITLE
Fix: change base class of `SimpleArrayData` from `_XMLObject` to `_BaseObject`

### DIFF
--- a/fastkml/containers.py
+++ b/fastkml/containers.py
@@ -316,8 +316,8 @@ class Document(_Container):
 
         """
         id_ = urlparse.urlparse(style_url).fragment
-        return next(
-            find_all(  # type: ignore[arg-type]
+        return next(  # type: ignore[return-value]
+            find_all(
                 self,
                 of_type=(Style, StyleMap),
                 id=id_,

--- a/fastkml/gx/data.py
+++ b/fastkml/gx/data.py
@@ -34,6 +34,7 @@ from fastkml.helpers import subelement_text_list_kwarg
 from fastkml.helpers import text_attribute
 from fastkml.helpers import text_subelement_kml
 from fastkml.helpers import text_subelement_list
+from fastkml.kml_base import _BaseObject
 from fastkml.registry import RegistryItem
 from fastkml.registry import registry
 
@@ -171,7 +172,7 @@ registry.register(
 )
 
 
-class SimpleArrayData(_XMLObject):
+class SimpleArrayData(_BaseObject):
     """
     A SimpleArrayData element.
 
@@ -188,29 +189,56 @@ class SimpleArrayData(_XMLObject):
         self,
         ns: Optional[str] = None,
         name_spaces: Optional[Dict[str, str]] = None,
+        id: Optional[str] = None,
+        target_id: Optional[str] = None,
         name: Optional[str] = None,
         data: Optional[Iterable[str]] = None,
+        **kwargs: Any,
     ) -> None:
         """
-        Create a SimpleArrayData element.
+        Initialize a new instance of the SimpleArrayData class.
 
         Args:
-            ns: The namespace to use.
-            name_spaces: A dictionary of namespace prefixes to namespace URIs.
-            name: The name of the element.
-            data: A list of string values.
+        ----
+            ns (Optional[str]): The namespace for the data.
+            name_spaces (Optional[Dict[str, str]]):
+                The dictionary of namespace prefixes and URIs.
+            id (Optional[str]): The ID of the data.
+            target_id (Optional[str]): The target ID of the data.
+            name (Optional[str]): The name of the object.
+            data (Optional[Iterable[str]]): The iterable of values.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+        -------
+            None
 
         """
-        super().__init__(ns=ns, name_spaces=name_spaces)
+        super().__init__(
+            ns=ns,
+            name_spaces=name_spaces,
+            id=id,
+            target_id=target_id,
+            **kwargs,
+        )
         self.data = [clean_string(d) for d in data] if data is not None else []
         self.name = clean_string(name)
 
     def __repr__(self) -> str:
-        """Create a string representation for SimpleArrayData."""
+        """
+        Return a string representation of the SimpleArrayData object.
+
+        Returns
+        -------
+            str: The string representation of the SimpleArrayData object.
+
+        """
         return (
             f"{self.__class__.__module__}.{self.__class__.__name__}("
             f"ns={self.ns!r}, "
             f"name_spaces={self.name_spaces!r}, "
+            f"id={self.id!r}, "
+            f"target_id={self.target_id!r}, "
             f"name={self.name!r}, "
             f"data={self.data!r}, "
             f"**{self._get_splat()!r},"
@@ -218,7 +246,14 @@ class SimpleArrayData(_XMLObject):
         )
 
     def __bool__(self) -> bool:
-        """Check if the element is named and has any data."""
+        """
+        Check if the object is considered True or False.
+
+        Returns
+        -------
+            bool: True if both the name and data are non-empty, False otherwise.
+
+        """
         return bool(self.data) and bool(self.name)
 
 

--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -61,8 +61,8 @@ class TestStdLibrary(StdLibrary):
             "name": "Integer",
             "display_name": "An Integer",
         }
-        s.fields = [data.SimpleField(**fields)]
-        assert s.fields[0] == data.SimpleField(**fields)
+        s.fields = [data.SimpleField(**fields)]  # type: ignore[arg-type]
+        assert s.fields[0] == data.SimpleField(**fields)  # type: ignore[arg-type]
 
     def test_schema_from_string(self) -> None:
         doc = """<Schema name="TrailHeadType" id="TrailHeadTypeId"

--- a/tests/gx/data_test.py
+++ b/tests/gx/data_test.py
@@ -61,8 +61,8 @@ class TestStdLibrary(StdLibrary):
             "name": "Integer",
             "display_name": "An Integer",
         }
-        s.array_fields = [SimpleArrayField(**fields)]
-        assert s.array_fields[0] == SimpleArrayField(**fields)
+        s.array_fields = [SimpleArrayField(**fields)]  # type: ignore[arg-type]
+        assert s.array_fields[0] == SimpleArrayField(**fields)  # type: ignore[arg-type]
 
     def test_schema_from_string(self) -> None:
         doc = """    <Schema id="schema"

--- a/tests/hypothesis/common.py
+++ b/tests/hypothesis/common.py
@@ -20,6 +20,7 @@ import logging
 
 from dateutil.tz import tzfile
 from dateutil.tz import tzutc
+from dateutil.tz import tzwin
 from pygeoif import GeometryCollection
 from pygeoif import MultiLineString
 from pygeoif import MultiPoint
@@ -74,6 +75,7 @@ eval_locals = {
     "Shape": Shape,
     "tzutc": tzutc,
     "tzfile": tzfile,
+    "tzwin": tzwin,
 }
 
 

--- a/tests/hypothesis/gx/data_test.py
+++ b/tests/hypothesis/gx/data_test.py
@@ -29,20 +29,27 @@ from tests.hypothesis.common import assert_repr_roundtrip
 from tests.hypothesis.common import assert_str_roundtrip
 from tests.hypothesis.common import assert_str_roundtrip_terse
 from tests.hypothesis.common import assert_str_roundtrip_verbose
+from tests.hypothesis.strategies import nc_name
 from tests.hypothesis.strategies import xml_text
 
 
 class TestLxml(Lxml):
     @given(
+        id=st.one_of(st.none(), nc_name()),
+        target_id=st.one_of(st.none(), nc_name()),
         name=st.one_of(st.none(), xml_text()),
         data=st.one_of(st.none(), st.lists(xml_text())),
     )
     def test_fuzz_simple_array_data(
         self,
+        id: typing.Optional[str],
+        target_id: typing.Optional[str],
         name: typing.Optional[str],
         data: typing.Optional[typing.Iterable[str]],
     ) -> None:
         simple_array_data = fastkml.gx.data.SimpleArrayData(
+            id=id,
+            target_id=target_id,
             name=name,
             data=data,
         )

--- a/tests/hypothesis/gx/track_test.py
+++ b/tests/hypothesis/gx/track_test.py
@@ -24,7 +24,7 @@ from hypothesis.provisional import urls
 import fastkml
 import fastkml.data
 import fastkml.enums
-import fastkml.gx
+import fastkml.gx.data
 import fastkml.types
 from tests.base import Lxml
 from tests.hypothesis.common import assert_repr_roundtrip
@@ -70,7 +70,7 @@ class TestLxml(Lxml):
                     ),
                     array_data=st.lists(
                         st.builds(
-                            fastkml.data.SimpleArrayData,
+                            fastkml.gx.data.SimpleArrayData,
                             name=xml_text().filter(lambda x: x.strip() != ""),
                             data=st.lists(
                                 xml_text().filter(lambda x: x.strip() != ""),


### PR DESCRIPTION
### **User description**
This change reflects the fact that `gx:SimpleArrayData` extends `kml:AbstractObjectType` in the XSD definition, which corresponds to `_BaseObject` in the codebase.
Also added missing `kwargs` to the constructor.
 Sorry I missed that in the previous pull request!


___

### **PR Type**
Bug fix


___

### **Description**
- Change `SimpleArrayData` base class from `_XMLObject` to `_BaseObject`

- Add missing `id` and `target_id` parameters to constructor

- Update constructor to accept `**kwargs` parameter

- Enhance docstrings and method documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_XMLObject"] -- "inheritance fix" --> B["_BaseObject"]
  C["SimpleArrayData"] -- "inherits from" --> B
  D["Constructor"] -- "add parameters" --> E["id, target_id, **kwargs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data.py</strong><dd><code>Fix inheritance and constructor parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/gx/data.py

<ul><li>Changed <code>SimpleArrayData</code> base class from <code>_XMLObject</code> to <code>_BaseObject</code><br> <li> Added <code>id</code> and <code>target_id</code> parameters to constructor<br> <li> Added <code>**kwargs</code> parameter handling<br> <li> Enhanced docstrings with proper formatting and type hints</ul>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/445/files#diff-fbc57e29efecedc93ac51f70eb22f973ea5f891150c9a8fef5ca776b029c3c45">+44/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_test.py</strong><dd><code>Update tests for new constructor parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/hypothesis/gx/data_test.py

<ul><li>Added <code>id</code> and <code>target_id</code> parameters to test function<br> <li> Updated test to include new constructor parameters<br> <li> Added import for <code>nc_name</code> strategy</ul>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/445/files#diff-2afd30eceac98e07261aa7b22528845a3c5140315594af6148f1e7c7db595a91">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `SimpleArrayData` base class to `_BaseObject` and update constructor and tests for consistency with XSD definition.
> 
>   - **Class Changes**:
>     - Change base class of `SimpleArrayData` from `_XMLObject` to `_BaseObject` in `data.py`.
>     - Add `kwargs` to `SimpleArrayData` constructor for flexible initialization.
>   - **Testing**:
>     - Update `test_fuzz_simple_array_data` in `data_test.py` to include `id` and `target_id` parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cleder%2Ffastkml&utm_source=github&utm_medium=referral)<sup> for d1a392c4ddde5040144506ca8de3d3ff53ddebc3. You can [customize](https://app.ellipsis.dev/cleder/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

## Summary by Sourcery

Fix inheritance and constructor signature of SimpleArrayData to match the XSD definition and update tests accordingly

Bug Fixes:
- Align SimpleArrayData inheritance by changing its base class to _BaseObject
- Add missing id, target_id, and **kwargs parameters to SimpleArrayData constructor

Enhancements:
- Enhance docstrings for SimpleArrayData __init__, __repr__, and __bool__ methods

Tests:
- Update fuzz tests to include id and target_id parameters and import nc_name strategy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - SimpleArrayData now accepts optional id and target_id fields.
  - String representation includes id and target_id for clearer debugging.

- Documentation
  - Expanded docstrings to cover new fields and clarify boolean behavior.

- Tests
  - Property-based tests updated to generate and validate id and target_id inputs.
  - Test environment extended to support tzwin-based repr evaluations.

- Refactor
  - SimpleArrayData aligned to a new internal base type; import path updated for consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->