### PR TITLE
Fix ambiguous datetime comparison during DST fall back in KmlDateTime

### DIFF
--- a/fastkml/times.py
+++ b/fastkml/times.py
@@ -26,6 +26,7 @@ https://developers.google.com/kml/documentation/time
 import re
 from datetime import date
 from datetime import datetime
+from datetime import timezone
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -174,11 +175,16 @@ class KmlDateTime:
 
     def __eq__(self, other: object) -> bool:
         """Return True if the two objects are equal."""
-        return (
-            self.dt == other.dt and self.resolution == other.resolution
-            if isinstance(other, KmlDateTime)
-            else False
-        )
+        if not isinstance(other, KmlDateTime) or self.resolution != other.resolution:
+            return False
+        if (
+            isinstance(self.dt, datetime)
+            and isinstance(other.dt, datetime)
+            and (self.dt.tzinfo is not None)
+            and (other.dt.tzinfo is not None)
+        ):
+            return self.dt.astimezone(timezone.utc) == other.dt.astimezone(timezone.utc)
+        return self.dt == other.dt
 
     def __str__(self) -> str:
         """Return the KML DateTime string representation of the object."""


### PR DESCRIPTION
### **User description**
The `datetime.__eq__` method considers two `datetime` objects equal if they represent the same point in time, even when their `tzinfo` differs.

However, this behavior changes during the DST fall back period. Unlike its usual behavior, `datetime.__eq__` does not compare UTC-equivalent values during the DST fall back hour. Instead, it treats `datetime`s as equal only if their local times match. This can result in false negatives when comparing across DST and non-DST zones.

example:
```python
dt_has_dst_0 = datetime(2016, 10, 30, 3, 0, tzinfo=dateutil.tz.gettz("Europe/Helsinki"))
dt_has_dst_1 = datetime(2016, 10, 30, 3, 0, tzinfo=dateutil.tz.gettz("Europe/Helsinki"), fold=1)
dt_no_dst = datetime(2016, 10, 30, 3, 0, tzinfo=dateutil.tz.gettz("Etc/GMT-3"))
dt_ofst = datetime(2016, 10, 30, 3, 0, tzinfo=timezone(timedelta(hours=3)))

print(dt_has_dst_0 == dt_has_dst_1) # True
print(dt_has_dst_0 == dt_no_dst) # False
print(dt_has_dst_0 == dt_ofst) # False
print(dt_no_dst == dt_ofst) # True
```

In the context of KML, `datetime`s that are equal in UTC should be treated as equal. To ensure this, we convert both `datetime`s to UTC before performing the comparison when their `tzinfo` are not `None`.

This issue also caused occasional failures in Hypothesis roundtrip tests. With this fix, those tests now pass as expected.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix datetime equality comparison during DST transitions

- Convert timezone-aware datetimes to UTC before comparison

- Resolve false negatives in DST fall back scenarios

- Improve Hypothesis roundtrip test reliability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["KmlDateTime.__eq__"] --> B["Check instance types"]
  B --> C["Both timezone-aware?"]
  C -->|Yes| D["Convert to UTC"]
  C -->|No| E["Direct comparison"]
  D --> F["Compare UTC times"]
  E --> F
  F --> G["Return equality result"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>times.py</strong><dd><code>Enhanced datetime equality with UTC conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/times.py

<ul><li>Import <code>timezone</code> module for UTC conversion<br> <li> Refactor <code>__eq__</code> method with improved logic structure<br> <li> Add UTC conversion for timezone-aware datetime comparisons<br> <li> Maintain backward compatibility for non-timezone cases</ul>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/446/files#diff-d08f0cfb2c0a85d0242f75c5991bd60a29a6b73cf9eaedfe64733b951a5cf162">+11/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `KmlDateTime.__eq__()` to compare `datetime` objects in UTC during DST fall back, resolving false negatives.
> 
>   - **Behavior**:
>     - Fixes `KmlDateTime.__eq__()` to compare `datetime` objects in UTC if both have `tzinfo`, resolving DST fall back issues.
>     - Ensures `datetime` objects are treated as equal if they represent the same UTC time, even with different local times.
>   - **Tests**:
>     - Fix resolves occasional failures in Hypothesis roundtrip tests related to DST transitions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cleder%2Ffastkml&utm_source=github&utm_medium=referral)<sup> for c3071130e9819f7e8e07a75d8a718a65a51c1f2b. You can [customize](https://app.ellipsis.dev/cleder/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected equality checks for timezone-aware timestamps by normalizing comparisons to UTC, preventing false mismatches across different time zones.
  * Preserved existing behavior for naive timestamps and mismatched types, ensuring backward compatibility.

* **Documentation**
  * Clarified behavior of timestamp equality with timezone-aware values to set correct expectations for users handling KML times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->