### PR TITLE
Add `custom_kwargs_getter` support to `_XMLObject._get_kwargs` for multi-namespace handling

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -6,7 +6,7 @@ Changelog
 
 - Improve README [Harshdev625]
 - Fix base class of some classes from _XMLObject to _BaseObject [hirohira9119]
-
+- Add custom_kwargs_getter support for multi-namespace handling [hirohira9119]
 
 1.2.0 (2025/10/01)
 ------------------

--- a/fastkml/__init__.py
+++ b/fastkml/__init__.py
@@ -153,3 +153,7 @@ __all__ = [
     "get_schema_parser",
     "validate",
 ]
+
+from fastkml import _registry_setup
+
+del _registry_setup

--- a/fastkml/_registry_setup.py
+++ b/fastkml/_registry_setup.py
@@ -14,7 +14,7 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 
-"""To avoid circular imports, some element registration is performed here.."""
+"""To avoid circular imports, some element registration is performed here."""
 
 import logging
 

--- a/fastkml/_registry_setup.py
+++ b/fastkml/_registry_setup.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2025 Christian Ledermann
+#
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+
+"""To avoid circular imports, some element registration is performed here.."""
+
+import logging
+
+from fastkml.data import ExtendedData
+from fastkml.gx.track import Track
+from fastkml.helpers import xml_subelement
+from fastkml.helpers import xml_subelement_kwarg
+from fastkml.registry import RegistryItem
+from fastkml.registry import registry
+
+logger = logging.getLogger(__name__)
+
+
+registry.register(
+    Track,
+    RegistryItem(
+        ns_ids=("kml", ""),
+        attr_name="extended_data",
+        node_name="ExtendedData",
+        classes=(ExtendedData,),
+        get_kwarg=xml_subelement_kwarg,
+        set_element=xml_subelement,
+    ),
+)

