### PR TITLE
Optimize xml_subelement to avoid lxml O(n^2) slowdown by using SubElement

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -3,6 +3,7 @@ Changelog
 1.4.0 (unreleased)
 ------------------
 
+- Optimize xml_subelement to avoid lxml O(n^2) slowdown by using SubElement [hirohira9119]
 
 1.3.0 (2025/10/16)
 ------------------

--- a/fastkml/base.py
+++ b/fastkml/base.py
@@ -170,6 +170,34 @@ class _XMLObject:
         element: Element = config.etree.Element(
             f"{self.ns}{self.get_tag_name()}",
         )
+        self.populate_element(element, precision, verbosity)
+        return element
+
+    def populate_element(
+        self,
+        element: Element,
+        precision: Optional[int] = None,
+        verbosity: Verbosity = Verbosity.normal,
+    ) -> None:
+        """
+
+        Populate an existing XML element with attributes and child elements.
+
+        This method adds the object's attributes and child elements to an existing
+        etree Element, using the registry to determine how each attribute should be
+        serialized. It is used internally by `etree_element` and by helper functions
+        like `xml_subelement` to build XML structures incrementally.
+
+        Parameters
+        ----------
+        element : Element
+            The XML element to populate with this object's data.
+        precision : Optional[int], default=None
+            The precision of the KML object.
+        verbosity : Verbosity, default=Verbosity.normal
+            The verbosity level.
+
+        """
         for item in registry.get(self.__class__):
             item.set_element(
                 obj=self,
@@ -180,7 +208,6 @@ class _XMLObject:
                 verbosity=verbosity,
                 default=item.default,
             )
-        return element
 
     def to_string(
         self,

--- a/fastkml/base.py
+++ b/fastkml/base.py
@@ -180,7 +180,6 @@ class _XMLObject:
         verbosity: Verbosity = Verbosity.normal,
     ) -> None:
         """
-
         Populate an existing XML element with attributes and child elements.
 
         This method adds the object's attributes and child elements to an existing

--- a/fastkml/helpers.py
+++ b/fastkml/helpers.py
@@ -673,12 +673,15 @@ def xml_subelement(
         None
 
     """
-    if getattr(obj, attr_name, None):
-        element.append(
-            getattr(obj, attr_name).etree_element(
-                precision=precision,
-                verbosity=verbosity,
-            ),
+    if child_obj := getattr(obj, attr_name, None):
+        child_element = config.etree.SubElement(
+            element,
+            f"{child_obj.ns}{child_obj.get_tag_name()}",
+        )
+        child_obj.populate_element(
+            child_element,
+            precision=precision,
+            verbosity=verbosity,
         )
 
 
@@ -710,11 +713,17 @@ def xml_subelement_list(
         None
 
     """
-    if getattr(obj, attr_name, None):
-        for item in getattr(obj, attr_name):
+    if items := getattr(obj, attr_name, None):
+        for item in items:
             if item:
-                element.append(
-                    item.etree_element(precision=precision, verbosity=verbosity),
+                child_element = config.etree.SubElement(
+                    element,
+                    f"{item.ns}{item.get_tag_name()}",
+                )
+                item.populate_element(
+                    element=child_element,
+                    precision=precision,
+                    verbosity=verbosity,
                 )
 
 


### PR DESCRIPTION
### **User description**
Closes #471


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor `etree_element` to extract element population logic

- Introduce `populate_element` method for incremental XML building

- Replace `element.append()` with `SubElement` in helper functions

- Avoid O(n²) performance degradation in lxml element creation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["etree_element creates element"] --> B["populate_element fills content"]
  C["xml_subelement helper"] --> D["SubElement creates child"]
  D --> B
  E["xml_subelement_list helper"] --> F["SubElement per item"]
  F --> B
  style A fill:#e1f5ff
  style B fill:#e1f5ff
  style C fill:#fff3e0
  style D fill:#fff3e0
  style E fill:#fff3e0
  style F fill:#fff3e0
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Extract element population into separate method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/base.py

<ul><li>Extract element population logic from <code>etree_element</code> into new <br><code>populate_element</code> method<br> <li> <code>etree_element</code> now creates element and delegates population to <br><code>populate_element</code><br> <li> <code>populate_element</code> handles registry-based attribute and child element <br>serialization<br> <li> Enables reuse of population logic by helper functions</ul>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/472/files#diff-9b16ed9fe658d6228a027f367e168f7ea471bb14a61e0c11d12be5153d25a3da">+28/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.py</strong><dd><code>Use SubElement to avoid O(n²) append slowdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fastkml/helpers.py

<ul><li>Replace <code>element.append(child.etree_element())</code> with <code>SubElement</code> in <br><code>xml_subelement</code><br> <li> Use walrus operator to assign and check child object existence<br> <li> Call <code>populate_element</code> on created <code>SubElement</code> instead of full <br><code>etree_element</code><br> <li> Apply same optimization pattern to <code>xml_subelement_list</code> for list items<br> <li> Eliminates O(n²) performance issue caused by repeated <code>append</code> <br>operations</ul>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/472/files#diff-b5b3941187e8c15a6401d21669f3dd0d541c710ecbb6238620a56e24305fc02c">+19/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HISTORY.rst</strong><dd><code>Document xml_subelement optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/HISTORY.rst

<ul><li>Add changelog entry documenting the xml_subelement optimization<br> <li> Entry added to unreleased 1.4.0 section</ul>


</details>


  </td>
  <td><a href="https://github.com/cleder/fastkml/pull/472/files#diff-98d733cee70f992558257d7aa263bc1c61465ae908831dddea5cac41954ab543">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized XML element creation to remove an O(n²) performance regression, improving speed for building XML structures.
  * Preserved existing public interfaces and observable behavior so integrations continue to work unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->