### PR TITLE
Filter default values in Hypothesis tests and add cases to unit tests

### DIFF
--- a/tests/hypothesis/geometry_test.py
+++ b/tests/hypothesis/geometry_test.py
@@ -17,7 +17,6 @@
 """Property based tests of the Geometry classes."""
 
 import typing
-from functools import partial
 
 from hypothesis import given
 from hypothesis import settings
@@ -56,24 +55,22 @@ kml_geometry = typing.Union[
     fastkml.geometry.Polygon,
 ]
 
-coordinates = partial(
-    given,
-    coords=st.one_of(st.none(), line_coords(srs=epsg4326, min_points=1)),
-)
+coordinates = {
+    "coords": st.one_of(st.none(), line_coords(srs=epsg4326, min_points=1)),
+}
 
-common_geometry = partial(
-    given,
-    id=st.one_of(st.none(), nc_name()),
-    target_id=st.one_of(st.none(), nc_name()),
-    extrude=st.one_of(st.none(), st.booleans()),
-    tessellate=st.one_of(st.none(), st.booleans()),
-    altitude_mode=st.one_of(
+common_geometry = {
+    "id": st.one_of(st.none(), nc_name()),
+    "target_id": st.one_of(st.none(), nc_name()),
+    "extrude": st.one_of(st.none(), st.booleans()),
+    "tessellate": st.one_of(st.none(), st.booleans()),
+    "altitude_mode": st.one_of(
         st.none(),
         st.sampled_from(
             AltitudeMode,
         ),
     ),
-)
+}
 
 
 def _test_repr_roundtrip(geometry: kml_geometry) -> None:
@@ -136,7 +133,7 @@ def _test_geometry_str_roundtrip_verbose(geometry: kml_geometry) -> None:
 
 
 class TestLxml(Lxml):
-    @coordinates()
+    @given(**coordinates)
     @settings(deadline=None)
     def test_coordinates_str_roundtrip(
         self,
@@ -155,7 +152,7 @@ class TestLxml(Lxml):
         assert coordinate.to_string(precision=10) == new_c.to_string(precision=10)
         assert validate(element=new_c.etree_element())
 
-    @coordinates()
+    @given(**coordinates)
     def test_coordinates_repr_roundtrip(
         self,
         coords: typing.Union[
@@ -171,7 +168,8 @@ class TestLxml(Lxml):
         assert coordinate == new_c
         assert validate(element=new_c.etree_element())
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             points(srs=epsg4326),
@@ -196,7 +194,8 @@ class TestLxml(Lxml):
 
         _test_repr_roundtrip(point)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             points(srs=epsg4326),
@@ -221,7 +220,8 @@ class TestLxml(Lxml):
 
         _test_geometry_str_roundtrip(point)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             points(srs=epsg4326),
@@ -246,7 +246,8 @@ class TestLxml(Lxml):
 
         _test_geometry_str_roundtrip_terse(point)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             points(srs=epsg4326),
@@ -271,7 +272,8 @@ class TestLxml(Lxml):
 
         _test_geometry_str_roundtrip_verbose(point)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             line_strings(srs=epsg4326),
@@ -297,7 +299,8 @@ class TestLxml(Lxml):
 
         _test_repr_roundtrip(line)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             line_strings(srs=epsg4326),
@@ -323,7 +326,8 @@ class TestLxml(Lxml):
 
         _test_geometry_str_roundtrip(line)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             line_strings(srs=epsg4326),
@@ -349,7 +353,8 @@ class TestLxml(Lxml):
 
         _test_geometry_str_roundtrip_terse(line)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             line_strings(srs=epsg4326),
@@ -375,7 +380,8 @@ class TestLxml(Lxml):
 
         _test_geometry_str_roundtrip_verbose(line)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             polygons(srs=epsg4326),
@@ -401,7 +407,8 @@ class TestLxml(Lxml):
 
         _test_repr_roundtrip(polygon)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             polygons(srs=epsg4326),
@@ -427,7 +434,8 @@ class TestLxml(Lxml):
 
         _test_geometry_str_roundtrip(polygon)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             polygons(srs=epsg4326),
@@ -453,7 +461,8 @@ class TestLxml(Lxml):
 
         _test_geometry_str_roundtrip_terse(polygon)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             polygons(srs=epsg4326),

--- a/tests/hypothesis/links_test.py
+++ b/tests/hypothesis/links_test.py
@@ -17,7 +17,6 @@
 
 import string
 import typing
-from functools import partial
 
 import pytest
 from hypothesis import given
@@ -35,39 +34,38 @@ from tests.hypothesis.common import assert_str_roundtrip_verbose
 from tests.hypothesis.strategies import nc_name
 from tests.hypothesis.strategies import query_strings
 
-common_link = partial(
-    given,
-    id=st.one_of(st.none(), nc_name()),
-    target_id=st.one_of(st.none(), nc_name()),
-    href=st.one_of(st.none(), urls()),
-    refresh_mode=st.one_of(st.none(), st.sampled_from(fastkml.enums.RefreshMode)),
-    refresh_interval=st.one_of(
+common_link = {
+    "id": st.one_of(st.none(), nc_name()),
+    "target_id": st.one_of(st.none(), nc_name()),
+    "href": st.one_of(st.none(), urls()),
+    "refresh_mode": st.one_of(st.none(), st.sampled_from(fastkml.enums.RefreshMode)),
+    "refresh_interval": st.one_of(
         st.none(),
         st.floats(allow_infinity=False, allow_nan=False),
     ),
-    view_refresh_mode=st.one_of(
+    "view_refresh_mode": st.one_of(
         st.none(),
         st.sampled_from(fastkml.enums.ViewRefreshMode),
     ),
-    view_refresh_time=st.one_of(
+    "view_refresh_time": st.one_of(
         st.none(),
         st.floats(allow_infinity=False, allow_nan=False),
     ),
-    view_bound_scale=st.one_of(
+    "view_bound_scale": st.one_of(
         st.none(),
         st.floats(allow_infinity=False, allow_nan=False),
     ),
-    view_format=st.one_of(
+    "view_format": st.one_of(
         st.none(),
         st.text(string.ascii_letters + string.punctuation),
     ),
-    http_query=st.one_of(st.none(), query_strings()),
-)
+    "http_query": st.one_of(st.none(), query_strings()),
+}
 
 
 class TestLxml(Lxml):
     @pytest.mark.parametrize("cls", [fastkml.Link, fastkml.Icon])
-    @common_link()
+    @given(**common_link)
     def test_fuzz_link(
         self,
         cls: typing.Union[typing.Type[fastkml.Link], typing.Type[fastkml.Icon]],

--- a/tests/hypothesis/model_test.py
+++ b/tests/hypothesis/model_test.py
@@ -234,13 +234,13 @@ class TestLxml(Lxml):
             st.builds(
                 fastkml.model.Scale,
                 x=st.floats(allow_nan=False, allow_infinity=False).filter(
-                    lambda x: x != 0,
+                    lambda x: x != 1.0,
                 ),
                 y=st.floats(allow_nan=False, allow_infinity=False).filter(
-                    lambda x: x != 0,
+                    lambda x: x != 1.0,
                 ),
                 z=st.floats(allow_nan=False, allow_infinity=False).filter(
-                    lambda x: x != 0,
+                    lambda x: x != 1.0,
                 ),
             ),
         ),

--- a/tests/hypothesis/multi_geometry_test.py
+++ b/tests/hypothesis/multi_geometry_test.py
@@ -18,8 +18,6 @@
 
 from __future__ import annotations
 
-from functools import partial
-
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
@@ -58,17 +56,16 @@ eval_locals = {
 }
 
 
-common_geometry = partial(
-    given,
-    id=st.one_of(st.none(), nc_name()),
-    target_id=st.one_of(st.none(), nc_name()),
-    extrude=st.one_of(st.none(), st.booleans()),
-    tessellate=st.one_of(st.none(), st.booleans()),
-    altitude_mode=st.one_of(
+common_geometry = {
+    "id": st.one_of(st.none(), nc_name()),
+    "target_id": st.one_of(st.none(), nc_name()),
+    "extrude": st.one_of(st.none(), st.booleans()),
+    "tessellate": st.one_of(st.none(), st.booleans()),
+    "altitude_mode": st.one_of(
         st.none(),
         st.sampled_from(AltitudeMode),
     ),
-)
+}
 
 
 def _test_repr_roundtrip(
@@ -188,7 +185,8 @@ def _test_geometry_str_roundtrip_verbose(
 class TestLxml(Lxml):
     """Validation requires lxml."""
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             multi_points(srs=epsg4326),
@@ -215,7 +213,8 @@ class TestLxml(Lxml):
 
         _test_repr_roundtrip(multi_geometry, MultiPoint)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             multi_points(srs=epsg4326),
@@ -247,7 +246,8 @@ class TestLxml(Lxml):
             altitude_mode=altitude_mode,
         )
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             multi_points(srs=epsg4326),
@@ -279,7 +279,8 @@ class TestLxml(Lxml):
             altitude_mode=altitude_mode,
         )
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             multi_points(srs=epsg4326),
@@ -311,7 +312,8 @@ class TestLxml(Lxml):
             altitude_mode=altitude_mode,
         )
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             multi_line_strings(srs=epsg4326),
@@ -337,7 +339,8 @@ class TestLxml(Lxml):
 
         _test_repr_roundtrip(multi_geometry, MultiLineString)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             multi_line_strings(srs=epsg4326),
@@ -369,7 +372,8 @@ class TestLxml(Lxml):
             altitude_mode=altitude_mode,
         )
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             multi_line_strings(srs=epsg4326),
@@ -401,7 +405,8 @@ class TestLxml(Lxml):
             altitude_mode=altitude_mode,
         )
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             multi_line_strings(srs=epsg4326),
@@ -433,7 +438,8 @@ class TestLxml(Lxml):
             altitude_mode=altitude_mode,
         )
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             multi_polygons(srs=epsg4326),
@@ -459,7 +465,8 @@ class TestLxml(Lxml):
 
         _test_repr_roundtrip(multi_geometry, MultiPolygon)
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             multi_polygons(srs=epsg4326),
@@ -491,7 +498,8 @@ class TestLxml(Lxml):
             altitude_mode=altitude_mode,
         )
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             multi_polygons(srs=epsg4326),
@@ -523,7 +531,8 @@ class TestLxml(Lxml):
             altitude_mode=altitude_mode,
         )
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             multi_polygons(srs=epsg4326),
@@ -555,7 +564,8 @@ class TestLxml(Lxml):
             altitude_mode=altitude_mode,
         )
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             geometry_collections(srs=epsg4326),
@@ -590,7 +600,8 @@ class TestLxml(Lxml):
         else:
             assert not new_mg
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             geometry_collections(srs=epsg4326),
@@ -626,7 +637,8 @@ class TestLxml(Lxml):
         else:
             assert not new_mg
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             geometry_collections(srs=epsg4326),
@@ -662,7 +674,8 @@ class TestLxml(Lxml):
         else:
             assert not new_mg
 
-    @common_geometry(
+    @given(
+        **common_geometry,
         geometry=st.one_of(
             st.none(),
             geometry_collections(srs=epsg4326),

--- a/tests/hypothesis/strategies.py
+++ b/tests/hypothesis/strategies.py
@@ -106,7 +106,7 @@ geometries = partial(
 lods = partial(
     st.builds,
     Lod,
-    min_lod_pixels=st.integers(),
+    min_lod_pixels=st.integers().filter(lambda x: x != 256),
     max_lod_pixels=st.integers(),
     min_fade_extent=st.integers(),
     max_fade_extent=st.integers(),
@@ -139,19 +139,19 @@ styles = partial(
     st.one_of,
     st.builds(
         fastkml.styles.LabelStyle,
-        color=kml_colors(),
+        color=kml_colors().filter(lambda x: x != "ffffffff"),
         color_mode=st.sampled_from(fastkml.enums.ColorMode),
         scale=st.floats(allow_nan=False, allow_infinity=False),
     ),
     st.builds(
         fastkml.styles.LineStyle,
-        color=kml_colors(),
+        color=kml_colors().filter(lambda x: x != "ffffffff"),
         color_mode=st.sampled_from(fastkml.enums.ColorMode),
         width=st.floats(allow_nan=False, allow_infinity=False, min_value=0),
     ),
     st.builds(
         fastkml.styles.PolyStyle,
-        color=kml_colors(),
+        color=kml_colors().filter(lambda x: x != "ffffffff"),
         color_mode=st.sampled_from(fastkml.enums.ColorMode),
         fill=st.booleans(),
         outline=st.booleans(),

--- a/tests/hypothesis/style_test.py
+++ b/tests/hypothesis/style_test.py
@@ -288,19 +288,19 @@ class TestLxml(Lxml):
                 ),
                 st.builds(
                     fastkml.styles.LabelStyle,
-                    color=kml_colors(),
+                    color=kml_colors().filter(lambda x: x != "ffffffff"),
                     color_mode=st.sampled_from(fastkml.enums.ColorMode),
                     scale=st.floats(allow_nan=False, allow_infinity=False),
                 ),
                 st.builds(
                     fastkml.styles.LineStyle,
-                    color=kml_colors(),
+                    color=kml_colors().filter(lambda x: x != "ffffffff"),
                     color_mode=st.sampled_from(fastkml.enums.ColorMode),
                     width=st.floats(allow_nan=False, allow_infinity=False, min_value=0),
                 ),
                 st.builds(
                     fastkml.styles.PolyStyle,
-                    color=kml_colors(),
+                    color=kml_colors().filter(lambda x: x != "ffffffff"),
                     color_mode=st.sampled_from(fastkml.enums.ColorMode),
                     fill=st.booleans(),
                     outline=st.booleans(),
@@ -348,19 +348,19 @@ class TestLxml(Lxml):
             st.tuples(
                 st.builds(
                     fastkml.styles.LabelStyle,
-                    color=kml_colors(),
+                    color=kml_colors().filter(lambda x: x != "ffffffff"),
                     color_mode=st.sampled_from(fastkml.enums.ColorMode),
                     scale=st.floats(allow_nan=False, allow_infinity=False),
                 ),
                 st.builds(
                     fastkml.styles.LineStyle,
-                    color=kml_colors(),
+                    color=kml_colors().filter(lambda x: x != "ffffffff"),
                     color_mode=st.sampled_from(fastkml.enums.ColorMode),
                     width=st.floats(allow_nan=False, allow_infinity=False, min_value=0),
                 ),
                 st.builds(
                     fastkml.styles.PolyStyle,
-                    color=kml_colors(),
+                    color=kml_colors().filter(lambda x: x != "ffffffff"),
                     color_mode=st.sampled_from(fastkml.enums.ColorMode),
                     fill=st.booleans(),
                     outline=st.booleans(),

--- a/tests/hypothesis/views_test.py
+++ b/tests/hypothesis/views_test.py
@@ -16,7 +16,6 @@
 """Property-based tests for the views module."""
 
 import typing
-from functools import partial
 
 from hypothesis import given
 from hypothesis import strategies as st
@@ -33,11 +32,10 @@ from tests.hypothesis.strategies import lat_lon_alt_boxes
 from tests.hypothesis.strategies import lods
 from tests.hypothesis.strategies import nc_name
 
-common_view = partial(
-    given,
-    id=st.one_of(st.none(), nc_name()),
-    target_id=st.one_of(st.none(), nc_name()),
-    longitude=st.one_of(
+common_view = {
+    "id": st.one_of(st.none(), nc_name()),
+    "target_id": st.one_of(st.none(), nc_name()),
+    "longitude": st.one_of(
         st.none(),
         st.floats(
             allow_nan=False,
@@ -46,7 +44,7 @@ common_view = partial(
             max_value=180,
         ).filter(lambda x: x != 0),
     ),
-    latitude=st.one_of(
+    "latitude": st.one_of(
         st.none(),
         st.floats(
             allow_nan=False,
@@ -55,20 +53,20 @@ common_view = partial(
             max_value=90,
         ).filter(lambda x: x != 0),
     ),
-    altitude=st.one_of(
+    "altitude": st.one_of(
         st.none(),
         st.floats(allow_nan=False, allow_infinity=False).filter(lambda x: x != 0),
     ),
-    heading=st.one_of(
+    "heading": st.one_of(
         st.none(),
         st.floats(allow_nan=False, allow_infinity=False, min_value=0, max_value=360),
     ),
-    tilt=st.one_of(
+    "tilt": st.one_of(
         st.none(),
         st.floats(allow_nan=False, allow_infinity=False, min_value=0, max_value=180),
     ),
-    altitude_mode=st.one_of(st.none(), st.sampled_from(fastkml.enums.AltitudeMode)),
-)
+    "altitude_mode": st.one_of(st.none(), st.sampled_from(fastkml.enums.AltitudeMode)),
+}
 
 
 class TestLxml(Lxml):
@@ -184,7 +182,8 @@ class TestLxml(Lxml):
         assert_str_roundtrip_terse(region)
         assert_str_roundtrip_verbose(region)
 
-    @common_view(
+    @given(
+        **common_view,
         roll=st.one_of(
             st.none(),
             st.floats(
@@ -224,7 +223,8 @@ class TestLxml(Lxml):
         assert_str_roundtrip_terse(camera)
         assert_str_roundtrip_verbose(camera)
 
-    @common_view(
+    @given(
+        **common_view,
         range=st.one_of(
             st.none(),
             st.floats(allow_nan=False, allow_infinity=False).filter(lambda x: x != 0),

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -21,6 +21,7 @@ from pygeoif.geometry import Point
 import fastkml.links
 import fastkml.model
 from fastkml.enums import AltitudeMode
+from fastkml.enums import Verbosity
 from tests.base import Lxml
 from tests.base import StdLibrary
 
@@ -142,6 +143,15 @@ class TestModel(StdLibrary):
         assert location.latitude == 49.279804095564
         assert location.geometry is None
         assert not location
+
+    def test_scale_to_string_terse_default(self) -> None:
+        scale = fastkml.model.Scale(x=1.0, y=1.0, z=1.0)
+        xml = scale.to_string(verbosity=Verbosity.terse)
+
+        assert "x>1.0</" not in xml
+        assert "y>1.0</" not in xml
+        assert "z>1.0</" not in xml
+        assert not fastkml.model.Scale.from_string(xml)
 
 
 class TestModelLxml(TestModel, Lxml):

--- a/tests/styles_test.py
+++ b/tests/styles_test.py
@@ -25,6 +25,7 @@ from fastkml.enums import ColorMode
 from fastkml.enums import DisplayMode
 from fastkml.enums import PairKey
 from fastkml.enums import Units
+from fastkml.enums import Verbosity
 from fastkml.exceptions import KMLParseError
 from fastkml.features import Placemark
 from tests.base import Lxml
@@ -219,6 +220,21 @@ class TestStdLibrary(StdLibrary):
         assert lines.color_mode == ColorMode.normal
         assert lines.width == 3.0
 
+    def test_line_style_to_string_terse_default(self) -> None:
+        lines = styles.LineStyle(
+            color="ffffffff",
+            color_mode=ColorMode.normal,
+            width=1.0,
+        )
+
+        serialized = lines.to_string(verbosity=Verbosity.terse)
+
+        assert '<kml:LineStyle xmlns:kml="http://www.opengis.net/kml/2.2"' in serialized
+        assert "<kml:color>ff0000ff</kml:color>" not in serialized
+        assert "<kml:colorMode>normal</kml:colorMode>" not in serialized
+        assert "<kml:width>1.0</kml:width>" not in serialized
+        assert not styles.LineStyle.from_string(serialized)
+
     def test_poly_style(self) -> None:
         ps = styles.PolyStyle(
             id="id-0",
@@ -258,6 +274,23 @@ class TestStdLibrary(StdLibrary):
         assert ps.fill == 1
         assert ps.outline == 0
 
+    def test_poly_style_to_string_terse_default(self) -> None:
+        ps = styles.PolyStyle(
+            color="ffffffff",
+            color_mode=ColorMode.normal,
+            fill=True,
+            outline=True,
+        )
+
+        serialized = ps.to_string(verbosity=Verbosity.terse)
+
+        assert '<kml:PolyStyle xmlns:kml="http://www.opengis.net/kml/2.2"' in serialized
+        assert "<kml:color>ffffffff</kml:color>" not in serialized
+        assert "<kml:colorMode>normal</kml:colorMode>" not in serialized
+        assert "<kml:fill>1</kml:fill>" not in serialized
+        assert "<kml:outline>1</kml:outline>" not in serialized
+        assert not styles.PolyStyle.from_string(serialized)
+
     def test_label_style(self) -> None:
         ls = styles.LabelStyle(
             id="id-0",
@@ -294,6 +327,23 @@ class TestStdLibrary(StdLibrary):
         assert ls.color == "ff001122"
         assert ls.color_mode == ColorMode.normal
         assert ls.scale == 2.2
+
+    def test_label_style_to_string_terse_default(self) -> None:
+        ls = styles.LabelStyle(
+            color="ffffffff",
+            color_mode=ColorMode.normal,
+            scale=1.0,
+        )
+
+        serialized = ls.to_string(verbosity=Verbosity.terse)
+
+        assert (
+            '<kml:LabelStyle xmlns:kml="http://www.opengis.net/kml/2.2"' in serialized
+        )
+        assert "<kml:color>ffffffff</kml:color>" not in serialized
+        assert "<kml:colorMode>normal</kml:colorMode>" not in serialized
+        assert "<kml:scale>1.0</kml:scale>" not in serialized
+        assert not styles.LabelStyle.from_string(serialized)
 
     def test_balloon_style(self) -> None:
         bs = styles.BalloonStyle(

--- a/tests/views_test.py
+++ b/tests/views_test.py
@@ -18,6 +18,7 @@
 
 from fastkml import views
 from fastkml.enums import AltitudeMode
+from fastkml.enums import Verbosity
 from tests.base import Lxml
 from tests.base import StdLibrary
 
@@ -200,6 +201,14 @@ class TestStdLibrary(StdLibrary):
         assert not region
         assert region.lat_lon_alt_box == lat_lon_alt_box
         assert region.lod is None
+
+    def test_lod_to_string_terse_default(self) -> None:
+        lod = views.Lod(min_lod_pixels=256, max_lod_pixels=0)
+        xml = lod.to_string(verbosity=Verbosity.terse)
+
+        assert "minLodPixels>256</" not in xml
+        assert "maxLodPixels>0</" in xml
+        assert not views.Lod.from_string(xml)
 
 
 class TestLxml(Lxml, TestStdLibrary):


### PR DESCRIPTION
### **User description**
This PR addresses failures in `assert_str_roundtrip_terse`, where default-valued parameters cause fields to be omitted during `terse` serialization. As a result, deserialization may produce falsy objects, leading to mismatches in roundtrip comparisons.

To resolve this, such default values are now excluded from Hypothesis tests. These cases will be covered separately via unit tests.

The exclusion is already implemented; unit test additions will follow. The PR will be marked ready once complete.

(Edit note)
Added unit tests; PR status changed to ready.

## Summary by Sourcery

Exclude default-valued parameters from Hypothesis test strategies to avoid terse serialization omissions and add unit tests verifying that default-valued fields are omitted in terse outputs for styles, Scale, and Lod

Enhancements:
- Filter out default color ("ffffffff"), default scale (1.0), and default LOD pixel value (256) in Hypothesis strategies to prevent missing fields during terse serialization
- Replace partial-based Hypothesis fixtures with direct `@given(**… )` dictionary unpacking for common parameters across geometry, links, views, and styles tests

Tests:
- Add unit tests confirming that LineStyle, PolyStyle, LabelStyle, Scale, and Lod omit default-valued fields in terse serialization and fail roundtrip deserialization as expected


___

### **PR Type**
Tests


___

### **Description**
- Filter default values from Hypothesis test strategies

- Add unit tests for excluded default parameters

- Replace partial decorators with dict parameters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hypothesis Strategies"] -- "filter defaults" --> B["Filtered Strategies"]
  B -- "prevent terse failures" --> C["Roundtrip Tests"]
  D["Unit Tests"] -- "cover defaults" --> E["Test Coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>geometry_test.py</strong><dd><code>Replace partial decorators with dict parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/447/files#diff-fef1f4e6f2bce9c140d9912c7cd16e73f8f5b17e8abd9a08ed6469202915b7ca">+37/-28</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>links_test.py</strong><dd><code>Replace partial decorators with dict parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/447/files#diff-9e1fc0d88fca6875229f9ca30912193ea214e4bad14ed13ab7c5046bd114c773">+13/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>model_test.py</strong><dd><code>Filter default scale value 1.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/447/files#diff-6a720d19666a26507e96425da5f1d96c1332cd17c50fc7bd23dcb2350b210e6b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>multi_geometry_test.py</strong><dd><code>Replace partial decorators with dict parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/447/files#diff-62429ef5316bba4d85f3d395ed68e6adaf2bfa4bc618ac4ebadc42ca78d6a568">+39/-26</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>strategies.py</strong><dd><code>Filter default values in LOD and style strategies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/447/files#diff-2bc13d8d0ba7f060660ebd59f37698d2143c659f446fd5babb193f5acbb2bf7f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>style_test.py</strong><dd><code>Filter default color value "ffffffff"</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/447/files#diff-45ddcf379343052c8ffdd3e5c375517c8db6623bdc4776b37a69f9945db64731">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>views_test.py</strong><dd><code>Replace partial decorators with dict parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/447/files#diff-c6c5387d38e6a4f757a17ddae8b9fa6946fa0b15e0b463834a55d6c1e662541c">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>model_test.py</strong><dd><code>Add unit test for Scale terse serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/447/files#diff-ec5e6ba9a5558b57712a3baa7487e58322f3973c702502a6f88985b32f3b6756">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>styles_test.py</strong><dd><code>Add unit tests for style terse serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/447/files#diff-112e84824d96441fb93b59e75a836ae39e984cccbef072f27e1447a3a8a5d6a1">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>views_test.py</strong><dd><code>Add unit test for LOD terse serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/447/files#diff-01bcb9ddaccd4454d5d4c996e0dae643a24dae772417ad6430a171989301f982">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exclude default values from Hypothesis tests and add unit tests to handle serialization issues in KML models.
> 
>   - **Behavior**:
>     - Exclude default-valued parameters from Hypothesis test strategies to prevent terse serialization from omitting fields and causing roundtrip assertion failures.
>     - Add unit tests to cover cases with default values.
>   - **Tests**:
>     - Filter out default color value "ffffffff" in `LabelStyle`, `LineStyle`, and `PolyStyle` strategies in `strategies.py`.
>     - Exclude default LOD pixel value 256 in `Lod` strategy in `strategies.py`.
>     - Exclude default scale value 1.0 in `Scale` model strategy in `model_test.py`.
>     - Add unit tests for `Scale`, `LineStyle`, `PolyStyle`, `LabelStyle`, and `Lod` to verify serialization behavior with default values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cleder%2Ffastkml&utm_source=github&utm_medium=referral)<sup> for f561e708a6a205bfaa7eeeddc56ab3a0aed72d60. You can [customize](https://app.ellipsis.dev/cleder/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added coverage for terse serialization of Scale, LineStyle, PolyStyle, LabelStyle, and Lod, ensuring default values are omitted and such XML isn’t parsed back into objects.
  - Tuned data generation: excluded white color (“ffffffff”) for certain styles, filtered out 256 for minimum LOD pixels, and adjusted Scale component constraints.
- Refactor
  - Simplified property-based test setup by switching to dictionary-driven parameterization for multiple test suites, improving readability and consistency.
- Chores
  - Removed unused imports and streamlined test decorators for cleaner test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->