--- a/fastkml/abstract_geometry.py
+++ b/fastkml/abstract_geometry.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2025 Christian Ledermann
+#
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+"""
+Classes and functions for working with geometries in KML files.
+
+The classes in this module represent different types of geometries, such as points,
+lines, polygons, and multi-geometries.
+These geometries can be used to define the shape and location of features in KML files.
+
+The module also provides functions for handling coordinates and extracting them from XML
+elements.
+
+"""
+
+from typing import Any
+from typing import Optional
+
+from fastkml.enums import AltitudeMode
+from fastkml.kml_base import _BaseObject
+
+
+class _Geometry(_BaseObject):
+    """
+    Baseclass with common methods for all geometry objects.
+
+    Attributes: extrude: boolean --> Specifies whether to connect the feature to
+                                     the ground with a line.
+                tessellate: boolean -->  Specifies whether to allow the LineString
+                                         to follow the terrain.
+                altitudeMode: --> Specifies how altitude components in the <coordinates>
+                                  element are interpreted.
+
+    """
+
+    altitude_mode: Optional[AltitudeMode]
+
+    def __init__(
+        self,
+        *,
+        ns: Optional[str] = None,
+        name_spaces: Optional[dict[str, str]] = None,
+        id: Optional[str] = None,
+        target_id: Optional[str] = None,
+        altitude_mode: Optional[AltitudeMode] = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Initialize a _Geometry object.
+
+        Args:
+        ----
+            ns: Namespace of the object.
+            name_spaces: Name spaces of the object.
+            id: Id of the object.
+            target_id: Target id of the object.
+            extrude: Specifies whether to connect the feature to the ground with a line.
+            tessellate: Specifies whether to allow the LineString to follow the terrain.
+            altitude_mode: Specifies how altitude components in the <coordinates>
+                           element are interpreted.
+            **kwargs: Additional keyword arguments.
+
+        """
+        super().__init__(
+            ns=ns,
+            id=id,
+            name_spaces=name_spaces,
+            target_id=target_id,
+            **kwargs,
+        )
+        self.altitude_mode = altitude_mode

--- a/fastkml/base.py
+++ b/fastkml/base.py
@@ -353,10 +353,10 @@ class _XMLObject:
         name_spaces = {**config.NAME_SPACES, **name_spaces}
         kwargs: dict[str, Any] = {"ns": ns, "name_spaces": name_spaces}
         for item in registry.get(cls):
-            for name_space in item.ns_ids:
-                kwarg = item.get_kwarg(
+            if item.custom_get_kwarg is not None:
+                kwarg = item.custom_get_kwarg(
                     element=element,
-                    ns=name_spaces.get(name_space, ""),
+                    ns_ids=item.ns_ids,
                     name_spaces=name_spaces,
                     node_name=item.node_name,
                     kwarg=item.attr_name,
@@ -364,10 +364,23 @@ class _XMLObject:
                     strict=strict,
                 )
                 if kwarg:
-                    kwargs.update(
-                        kwarg,
+                    kwargs.update(kwarg)
+            else:
+                for name_space in item.ns_ids:
+                    kwarg = item.get_kwarg(
+                        element=element,
+                        ns=name_spaces.get(name_space, ""),
+                        name_spaces=name_spaces,
+                        node_name=item.node_name,
+                        kwarg=item.attr_name,
+                        classes=item.classes,
+                        strict=strict,
                     )
-                    break
+                    if kwarg:
+                        kwargs.update(
+                            kwarg,
+                        )
+                        break
         return kwargs
 
     @classmethod

--- a/fastkml/containers.py
+++ b/fastkml/containers.py
@@ -23,18 +23,12 @@ from typing import Optional
 from typing import Union
 
 from fastkml import atom
-from fastkml import gx
 from fastkml.data import ExtendedData
 from fastkml.data import Schema
 from fastkml.features import NetworkLink
 from fastkml.features import Placemark
 from fastkml.features import Snippet
 from fastkml.features import _Feature
-from fastkml.geometry import LinearRing
-from fastkml.geometry import LineString
-from fastkml.geometry import MultiGeometry
-from fastkml.geometry import Point
-from fastkml.geometry import Polygon
 from fastkml.helpers import xml_subelement_list
 from fastkml.helpers import xml_subelement_list_kwarg
 from fastkml.overlays import GroundOverlay
@@ -55,16 +49,6 @@ from fastkml.views import Region
 logger = logging.getLogger(__name__)
 
 __all__ = ["Document", "Folder"]
-
-KmlGeometry = Union[
-    Point,
-    LineString,
-    LinearRing,
-    Polygon,
-    MultiGeometry,
-    gx.MultiTrack,
-    gx.Track,
-]
 
 
 class _Container(_Feature):

--- a/fastkml/features.py
+++ b/fastkml/features.py
@@ -30,7 +30,6 @@ from pygeoif.types import GeoType
 
 from fastkml import atom
 from fastkml import config
-from fastkml import gx
 from fastkml.base import _XMLObject
 from fastkml.data import ExtendedData
 from fastkml.geometry import AnyGeometryType
@@ -40,6 +39,8 @@ from fastkml.geometry import MultiGeometry
 from fastkml.geometry import Point
 from fastkml.geometry import Polygon
 from fastkml.geometry import create_kml_geometry
+from fastkml.gx.track import MultiTrack
+from fastkml.gx.track import Track
 from fastkml.helpers import attribute_int_kwarg
 from fastkml.helpers import bool_subelement
 from fastkml.helpers import clean_string
@@ -79,8 +80,8 @@ KmlGeometry = Union[
     Polygon,
     Model,
     MultiGeometry,
-    gx.MultiTrack,
-    gx.Track,
+    MultiTrack,
+    Track,
 ]
 
 
@@ -675,8 +676,8 @@ registry.register(
             Polygon,
             MultiGeometry,
             Model,
-            gx.MultiTrack,
-            gx.Track,
+            MultiTrack,
+            Track,
         ),
         get_kwarg=xml_subelement_kwarg,
         set_element=xml_subelement,

--- a/fastkml/geometry.py
+++ b/fastkml/geometry.py
@@ -45,12 +45,15 @@ from pygeoif.types import LineType
 from typing_extensions import Self
 
 from fastkml import config
+from fastkml.abstract_geometry import _Geometry
 from fastkml.base import _XMLObject
 from fastkml.enums import AltitudeMode
 from fastkml.enums import Verbosity
 from fastkml.exceptions import GeometryError
 from fastkml.exceptions import KMLParseError
 from fastkml.exceptions import KMLWriteError
+from fastkml.gx.track import MultiTrack
+from fastkml.gx.track import Track
 from fastkml.helpers import bool_subelement
 from fastkml.helpers import enum_subelement
 from fastkml.helpers import subelement_bool_kwarg
@@ -59,6 +62,7 @@ from fastkml.helpers import xml_subelement
 from fastkml.helpers import xml_subelement_kwarg
 from fastkml.helpers import xml_subelement_list
 from fastkml.helpers import xml_subelement_list_kwarg
+from fastkml.helpers import xml_subelement_list_multi_ns_kwarg
 from fastkml.kml_base import _BaseObject
 from fastkml.registry import RegistryItem
 from fastkml.registry import registry
@@ -304,57 +308,6 @@ registry.register(
         set_element=coordinates_subelement,
     ),
 )
-
-
-class _Geometry(_BaseObject):
-    """
-    Baseclass with common methods for all geometry objects.
-
-    Attributes: extrude: boolean --> Specifies whether to connect the feature to
-                                     the ground with a line.
-                tessellate: boolean -->  Specifies whether to allow the LineString
-                                         to follow the terrain.
-                altitudeMode: --> Specifies how altitude components in the <coordinates>
-                                  element are interpreted.
-
-    """
-
-    altitude_mode: Optional[AltitudeMode]
-
-    def __init__(
-        self,
-        *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
-        **kwargs: Any,
-    ) -> None:
-        """
-        Initialize a _Geometry object.
-
-        Args:
-        ----
-            ns: Namespace of the object.
-            name_spaces: Name spaces of the object.
-            id: Id of the object.
-            target_id: Target id of the object.
-            extrude: Specifies whether to connect the feature to the ground with a line.
-            tessellate: Specifies whether to allow the LineString to follow the terrain.
-            altitude_mode: Specifies how altitude components in the <coordinates>
-                           element are interpreted.
-            **kwargs: Additional keyword arguments.
-
-        """
-        super().__init__(
-            ns=ns,
-            id=id,
-            name_spaces=name_spaces,
-            target_id=target_id,
-            **kwargs,
-        )
-        self.altitude_mode = altitude_mode
 
 
 class Point(_Geometry):
@@ -1230,7 +1183,9 @@ def create_multigeometry(
 class MultiGeometry(_BaseObject):
     """A container for zero or more geometry primitives."""
 
-    kml_geometries: list[Union[Point, LineString, Polygon, LinearRing, Self]]
+    kml_geometries: list[
+        Union[Point, LineString, Polygon, LinearRing, Self, Track, MultiTrack]
+    ]
 
     def __init__(
         self,
@@ -1243,7 +1198,9 @@ class MultiGeometry(_BaseObject):
         tessellate: Optional[bool] = None,
         altitude_mode: Optional[AltitudeMode] = None,
         kml_geometries: Optional[
-            Iterable[Union[Point, LineString, Polygon, LinearRing, Self]]
+            Iterable[
+                Union[Point, LineString, Polygon, LinearRing, Self, Track, MultiTrack]
+            ]
         ] = None,
         geometry: Optional[MultiGeometryType] = None,
         **kwargs: Any,
@@ -1346,17 +1303,34 @@ class MultiGeometry(_BaseObject):
 registry.register(
     MultiGeometry,
     item=RegistryItem(
-        ns_ids=("kml", ""),
-        classes=(Point, LineString, Polygon, LinearRing, MultiGeometry),
+        ns_ids=("kml", "", "gx"),
+        classes=(
+            Point,
+            LineString,
+            Polygon,
+            LinearRing,
+            MultiGeometry,
+            Track,
+            MultiTrack,
+        ),
         attr_name="kml_geometries",
-        node_name="(Point|LineString|Polygon|LinearRing|MultiGeometry)",
+        node_name="Point,LineString,Polygon,LinearRing,MultiGeometry,Track,MultiTrack",
         get_kwarg=xml_subelement_list_kwarg,
         set_element=xml_subelement_list,
+        custom_get_kwarg=xml_subelement_list_multi_ns_kwarg,
     ),
 )
 
 
-KMLGeometryType = Union[Point, LineString, Polygon, LinearRing, MultiGeometry]
+KMLGeometryType = Union[
+    Point,
+    LineString,
+    Polygon,
+    LinearRing,
+    MultiGeometry,
+    Track,
+    MultiTrack,
+]
 
 
 def _unknown_geometry_type(geometry: Union[GeoType, GeoCollectionType]) -> NoReturn:

--- a/fastkml/gx/track.py
+++ b/fastkml/gx/track.py
@@ -20,6 +20,7 @@ import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import zip_longest
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
 from typing import cast
@@ -29,7 +30,6 @@ from pygeoif.types import PointType
 
 from fastkml import config
 from fastkml.abstract_geometry import _Geometry
-from fastkml.data import ExtendedData
 from fastkml.enums import AltitudeMode
 from fastkml.helpers import bool_subelement
 from fastkml.helpers import coords_subelement_list
@@ -39,13 +39,15 @@ from fastkml.helpers import datetime_subelement_list_kwarg
 from fastkml.helpers import enum_subelement
 from fastkml.helpers import subelement_bool_kwarg
 from fastkml.helpers import subelement_enum_kwarg
-from fastkml.helpers import xml_subelement
-from fastkml.helpers import xml_subelement_kwarg
 from fastkml.helpers import xml_subelement_list
 from fastkml.helpers import xml_subelement_list_kwarg
 from fastkml.registry import RegistryItem
 from fastkml.registry import registry
 from fastkml.times import KmlDateTime
+
+if TYPE_CHECKING:
+    from fastkml.data import ExtendedData
+
 
 __all__ = [
     "Angle",
@@ -134,7 +136,7 @@ class Track(_Geometry):
 
     _default_nsid = config.GX
     track_items: list[TrackItem]
-    extended_data: Optional[ExtendedData]
+    extended_data: Optional["ExtendedData"]
 
     def __init__(
         self,
@@ -148,7 +150,7 @@ class Track(_Geometry):
         whens: Optional[Iterable[KmlDateTime]] = None,
         coords: Optional[Iterable[PointType]] = None,
         angles: Optional[Iterable[PointType]] = None,
-        extended_data: Optional[ExtendedData] = None,
+        extended_data: Optional["ExtendedData"] = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -352,17 +354,9 @@ registry.register(
         default=(0.0, 0.0, 0.0),
     ),
 )
-registry.register(
-    Track,
-    RegistryItem(
-        ns_ids=("kml", ""),
-        attr_name="extended_data",
-        node_name="ExtendedData",
-        classes=(ExtendedData,),
-        get_kwarg=xml_subelement_kwarg,
-        set_element=xml_subelement,
-    ),
-)
+
+# To avoids circular imports,
+# ExtendedData registration is performed in registry_setup.py.
 
 
 def tracks_to_geometry(tracks: Iterable[Track]) -> geo.MultiLineString:

--- a/fastkml/gx/track.py
+++ b/fastkml/gx/track.py
@@ -28,9 +28,9 @@ import pygeoif.geometry as geo
 from pygeoif.types import PointType
 
 from fastkml import config
+from fastkml.abstract_geometry import _Geometry
 from fastkml.data import ExtendedData
 from fastkml.enums import AltitudeMode
-from fastkml.geometry import _Geometry
 from fastkml.helpers import bool_subelement
 from fastkml.helpers import coords_subelement_list
 from fastkml.helpers import coords_subelement_list_kwarg

--- a/fastkml/helpers.py
+++ b/fastkml/helpers.py
@@ -1412,3 +1412,55 @@ def xml_subelement_list_kwarg(
                 ],
             )
     return {kwarg: args_list} if args_list else {}
+
+
+def xml_subelement_list_multi_ns_kwarg(
+    *,
+    element: Element,
+    ns_ids: tuple[str, ...],
+    name_spaces: dict[str, str],
+    node_name: str,
+    kwarg: str,
+    classes: tuple[type[object], ...],
+    strict: bool,
+) -> dict[str, list["_XMLObject"]]:
+    """
+    Return a dictionary with the specified keyword argument and its list of subelements.
+
+    Args:
+    ----
+        element (Element): The XML element to search within.
+        ns_ids (str): The namespace ID of the XML element.
+        name_spaces (Dict[str, str]): A dictionary mapping namespace prefixes to URIs.
+        node_name (str): The name of the XML node to search for.
+        kwarg (str): The name of the keyword argument to store the found subelements.
+        classes (Tuple[Type[object], ...]): A tuple of classes that represent the types.
+        strict (bool): A flag indicating whether to enforce strict parsing rules.
+
+    Returns:
+    -------
+        Dict[str, List["_XMLObject"]]: A dictionary containing the specified keyword
+            argument and its list of subelements.
+
+    """
+    args_list = []
+    assert node_name is not None  # noqa: S101
+    assert name_spaces is not None  # noqa: S101
+    for name_space in ns_ids:
+        ns = name_spaces.get(name_space, "")
+        for obj_class in classes:
+            if subelements := element.findall(
+                f"{ns}{obj_class.get_tag_name()}",  # type: ignore[attr-defined]
+            ):
+                args_list.extend(
+                    [
+                        obj_class.class_from_element(  # type: ignore[attr-defined]
+                            ns=ns,
+                            name_spaces=name_spaces,
+                            element=subelement,
+                            strict=strict,
+                        )
+                        for subelement in subelements
+                    ],
+                )
+    return {kwarg: args_list} if args_list else {}

--- a/fastkml/helpers.py
+++ b/fastkml/helpers.py
@@ -1430,7 +1430,7 @@ def xml_subelement_list_multi_ns_kwarg(
     Args:
     ----
         element (Element): The XML element to search within.
-        ns_ids (str): The namespace ID of the XML element.
+        ns_ids (Tuple[str, ...]): The namespace IDs of the XML element.
         name_spaces (Dict[str, str]): A dictionary mapping namespace prefixes to URIs.
         node_name (str): The name of the XML node to search for.
         kwarg (str): The name of the keyword argument to store the found subelements.

--- a/fastkml/overlays.py
+++ b/fastkml/overlays.py
@@ -23,7 +23,6 @@ from typing import Union
 
 from fastkml import atom
 from fastkml import config
-from fastkml import gx
 from fastkml.base import _XMLObject
 from fastkml.data import ExtendedData
 from fastkml.enums import AltitudeMode
@@ -32,11 +31,7 @@ from fastkml.enums import Shape
 from fastkml.enums import Units
 from fastkml.features import Snippet
 from fastkml.features import _Feature
-from fastkml.geometry import LinearRing
-from fastkml.geometry import LineString
-from fastkml.geometry import MultiGeometry
 from fastkml.geometry import Point
-from fastkml.geometry import Polygon
 from fastkml.helpers import attribute_enum_kwarg
 from fastkml.helpers import attribute_float_kwarg
 from fastkml.helpers import clean_string
@@ -79,16 +74,6 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
-
-KmlGeometry = Union[
-    Point,
-    LineString,
-    LinearRing,
-    Polygon,
-    MultiGeometry,
-    gx.MultiTrack,
-    gx.Track,
-]
 
 
 class _Overlay(_Feature):

--- a/fastkml/registry.py
+++ b/fastkml/registry.py
@@ -50,6 +50,20 @@ class GetKWArgs(Protocol):
     ) -> dict[str, Any]: ...
 
 
+class CustomGetKWArgs(Protocol):
+    def __call__(
+        self,
+        *,
+        element: Element,
+        ns_ids: tuple[str, ...],
+        name_spaces: dict[str, str],
+        node_name: str,
+        kwarg: str,
+        classes: tuple[type[object], ...],
+        strict: bool,
+    ) -> dict[str, Any]: ...
+
+
 class SetElement(Protocol):
     def __call__(
         self,
@@ -81,7 +95,8 @@ class RegistryItem:
     - ``type``: The type of the XML object.
     - ``node_name``: The name of the XML node that the mapping applies to.
     - ``default``: An optional default value for the Python object attribute.
-
+    - ``custom_get_kwarg``: An optional custom function that retrieves keyword arguments
+      for the Python object.
     """
 
     ns_ids: tuple[str, ...]
@@ -91,6 +106,7 @@ class RegistryItem:
     set_element: SetElement
     node_name: str
     default: Any = None
+    custom_get_kwarg: Optional[CustomGetKWArgs] = None
 
 
 class Registry:

--- a/tests/geometries/geometry_test.py
+++ b/tests/geometries/geometry_test.py
@@ -19,13 +19,13 @@
 import pytest
 from pygeoif import geometry as geo
 
+from fastkml.abstract_geometry import _Geometry
 from fastkml.enums import AltitudeMode
 from fastkml.geometry import LinearRing
 from fastkml.geometry import LineString
 from fastkml.geometry import MultiGeometry
 from fastkml.geometry import Point
 from fastkml.geometry import Polygon
-from fastkml.geometry import _Geometry
 from fastkml.geometry import create_kml_geometry
 from tests.base import Lxml
 from tests.base import StdLibrary
@@ -231,6 +231,23 @@ class TestGetGeometry(StdLibrary):
 
         assert g.geometry is not None
         assert len(g.geometry) == 2
+
+    def test_multi_ns(self) -> None:
+        doc = """
+        <kml:MultiGeometry xmlns:kml="http://www.opengis.net/kml/2.2">
+          <kml:Point>
+            <kml:coordinates>0.000000,1.000000</kml:coordinates>
+          </kml:Point>
+          <gx:Track xmlns:gx="http://www.google.com/kml/ext/2.2">
+            <kml:when>2000-01-01</kml:when>
+            <gx:coord>1.0 1.0</gx:coord>
+          </gx:Track>
+        </kml:MultiGeometry>
+        """
+
+        g = MultiGeometry.from_string(doc)
+
+        assert len(g.geometry) == 2  # type: ignore[arg-type]
 
     def test_geometrycollection(self) -> None:
         doc = """


### PR DESCRIPTION
### **User description**
Closes #454 

As part of testing the `custom_kwargs_getter` implementation, I’m attempting to add `gx:Track` to `MultiGeometry`, which is defined in the KML schema as a multi-namespace structure.
However, during implementation, I encountered a circular import error:
```
  File "./fastkml/fastkml/__init__.py", line 32, in <module>
    from fastkml.containers import Document
  File "./fastkml/fastkml/containers.py", line 26, in <module>
    from fastkml.data import ExtendedData
  File "./fastkml/fastkml/data.py", line 31, in <module>
    from fastkml.gx.data import SimpleArrayData
  File "./fastkml/fastkml/gx/__init__.py", line 83, in <module>
    from fastkml.gx.track import Angle
  File "./fastkml/fastkml/gx/track.py", line 32, in <module>
    from fastkml.data import ExtendedData
ImportError: cannot import name 'ExtendedData' from partially initialized module 'fastkml.data' (most likely due to a circular import) (./fastkml/fastkml/data.py)
```

This proved difficult to resolve, so I am submitting this as a draft for now.
For next steps, I would appreciate input on the following options:
1. Resolve the circular import — if so, what would be the preferred strategy?
2. Handle the addition of `gx:Track` to `MultiGeometry` in a separate PR — if so, what would be an appropriate way to test this case?

Note: I had already encountered this error during earlier testing. As a temporary workaround, I bypassed the actual class structure and added `gx:Track` to `KML.features` for verification. This approach worked without issue.

## Summary by Sourcery

Implement multi-namespace element support in XML parsing by adding custom_get_kwarg protocol and a dedicated multi-namespace helper, extend MultiGeometry to include gx:Track and gx:MultiTrack, refactor registry setup to avoid circular imports, extract common geometry base class, and add a unit test for mixed-namespace geometry parsing

New Features:
- Introduce custom_get_kwarg in RegistryItem and integrate it into _get_kwargs for custom XML parsing
- Add xml_subelement_list_multi_ns_kwarg helper to support multi-namespace subelement extraction
- Enable parsing of gx:Track and gx:MultiTrack elements inside MultiGeometry

Enhancements:
- Move the _Geometry base class into a new abstract_geometry.py module and remove redundant KmlGeometry type aliases
- Refactor _get_kwargs to prefer custom_get_kwarg before standard parsing loops
- Relocate Track’s ExtendedData registry setup into _registry_setup.py to resolve circular imports
- Clean up gx/track.py imports with TYPE_CHECKING and string annotations

Tests:
- Add test_multi_ns to verify MultiGeometry.from_string handles mixed kml and gx namespace elements


___

### **PR Type**
Enhancement


___

### **Description**
- Add multi-namespace support for XML subelement parsing via `custom_get_kwarg`

- Extend `MultiGeometry` to include `gx:Track` and `gx:MultiTrack` elements

- Refactor `_Geometry` base class into separate `abstract_geometry` module

- Create `_registry_setup` module to resolve circular import issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Add custom_get_kwarg protocol"] --> B["Implement xml_subelement_list_multi_ns_kwarg"]
  B --> C["Update MultiGeometry to support gx:Track"]
  D["Extract _Geometry to abstract_geometry"] --> E["Create _registry_setup module"]
  E --> F["Resolve circular imports"]
  C --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>base.py</strong><dd><code>Add custom_get_kwarg support to _get_kwargs method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-9b16ed9fe658d6228a027f367e168f7ea471bb14a61e0c11d12be5153d25a3da">+19/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>registry.py</strong><dd><code>Add CustomGetKWArgs protocol and custom_get_kwarg field</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-365d6e4b146c94c639db1b5f3f54d342a6b3458ab4a208695400b366cebd273c">+17/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>helpers.py</strong><dd><code>Implement xml_subelement_list_multi_ns_kwarg helper function</code></dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-b5b3941187e8c15a6401d21669f3dd0d541c710ecbb6238620a56e24305fc02c">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>geometry.py</strong><dd><code>Extend MultiGeometry to support Track and MultiTrack</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-47314ad0817fc0fdde5a4ccab1250d104c27d592f1dd0f9952b454a4e3cdf65d">+31/-57</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>abstract_geometry.py</strong><dd><code>Extract _Geometry base class to new module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-7a15ec708aa517089f27d79a550116bc190024df553c0e18d3ca09bb5864e3ab">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>_registry_setup.py</strong><dd><code>Create registry setup module for circular import resolution</code></dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-ce17e719a0dced29d4b1b950710aecc6e68feca5e7a1bb1672e474050332079b">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>track.py</strong><dd><code>Update imports and use TYPE_CHECKING for ExtendedData</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-da78ea6b178211c744f17559e82d391948581d33262bcd1d663a171f53ab8c15">+11/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>features.py</strong><dd><code>Update KmlGeometry type and imports for Track types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-00a3c2aa0b823504cfb27c3ddc29f807d2542e48259b8f219a673393e6fa2c5c">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Import and cleanup _registry_setup module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-3629e121239e3f7c6ac52604b011106bd7d417fc59a153d5b3d677bbaf7b7653">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>containers.py</strong><dd><code>Remove unused KmlGeometry type and geometry imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-738931297f80e440cd189073efb0323af2ac936d1eed3f2dd130b44fa79fa003">+0/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>overlays.py</strong><dd><code>Remove unused KmlGeometry type and geometry imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-53d4a4402d4b36ba24c38b2494214f2940433d433946065052596dbd37cc3565">+0/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>geometry_test.py</strong><dd><code>Add multi-namespace test for MultiGeometry with gx:Track</code>&nbsp; </dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-c58e16d0b9d54da03108c95fc089fb3cf98368c0a35e0807127fd57d2209fd1f">+18/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>HISTORY.rst</strong><dd><code>Document custom_kwargs_getter multi-namespace support addition</code></dd></td>
  <td><a href="https://github.com/cleder/fastkml/pull/463/files#diff-98d733cee70f992558257d7aa263bc1c61465ae908831dddea5cac41954ab543">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MultiGeometry now supports Track and MultiTrack across KML and GX namespaces.
  - Added support for extracting subelements across multiple namespaces via a customizable handler.

- **Documentation**
  - Changelog updated under the upcoming 1.3.0 section.

- **Tests**
  - Added test coverage for mixed-namespace MultiGeometry parsing.

- **Refactor**
  - Reduced circular-import issues and cleaned public import surface for more stable initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->