### PR TITLE
Fix typo in a test and add an unit test

### DIFF
--- a/tests/styles_test.py
+++ b/tests/styles_test.py
@@ -230,7 +230,7 @@ class TestStdLibrary(StdLibrary):
         serialized = lines.to_string(verbosity=Verbosity.terse)
 
         assert '<kml:LineStyle xmlns:kml="http://www.opengis.net/kml/2.2"' in serialized
-        assert "<kml:color>ff0000ff</kml:color>" not in serialized
+        assert "<kml:color>ffffffff</kml:color>" not in serialized
         assert "<kml:colorMode>normal</kml:colorMode>" not in serialized
         assert "<kml:width>1.0</kml:width>" not in serialized
         assert not styles.LineStyle.from_string(serialized)

--- a/tests/times_test.py
+++ b/tests/times_test.py
@@ -19,6 +19,7 @@
 import datetime
 
 import pytest
+from dateutil.tz import gettz
 from dateutil.tz import tzoffset
 from dateutil.tz import tzutc
 
@@ -97,6 +98,18 @@ class TestDateTime(StdLibrary):
             match=r"^'NoneType' object has no attribute 'isoformat'$",
         ):
             str(kdt)
+
+    def test_kml_datetime_in_dst_fall_back(self) -> None:
+        dt = datetime.datetime(2016, 10, 30, 3, 30, tzinfo=gettz("Europe/Helsinki"))
+
+        kdt_dst_0 = KmlDateTime(dt)
+        kdt_dst_1 = KmlDateTime(dt.replace(fold=1))
+        kdt_no_dst = KmlDateTime(dt.replace(tzinfo=gettz("Etc/GMT-3")))
+
+        assert kdt_dst_0 != kdt_dst_1
+        assert kdt_dst_0 == kdt_no_dst
+        assert str(kdt_dst_0) != str(kdt_dst_1)
+        assert str(kdt_dst_0) == str(kdt_no_dst)
 
     def test_parse_year(self) -> None:
         dt = KmlDateTime.parse("2000")


### PR DESCRIPTION
This is a follow-up to the previous pull requests (#446, #447).

- Fix typo in assert statement
  The expected value in an assert statement was incorrect. This could have caused a test to pass incorrectly (a false positive) even if there was an error. The assertion has been corrected to work as intended.
- Add unit test for DST fall back
  A new unit test has been added to ensure that datetime equality is handled correctly during the Daylight Saving Time (DST) fall back period.

My apologies for not including these changes in the initial commit. I noticed them upon re-review.

## Summary by Sourcery

Fix a typo in an existing style test and add a new unit test for DST fall back handling in KmlDateTime.

Bug Fixes:
- Correct the expected default color assertion in the LineStyle terse output test from ff0000ff to ffffffff to prevent a false positive.

Tests:
- Add a unit test for DST fall back in KmlDateTime to verify correct equality and string representation across fold and non-DST scenarios.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes a typo in `styles_test.py` and adds a DST fall back unit test in `times_test.py`.
> 
>   - **Tests**:
>     - Fix typo in `test_line_style_to_string_terse_default()` in `styles_test.py`, correcting expected value in assert statement.
>     - Add `test_kml_datetime_in_dst_fall_back()` in `times_test.py` to verify datetime equality during DST fall back period.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=cleder%2Ffastkml&utm_source=github&utm_medium=referral)<sup> for 0f3134ad89ca9d104978644618eba07e1ffd5055. You can [customize](https://app.ellipsis.dev/cleder/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded datetime tests to cover daylight saving time fall-back scenarios, verifying correct handling of ambiguous times and consistent string representations across equivalent timezones.
  - Adjusted color serialization expectations in style-related tests to align with the intended default color output, ensuring accurate validation of terse formatting.
  - Overall, these updates improve test coverage and confidence in time and style formatting behavior without changing any user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->