### PR TITLE
503 typechecking fails with ty and pyrefly

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.15-dev']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.15-dev']
 
     steps:
       - uses: actions/checkout@v7
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pypy-version: ['pypy-3.9', 'pypy-3.10', 'pypy-3.11']
+        pypy-version: ['pypy-3.10', 'pypy-3.11']
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.pypy-version }}

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -97,8 +97,8 @@ jobs:
           pip install -e ".[typing, complexity, linting, tests]"
       - name: Typecheck
         run: |
-          ty fastkml tests
-          pyrefly fastkml tests
+          ty check fastkml tests
+          pyrefly check fastkml tests
       - name: Linting
         run: |
           ruff check --no-fix fastkml tests examples docs

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -97,7 +97,8 @@ jobs:
           pip install -e ".[typing, complexity, linting, tests]"
       - name: Typecheck
         run: |
-          mypy fastkml tests
+          ty fastkml tests
+          pyrefly fastkml tests
       - name: Linting
         run: |
           ruff check --no-fix fastkml tests examples docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 ---
+ci:
+  skip: [pyprojectsort]
 default_language_version:
   python: python3.12
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,11 +62,20 @@ repos:
     rev: "v1.0.2"
     hooks:
       - id: sphinx-lint
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+  - repo: local
     hooks:
-      - id: mypy
-        additional_dependencies: [pygeoif>=1.4, arrow, pytest, hypothesis, types-python-dateutil]
+      - id: ty
+        name: ty
+        entry: ty check fastkml tests
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: pyrefly
+        name: pyrefly
+        entry: pyrefly check fastkml tests
+        language: system
+        types: [python]
+        pass_filenames: false
   - repo: https://github.com/adamchainz/blacken-docs
     rev: "1.20.0"
     hooks:

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,2 +1,2 @@
 refactor:
-  python_version: '3.9'
+  python_version: '3.10'

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Features
 * **Simple and fast**: Easy-to-use API with fast performance
 * **Geometry support**: Handles geometries as pygeoif_ objects, compatible with any geometry that implements the ``__geo_interface__`` protocol, such as shapely_
 * **Cross-platform compatibility**: Tested on `CPython <https://python.org>`_, `PyPy <https://www.pypy.org/>`_ and `GraalPy <https://www.graalvm.org/python/>`_
-* **Python 3.9+**: Works on alternative Python implementations that support Python *>=3.9*
+* **Python 3.10+**: Works on alternative Python implementations that support Python *>=3.10*
 
 Status
 ======
@@ -122,11 +122,13 @@ Installation
 Basic Installation
 ------------------
 
-Install the package using pip:
+Add FastKML to your project by installing it from PyPI. 
+You can install it using uv, pip, or conda.
 
 .. code-block:: bash
 
-    pip install fastkml
+    uv add fastkml
+
 
 This will install FastKML with all required dependencies.
 
@@ -137,7 +139,14 @@ For enhanced performance, install with lxml:
 
 .. code-block:: bash
 
-    pip install "fastkml[lxml]"
+    uv add "fastkml[lxml]"
+
+Using pip
+---------
+
+.. code-block:: bash
+
+    pip install fastkml
 
 Using Conda
 -----------

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ Installation
 Basic Installation
 ------------------
 
-Add FastKML to your project by installing it from PyPI. 
+Add FastKML to your project by installing it from PyPI.
 You can install it using uv, pip, or conda.
 
 .. code-block:: bash

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,8 @@ Changelog
 1.5.0 (unreleased)
 ------------------
 
+- Drop support for Python 3.9.
+
 
 1.4.0 (2025/11/04)
 ------------------

--- a/docs/codedocs/guides/mypy-to-ty-and-pyrefly-migration.md
+++ b/docs/codedocs/guides/mypy-to-ty-and-pyrefly-migration.md
@@ -78,8 +78,8 @@ If the project also defines its own `Protocol` to abstract over both backends (e
 if TYPE_CHECKING:
     from lxml.etree import _Element as Element
 else:
-    class Element(Protocol):
-        ...  # the original structural protocol, unchanged
+
+    class Element(Protocol): ...  # the original structural protocol, unchanged
 ```
 
 This one change collapsed roughly 150 of ~240 diagnostics in the fastkml migration, because it fixed both the "backend-specific kwarg doesn't exist" class of errors *and* the "structural Protocol isn't assignable to a concrete stdlib parameter type" class in one shot (see pitfall below).

--- a/docs/codedocs/guides/mypy-to-ty-and-pyrefly-migration.md
+++ b/docs/codedocs/guides/mypy-to-ty-and-pyrefly-migration.md
@@ -1,0 +1,275 @@
+---
+title: "Migrate From mypy To ty And pyrefly"
+description: "A field-tested playbook, pitfall list, and config cheat-sheet for moving a codebase off mypy onto ty and pyrefly, written for both human and AI-agent execution."
+---
+
+This guide is not about using `fastkml`. It documents how `fastkml` itself was migrated from `mypy` to Astral's `ty` and Meta's `pyrefly`, so the same playbook can be replayed on other codebases with less trial and error. Keep it here because the next migration (human- or agent-driven) should start from findings, not from zero.
+
+<Callout type="info">Running two checkers instead of one is deliberate, not incidental. `ty` and `pyrefly` disagree with each other and with mypy often enough that running only one gives a false sense of completeness. Budget for both, and expect them to catch different subsets of the same bugs.</Callout>
+
+## TL;DR
+
+1. Get a raw error-count baseline for both tools **before** touching any source. Categorize by error kind, not by file.
+2. Look for one **systemic** root cause before fixing anything file-by-file. In most codebases with an optional C-extension backend (lxml, pydantic-core, orjson, etc.) there is a single architectural fix that collapses 60-90% of the noise.
+3. Fix genuine bugs the tools surface (there will be some — both tools are pickier than mypy about `Optional`/union narrowing, positional-only stubs, and unpacking).
+4. Bulk-suppress test-file "constructed-then-accessed-without-narrowing" noise scoped to `tests/**`, not case by case, and not by widening the rule to error kinds that could hide real bugs (`invalid-argument-type` is not `unresolved-attribute`).
+5. Turn on strict presets, then promote specific rules the preset doesn't cover, and explicitly cut the ones that create disproportionate mechanical churn (ask a human before doing a 80-site `@override` sweep).
+6. Verify: both tools clean, full test suite green (with **and** without optional runtime deps installed), linter clean, and the TOML re-parses.
+
+## Phase 0 — Inventory the mypy config honestly
+
+Before deleting `[tool.mypy]`, read what each flag actually bought you, because that's the strictness bar `ty`/`pyrefly` need to match or exceed:
+
+| mypy setting | Rough ty/pyrefly equivalent |
+|---|---|
+| `disallow_any_generics` | ty `missing-type-argument = "error"` |
+| `warn_redundant_casts` | ty `redundant-cast`; pyrefly `redundant-cast` (both exist, check current default level) |
+| `warn_unused_ignores` | ty `unused-ignore-comment` / `unused-type-ignore-comment`; pyrefly `unused-ignore` (on by default under `strict`) |
+| `warn_unreachable` | pyrefly's `strict` preset covers this; ty has no exact analog — don't assume parity, spot-check |
+| `disallow_untyped_defs` | Neither tool has a literal flag for this — `ty` infers types through unannotated bodies by default (different philosophy from mypy). Don't expect a 1:1 mapping; re-derive intent instead of hunting for the same flag name. |
+| Per-module `disable_error_code` overrides | pyrefly `[[tool.pyrefly.sub-config]]` + `matches` glob; ty `[[tool.ty.overrides]]` + `include` glob |
+
+Also inventory **stale** per-module overrides — a mypy config that's been edited over years accumulates dead entries (a module path that was renamed or deleted, but the override survived). Grep for the referenced paths; don't carry dead config forward.
+
+## Phase 1 — Install both tools and get a baseline
+
+```bash
+uv pip install ty pyrefly
+ty check <src> <tests>
+pyrefly check <src> <tests>
+```
+
+Immediately categorize, don't read line by line yet:
+
+```bash
+ty check <src> <tests> 2>&1 | grep -oE '^error\[[a-zA-Z-]+\]' | sort | uniq -c | sort -rn
+ty check <src> <tests> 2>&1 | grep -E '^\s+-->' | sed -E 's/^\s+--> //; s/:[0-9]+:[0-9]+$//' | sort | uniq -c | sort -rn
+```
+
+The second command (errors by file) usually reveals the systemic cause immediately: a handful of files concentrate a disproportionate share of the errors, and they're usually the ones touching an optional/duck-typed dependency.
+
+<Callout type="warn">If a partial migration already exists in the repo (CI switched over but `pyproject.toml` grew broad `ignore-missing-imports = ["*"]` / blanket `missing-attribute = "ignore"` sub-configs), treat that as a red flag, not a starting point. Broad suppressions accumulated during an in-progress migration usually mean someone hit friction and silenced it rather than fixed it. Re-run with those suppressions removed to see the real baseline before deciding what's worth keeping.</Callout>
+
+## Phase 2 — Find the systemic root cause first
+
+The highest-leverage move in this kind of migration is almost never "fix errors file by file." It's finding the one architectural mismatch that both checkers are tripping over identically across dozens of call sites.
+
+**The recurring pattern**: a project supports an optional, richer backend (lxml over `xml.etree.ElementTree`, `orjson` over `json`, `ujson`, a C-accelerated regex engine, etc.) via a runtime try/except import, and defines either a `Protocol` or just relies on structural duck-typing to abstract over both. mypy tolerated this for years via `ignore_missing_imports = true`, which silently treats the untyped backend as `Any` everywhere. Neither `ty` nor `pyrefly` degrade that gracefully by default — they'll either partially resolve the untyped backend's real (but incomplete) info, or fall back to typing it against whichever branch of the try/except *does* have full stubs (usually the stdlib fallback), and then report every method/kwarg the richer backend uniquely offers as invalid.
+
+**The fix**, applied at the import site (not scattered across every call site):
+
+```python
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Type-checkers see the richer backend's own stubs; the preferred
+    # backend's API is treated as a superset of the fallback's.
+    from lxml import etree
+else:
+    try:
+        from lxml import etree
+    except ImportError:
+        import xml.etree.ElementTree as etree
+```
+
+If the project also defines its own `Protocol` to abstract over both backends (e.g. `types.py: class Element(Protocol): ...`), consider going one step further and making that Protocol **literally alias the richer backend's real type** under `TYPE_CHECKING`, falling back to the structural `Protocol` only for runtime/non-typechecking purposes:
+
+```python
+if TYPE_CHECKING:
+    from lxml.etree import _Element as Element
+else:
+    class Element(Protocol):
+        ...  # the original structural protocol, unchanged
+```
+
+This one change collapsed roughly 150 of ~240 diagnostics in the fastkml migration, because it fixed both the "backend-specific kwarg doesn't exist" class of errors *and* the "structural Protocol isn't assignable to a concrete stdlib parameter type" class in one shot (see pitfall below).
+
+If a stub package exists for the richer backend (`lxml-stubs`, `types-ujson`, etc.), add it to your typing dev-dependencies — but read the pitfalls section before assuming it's a strict improvement for *both* checkers.
+
+## Pitfalls (the part worth re-reading before your second migration)
+
+### 1. `# type: ignore[code]` is not portable
+
+Neither `ty` nor `pyrefly` parses mypy's bracketed error-code suppression the way mypy does.
+
+- `ty` honors a **bare** `# type: ignore` (no brackets) as a blanket suppression for that line, but a bracketed `# type: ignore[some-code]` is **not** recognized as a ty-ignore at all — it's inert noise as far as ty is concerned, and the underlying error still fires.
+- `pyrefly` does honor `# type: ignore[...]` by default (its `--enabled-ignores` defaults to `type,pyrefly`), so bracketed mypy comments mostly still work for pyrefly specifically.
+- Both tools have their own dedicated syntax: `# ty: ignore[rule-name]` and `# pyrefly: ignore` / `# pyrefly: ignore[error-kind]`.
+
+Verify empirically before trusting any of this — behavior can change between tool versions:
+
+```python
+def f() -> int:
+    return "y"  # type: ignore[return-value]
+```
+
+Run `ty check` and `pyrefly check` against a two-line repro before deciding on a suppression strategy for the whole codebase.
+
+**Practical rule that worked well**: keep the original `# type: ignore[code]` comment (documents intent, keeps pyrefly happy) and append `# ty: ignore[rule-name]` on the same physical line for ty. Don't strip the mypy-era comments outright; they're free documentation of *why* a line is exceptional.
+
+### 2. pyrefly's TOML keys are snake_case even though its CLI flags are kebab-case
+
+This is the single most time-consuming mistake to make. `pyrefly check --replace-imports-with-any 'lxml.*'` works from the CLI. Writing the "obvious" TOML equivalent:
+
+```toml
+[tool.pyrefly]
+replace-imports-with-any = ["lxml.*"]   # WRONG — silently different key
+```
+
+...does not raise an error from `pyrefly check` in some code paths, but it **does** hard-fail with `pyrefly dump-config` (`unknown variant 'replace-imports-with-any'... Fatal configuration error`), and depending on invocation order this can also break `pyrefly check` itself later. The correct TOML key uses underscores:
+
+```toml
+[tool.pyrefly]
+replace_imports_with_any = ["lxml.*"]
+```
+
+Meanwhile, **error-kind names** (used as dict keys under `[tool.pyrefly.errors]` or inside a `rules = {...}` table) *do* use hyphens (`missing-override-decorator`, `redundant-cast`, etc.) — matching the CLI's `--error`/`--ignore` rule-name spelling, not the config-field spelling. There is no single consistent casing convention across the whole config surface; check `pyrefly dump-config` after every config change, not just `pyrefly check`, because `check` can look clean while a nearby key is silently ignored.
+
+<Callout type="warn">After any pyrefly config edit, run both `pyrefly dump-config` (schema/parse validation) and `pyrefly check` (behavioral validation) — one catches structural mistakes the other doesn't surface.</Callout>
+
+### 3. pyrefly's `[[tool.pyrefly.sub-config]]` array-of-tables is fragile against interleaving
+
+Pyrefly's per-path overrides use TOML's array-of-tables syntax:
+
+```toml
+[[tool.pyrefly.sub-config]]
+matches = "tests/**/*"
+
+[tool.pyrefly.sub-config.errors]
+missing-attribute = "ignore"
+```
+
+TOML allows other, unrelated top-level tables to appear *between* `[[tool.pyrefly.sub-config]]` and its paired `[tool.pyrefly.sub-config.errors]` — the nested table still binds to the most-recently-opened array element regardless of what's interleaved. That means a `pyproject.toml` that grew organically (auto-migration tooling appending blocks near whatever happened to be at the end of the file) can end up with three sub-config blocks scattered across 100+ lines of unrelated project/tool config, and it will *still parse*. It becomes a landmine the moment someone (or an agent) deletes one `[[tool.pyrefly.sub-config]]` header without also deleting its now-orphaned `[tool.pyrefly.sub-config.errors]` block — the orphaned errors table then either binds to the wrong array element or breaks parsing entirely.
+
+**Fix**: keep every pyrefly (and ty) config block **contiguous** in one place in the file, even if that means moving it away from wherever an automated tool first inserted it. Re-parse after every edit:
+
+```bash
+python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb')); print('OK')"
+```
+
+### 4. A `Protocol` is not assignable to a concrete class parameter
+
+If your duck-typing abstraction is a `Protocol` (say, `types.Element`) and internal code passes `Element`-typed values into functions that are typed against the *concrete* stdlib/third-party class (`xml.etree.ElementTree.SubElement(parent: Element[Any], ...)`), both `ty` and `pyrefly` will reject it — even though the Protocol is structurally compatible at every call site. Protocol → concrete-class assignability doesn't work the way concrete → Protocol does, and a mutable/invariant attribute (`text: str` on the Protocol vs. `text: str | None` on the real class) makes it worse.
+
+This resolves itself for free once you apply the Phase 2 fix (alias the Protocol to the real backend's type under `TYPE_CHECKING`) for internal, backend-facing code. Keep the original Protocol only for the codebase's genuinely-public, backend-agnostic API surface.
+
+### 5. Registry/callback-style dispatch can't be narrowed at the signature level
+
+A common pattern: a generic dispatch table stores `classes: tuple[type[object], ...]` and a matching `Protocol` requires every registered callback to accept exactly that (necessarily wide) signature, even though any *individual* callback only ever receives one concrete class at runtime. You cannot narrow an individual callback's parameter type to the concrete class it actually expects (`tuple[type[SpecificClass], ...]`) — that breaks structural assignability against the wider Protocol the dispatcher requires (parameter types are contravariant; a callback that only accepts a narrower type can't stand in for one the dispatcher will call with the wider type).
+
+Fix at the call site inside the function body instead of the signature: `cast("tuple[type[SpecificClass], ...]", classes)`, or `cls = cast("type[SpecificClass]", classes[0])`. Keep the public signature honestly wide.
+
+### 6. `**heterogeneous_dict` splats can't be validated against multi-parameter constructors
+
+```python
+fields = {"type_": DataType.int_, "name": "Integer"}
+SimpleField(**fields)
+```
+
+Both checkers infer `fields: dict[str, DataType | str]` and then check *every* keyword argument against that whole union, rather than against each parameter's own specific type — because plain `dict[str, ...]` splatting isn't a `TypedDict`, so there's no per-key type information available. This isn't a narrowing bug or an inherent-bad-input case; it's a structural limitation of `**dict` splatting itself. Either convert the dict to a `TypedDict` (real fix, more invasive) or accept a targeted ignore comment — don't spend time trying to "fix" it any other way.
+
+### 7. Community stub packages can behave differently per checker
+
+If you add a community-maintained stub package (`lxml-stubs`, etc.) rather than relying on inline `py.typed` types, expect it to have its own bugs, and expect those bugs to manifest **differently per checker**. In this migration, `lxml-stubs` declares several attributes using the legacy stub syntax `tag = ...  # type: str` (pre-PEP 526). `ty` tolerates this by falling back to `Unknown` for that attribute (safe, just loses precision). `pyrefly` mis-parses it as the attribute's type being the **literal value** `Ellipsis`, then reports every subsequent use (`.strip()`, `.split()`, slicing) as an error on a nonexistent `EllipsisType` method — a wave of dozens of false positives that has nothing to do with your code.
+
+There is no fix on your side other than working around the stub bug per-checker:
+
+```toml
+[tool.pyrefly]
+# Force pyrefly to treat the whole (broken-for-pyrefly) stub package as Any,
+# while `ty` still gets full value from the same installed stub package.
+replace_imports_with_any = ["lxml.*"]
+```
+
+Don't assume "we added the stub package" is the end of the story — verify both tools independently after adding any third-party stub dependency, because "more type information" is not always strictly better across tools.
+
+### 8. Fixing the root cause makes old workaround `cast()`s redundant — clean them up
+
+Once you fix the systemic issue, re-run both tools and look specifically for `redundant-cast` warnings. Every `cast("Element", root)` that existed purely to placate mypy's `ignore_missing_imports` fallback becomes genuinely unnecessary once the real type flows through correctly, and leaving it in is now dead weight (and a `ty`/`pyrefly` warning) rather than a workaround. This is a good automatic signal that the root-cause fix actually landed.
+
+### 9. Some "strict" rules are mechanical churn, not bug-catching — decide explicitly, don't default to on
+
+Pyrefly's `strict` preset (and to a lesser extent `ty`'s optional rules) includes checks like `missing-override-decorator` (PEP 698 `@override`), which can flag **dozens to low-hundreds** of ordinary `__repr__`/`__init__`/method overrides in any codebase with meaningful inheritance. This is a legitimate check with real value in large team codebases (catches silently-broken overrides after a base-class rename), but adding `@override` everywhere is a large, purely mechanical diff disconnected from the actual "fix type errors" task.
+
+Don't silently turn this on or off. Surface it explicitly (to a human reviewer, or via an explicit question if you're an agent) before deciding: disable it with a documented reason, or actually do the sweep. Either is defensible; picking silently isn't.
+
+### 10. Test-file "narrowing noise" is real but should not become a license to blanket-suppress everything
+
+The overwhelming majority of test-file errors in a mature test suite will be the same shape: construct an object, then immediately access/assign a field typed `X | None` or `A | B | None`, without a narrowing `assert x is not None` — because the test *knows* the value is set (it just set it three lines up) but the checker doesn't. This is legitimately safe to bulk-suppress scoped to the test tree:
+
+```toml
+[[tool.pyrefly.sub-config]]
+matches = "tests/**/*"
+[tool.pyrefly.sub-config.errors]
+missing-attribute = "ignore"
+
+[[tool.ty.overrides]]
+include = ["tests/**"]
+rules = { unresolved-attribute = "ignore", invalid-assignment = "ignore" }
+```
+
+But scope the suppressed **rule names** narrowly (`unresolved-attribute`/`missing-attribute`/the specific `invalid-assignment` shape), not broad categories like `invalid-argument-type`/`bad-argument-type` — those catch genuinely wrong types passed into calls, which do happen in test code (typos, copy-paste of the wrong fixture) and are worth keeping visible. In the fastkml migration, roughly 90% of test-file errors were narrowing noise safely bulk-suppressed, and the remaining 10% surfaced one genuine test bug (a string literal assigned where an enum member was expected) plus a batch of deliberately-invalid-input tests that just needed their ignore-comment syntax migrated (see pitfall 1).
+
+## Phase 3 — Work file by file for what's left
+
+After the systemic fix and the bulk test-suppression, what remains is usually a short, tractable list (tens, not hundreds, of diagnostics). For each:
+
+1. **Read the surrounding code before deciding how to fix it.** The same `unresolved-attribute` shape can be a real narrowing gap (add `assert x is not None`, matching the style already used elsewhere in the file), a genuine latent bug (an off-by-one/empty-tuple case an unpacking `*args` call didn't guard against), or a structural dispatch limitation (pitfall 5).
+2. **Prefer a real fix over a cast or ignore** wherever one exists cheaply: correcting a wrong return-type annotation (`Optional[X]` that never actually returns `None`), adding `isinstance` narrowing instead of a loose dict-dispatch, genericizing a `find`/`find_all`-style utility with `@overload` + a `TypeVar` instead of returning `object`.
+3. **Use `cast()` with a one-line comment explaining *why*** when the limitation is structural (pitfalls 4-6), not because you're in a hurry.
+4. Re-run the checker on just that file after each fix (`ty check path/to/file.py`) — faster feedback loop than re-running the whole tree, and it confirms the fix didn't introduce a new diagnostic in the same file.
+
+## Phase 4 — Tighten to "maximum quality"
+
+Once both tools report zero errors on the fixed baseline, raise the bar deliberately rather than assuming the default preset is already strict:
+
+```toml
+[tool.pyrefly]
+preset = "strict"   # not "legacy" / "default" — legacy exists specifically to ease mypy migrations, it's a floor, not a target
+
+[tool.ty.rules]
+# Promote rules ty ships at warn/ignore by default; discover the full list with `ty explain rule`.
+possibly-missing-attribute = "error"
+possibly-missing-import = "error"
+possibly-unresolved-reference = "error"
+missing-type-argument = "error"
+unused-ignore-comment = "error"
+unused-type-ignore-comment = "error"
+redundant-cast = "error"
+```
+
+Discover what's available rather than guessing:
+
+```bash
+ty explain rule                 # every rule, default level, rationale, examples
+pyrefly check --help            # --preset options, --error/--warn/--ignore, --replace-imports-with-any, etc.
+pyrefly dump-config             # what's actually active for this project right now
+```
+
+## Phase 5 — Verify
+
+Don't call it done on "the type checker is quiet." Run the full loop:
+
+```bash
+ty check <src> <tests>
+pyrefly check <src> <tests>
+ruff check --no-fix <src> <tests>          # type-fix edits (casts, isinstance, overloads) can introduce lint issues
+ruff format --check <src> <tests>
+python -m pytest                            # with optional runtime deps installed
+uv pip uninstall <optional-dep>             # e.g. lxml
+python -m pytest -m "not <slow-marker>"     # confirm the fallback code path still works
+uv pip install -e ".[typing,<optional-dep>]"
+python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"
+```
+
+The "uninstall the optional dependency and re-run tests" step matters specifically because Phase 2's fix changes how the optional backend is *typed*, not just how it's imported — if the runtime fallback logic was touched at all while chasing type errors, this is the step that catches a broken fallback path before it ships.
+
+## Case study numbers (fastkml)
+
+For calibration on what "a lot of noise, mostly one root cause" looks like in practice:
+
+- Baseline: `ty` reported 237 diagnostics across source + tests; `pyrefly` reported 40 errors (with an already-too-permissive config suppressing 38 more).
+- One import-site fix (Phase 2, aliasing the duck-typed `Element` Protocol and `etree` module to `lxml`'s real stubs under `TYPE_CHECKING`) collapsed `ty`'s source-only count from 47 to 13 in a single step.
+- Total genuine bugs found and fixed in library source: 5 (a missed `.getroot()` call, an unguarded empty-tuple unpack in a `zip_longest` loop, a too-loose `type[object]` dispatch signature, a `Self`-in-a-list invariance issue, and one example script passing `bytes` where `str` was expected).
+- Total genuine bugs found and fixed in tests: 1 (a string literal compared against an enum field).
+- Final state: zero errors on `ty check` and `pyrefly check` for the CI-covered scope, with all pre-existing tests still passing, both with and without the optional `lxml` backend installed.

--- a/examples/read_kml.py
+++ b/examples/read_kml.py
@@ -31,7 +31,7 @@ doc = """<?xml version="1.0" encoding="UTF-8"?>
 
 # Create the KML object to store the parsed result
 # Read in the KML string
-k = kml.KML.from_string(doc.encode("utf-8"))
+k = kml.KML.from_string(doc)
 
 # Next we perform some simple sanity checks
 

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -4,7 +4,7 @@ import pathlib
 from fastkml import kml
 
 
-def print_child_features(element, depth=0):
+def print_child_features(element: object, depth: int = 0) -> None:
     """Prints the name of every child node of the given element, recursively."""
     if not getattr(element, "features", None):
         return

--- a/examples/transform_cascading_style.py
+++ b/examples/transform_cascading_style.py
@@ -70,6 +70,9 @@ registry.register(
 
 cs_kml = KML.parse(examples_dir / "gx_cascading_style.kml", validate=False)
 document = find(cs_kml, of_type=Document)
+assert document is not None  # noqa: S101
+# gx_cascading_style is a dynamic attribute added to Document by the
+# registry.register() call above; Document's type doesn't declare it.
 for cascading_style in document.gx_cascading_style:
     kml_style = cascading_style.style
     kml_style.id = cascading_style.id

--- a/examples/transform_cascading_style.py
+++ b/examples/transform_cascading_style.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import pathlib
 from typing import Any
-from typing import Optional
 
 from fastkml import KML
 from fastkml import Document
@@ -31,11 +30,11 @@ class CascadingStyle(_BaseObject):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        style: Optional[Style] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        style: Style | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the CascadingStyle object."""

--- a/fastkml/abstract_geometry.py
+++ b/fastkml/abstract_geometry.py
@@ -26,7 +26,6 @@ elements.
 """
 
 from typing import Any
-from typing import Optional
 
 from fastkml.enums import AltitudeMode
 from fastkml.kml_base import _BaseObject
@@ -41,16 +40,16 @@ class _Geometry(_BaseObject):
 
     """
 
-    altitude_mode: Optional[AltitudeMode]
+    altitude_mode: AltitudeMode | None
 
     def __init__(
         self,
         *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        altitude_mode: AltitudeMode | None = None,
         **kwargs: Any,
     ) -> None:
         """

--- a/fastkml/atom.py
+++ b/fastkml/atom.py
@@ -35,7 +35,6 @@ This library only implements a subset of Atom that is useful with KML
 
 import logging
 from typing import Any
-from typing import Optional
 
 from fastkml import config
 from fastkml.base import _XMLObject
@@ -82,23 +81,23 @@ class Link(_AtomObject):
     title, and length.
     """
 
-    href: Optional[str]
-    rel: Optional[str]
-    type: Optional[str]
-    hreflang: Optional[str]
-    title: Optional[str]
-    length: Optional[int]
+    href: str | None
+    rel: str | None
+    type: str | None
+    hreflang: str | None
+    title: str | None
+    length: int | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        href: Optional[str] = None,
-        rel: Optional[str] = None,
-        type: Optional[str] = None,  # noqa: A002
-        hreflang: Optional[str] = None,
-        title: Optional[str] = None,
-        length: Optional[int] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        href: str | None = None,
+        rel: str | None = None,
+        type: str | None = None,  # noqa: A002
+        hreflang: str | None = None,
+        title: str | None = None,
+        length: int | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -258,17 +257,17 @@ class _Person(_AtomObject):
 
     """
 
-    name: Optional[str]
-    uri: Optional[str]
-    email: Optional[str]
+    name: str | None
+    uri: str | None
+    email: str | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        name: Optional[str] = None,
-        uri: Optional[str] = None,
-        email: Optional[str] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        name: str | None = None,
+        uri: str | None = None,
+        email: str | None = None,
         **kwargs: Any,
     ) -> None:
         """

--- a/fastkml/base.py
+++ b/fastkml/base.py
@@ -33,7 +33,6 @@ consistent handling of XML operations across the library.
 
 import logging
 from typing import Any
-from typing import Optional
 
 from typing_extensions import Self
 
@@ -58,8 +57,8 @@ class _XMLObject:
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -135,7 +134,7 @@ class _XMLObject:
 
     def etree_element(
         self,
-        precision: Optional[int] = None,
+        precision: int | None = None,
         verbosity: Verbosity = Verbosity.normal,
     ) -> Element:
         """
@@ -175,7 +174,7 @@ class _XMLObject:
     def populate_element(
         self,
         element: Element,
-        precision: Optional[int] = None,
+        precision: int | None = None,
         verbosity: Verbosity = Verbosity.normal,
     ) -> None:
         """
@@ -211,7 +210,7 @@ class _XMLObject:
         self,
         *,
         prettyprint: bool = True,
-        precision: Optional[int] = None,
+        precision: int | None = None,
         verbosity: Verbosity = Verbosity.normal,
     ) -> str:
         """
@@ -248,7 +247,7 @@ class _XMLObject:
                 encoding="unicode",
             )
 
-    def validate(self) -> Optional[bool]:
+    def validate(self) -> bool | None:
         """
         Validate the KML object against the XML schema.
 
@@ -295,7 +294,7 @@ class _XMLObject:
         return cls.__name__
 
     @classmethod
-    def _get_ns(cls, ns: Optional[str], name_spaces: dict[str, str]) -> str:
+    def _get_ns(cls, ns: str | None, name_spaces: dict[str, str]) -> str:
         """
         Get the namespace.
 
@@ -319,7 +318,7 @@ class _XMLObject:
         cls,
         *,
         ns: str,
-        name_spaces: Optional[dict[str, str]] = None,
+        name_spaces: dict[str, str] | None = None,
         element: Element,
         strict: bool,
     ) -> dict[str, Any]:
@@ -407,7 +406,7 @@ class _XMLObject:
         cls,
         *,
         ns: str,
-        name_spaces: Optional[dict[str, str]] = None,
+        name_spaces: dict[str, str] | None = None,
         element: Element,
         strict: bool,
     ) -> Self:
@@ -446,8 +445,8 @@ class _XMLObject:
         cls,
         string: str,
         *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
         strict: bool = True,
     ) -> Self:
         """

--- a/fastkml/base.py
+++ b/fastkml/base.py
@@ -476,5 +476,8 @@ class _XMLObject:
             ns=ns,
             name_spaces=name_spaces,
             strict=strict,
-            element=config.etree.fromstring(string),
+            # lxml rejects a `str` with an XML encoding declaration
+            # (`<?xml ... encoding="..."?>`); bytes let it honor the
+            # declared encoding itself.
+            element=config.etree.fromstring(string.encode("utf-8")),
         )

--- a/fastkml/base.py
+++ b/fastkml/base.py
@@ -34,7 +34,6 @@ consistent handling of XML operations across the library.
 import logging
 from typing import Any
 from typing import Optional
-from typing import cast
 
 from typing_extensions import Self
 
@@ -238,21 +237,15 @@ class _XMLObject:
             verbosity=verbosity,
         )
         try:
-            return cast(
-                "str",
-                config.etree.tostring(
-                    element,
-                    encoding="unicode",
-                    pretty_print=prettyprint,
-                ),
+            return config.etree.tostring(
+                element,
+                encoding="unicode",
+                pretty_print=prettyprint,
             )
         except TypeError:
-            return cast(
-                "str",
-                config.etree.tostring(
-                    element,
-                    encoding="unicode",
-                ),
+            return config.etree.tostring(
+                element,
+                encoding="unicode",
             )
 
     def validate(self) -> Optional[bool]:
@@ -484,8 +477,5 @@ class _XMLObject:
             ns=ns,
             name_spaces=name_spaces,
             strict=strict,
-            element=cast(
-                "Element",
-                config.etree.fromstring(string),
-            ),
+            element=config.etree.fromstring(string),
         )

--- a/fastkml/config.py
+++ b/fastkml/config.py
@@ -19,6 +19,7 @@
 import logging
 import warnings
 from types import ModuleType
+from typing import TYPE_CHECKING
 from typing import Final
 
 __all__ = [
@@ -32,12 +33,17 @@ __all__ = [
     "set_etree_implementation",
 ]
 
-try:  # pragma: no cover
+if TYPE_CHECKING:
+    # Type checkers see lxml's own (permissive) stubs, since lxml is the
+    # preferred backend and its API is a superset of xml.etree.ElementTree's.
     from lxml import etree
+else:
+    try:  # pragma: no cover
+        from lxml import etree
 
-except ImportError:  # pragma: no cover
-    warnings.warn("Package `lxml` missing. Pretty print will be disabled")  # noqa: B028
-    import xml.etree.ElementTree as etree  # noqa: N813, ICN001
+    except ImportError:  # pragma: no cover
+        warnings.warn("Package `lxml` missing. Pretty print will be disabled")  # noqa: B028
+        import xml.etree.ElementTree as etree  # noqa: N813, ICN001
 
 
 logger = logging.getLogger(__name__)
@@ -46,7 +52,7 @@ logger = logging.getLogger(__name__)
 def set_etree_implementation(implementation: ModuleType) -> None:
     """Set the etree implementation to use."""
     global etree  # noqa: PLW0603
-    etree = implementation
+    etree = implementation  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
 
 
 KML: Final = "kml"

--- a/fastkml/containers.py
+++ b/fastkml/containers.py
@@ -19,8 +19,6 @@ import logging
 import urllib.parse as urlparse
 from collections.abc import Iterable
 from typing import Any
-from typing import Optional
-from typing import Union
 
 from fastkml import atom
 from fastkml.data import ExtendedData
@@ -65,27 +63,27 @@ class _Container(_Feature):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        name: Optional[str] = None,
-        visibility: Optional[bool] = None,
-        isopen: Optional[bool] = None,
-        atom_link: Optional[atom.Link] = None,
-        atom_author: Optional[atom.Author] = None,
-        address: Optional[str] = None,
-        phone_number: Optional[str] = None,
-        snippet: Optional[Snippet] = None,
-        description: Optional[str] = None,
-        view: Optional[Union[Camera, LookAt]] = None,
-        times: Optional[Union[TimeSpan, TimeStamp]] = None,
-        style_url: Optional[StyleUrl] = None,
-        styles: Optional[Iterable[Union[Style, StyleMap]]] = None,
-        region: Optional[Region] = None,
-        extended_data: Optional[ExtendedData] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        name: str | None = None,
+        visibility: bool | None = None,
+        isopen: bool | None = None,
+        atom_link: atom.Link | None = None,
+        atom_author: atom.Author | None = None,
+        address: str | None = None,
+        phone_number: str | None = None,
+        snippet: Snippet | None = None,
+        description: str | None = None,
+        view: Camera | LookAt | None = None,
+        times: TimeSpan | TimeStamp | None = None,
+        style_url: StyleUrl | None = None,
+        styles: Iterable[Style | StyleMap] | None = None,
+        region: Region | None = None,
+        extended_data: ExtendedData | None = None,
         # Container specific
-        features: Optional[Iterable[_Feature]] = None,
+        features: Iterable[_Feature] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -171,27 +169,27 @@ class Document(_Container):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        name: Optional[str] = None,
-        visibility: Optional[bool] = None,
-        isopen: Optional[bool] = None,
-        atom_link: Optional[atom.Link] = None,
-        atom_author: Optional[atom.Author] = None,
-        address: Optional[str] = None,
-        phone_number: Optional[str] = None,
-        snippet: Optional[Snippet] = None,
-        description: Optional[str] = None,
-        view: Optional[Union[Camera, LookAt]] = None,
-        times: Optional[Union[TimeSpan, TimeStamp]] = None,
-        style_url: Optional[StyleUrl] = None,
-        styles: Optional[Iterable[Union[Style, StyleMap]]] = None,
-        region: Optional[Region] = None,
-        extended_data: Optional[ExtendedData] = None,
-        features: Optional[Iterable[_Feature]] = None,
-        schemata: Optional[Iterable[Schema]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        name: str | None = None,
+        visibility: bool | None = None,
+        isopen: bool | None = None,
+        atom_link: atom.Link | None = None,
+        atom_author: atom.Author | None = None,
+        address: str | None = None,
+        phone_number: str | None = None,
+        snippet: Snippet | None = None,
+        description: str | None = None,
+        view: Camera | LookAt | None = None,
+        times: TimeSpan | TimeStamp | None = None,
+        style_url: StyleUrl | None = None,
+        styles: Iterable[Style | StyleMap] | None = None,
+        region: Region | None = None,
+        extended_data: ExtendedData | None = None,
+        features: Iterable[_Feature] | None = None,
+        schemata: Iterable[Schema] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -282,7 +280,7 @@ class Document(_Container):
             ")"
         )
 
-    def get_style_by_url(self, style_url: str) -> Optional[Union[Style, StyleMap]]:
+    def get_style_by_url(self, style_url: str) -> Style | StyleMap | None:
         """
         Get a style by URL.
 

--- a/fastkml/containers.py
+++ b/fastkml/containers.py
@@ -298,7 +298,7 @@ class Document(_Container):
 
         """
         id_ = urlparse.urlparse(style_url).fragment
-        return next(  # type: ignore[return-value]
+        return next(
             find_all(
                 self,
                 of_type=(Style, StyleMap),

--- a/fastkml/data.py
+++ b/fastkml/data.py
@@ -22,8 +22,6 @@ https://developers.google.com/kml/documentation/extendeddata
 import logging
 from collections.abc import Iterable
 from typing import Any
-from typing import Optional
-from typing import Union
 
 from fastkml.base import _XMLObject
 from fastkml.enums import DataType
@@ -82,17 +80,17 @@ class SimpleField(_XMLObject):
 
     _default_nsid = "kml"
 
-    name: Optional[str]
-    type_: Optional[DataType]
-    display_name: Optional[str]
+    name: str | None
+    type_: DataType | None
+    display_name: str | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        name: Optional[str] = None,
-        type_: Optional[DataType] = None,
-        display_name: Optional[str] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        name: str | None = None,
+        type_: DataType | None = None,
+        display_name: str | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -202,18 +200,18 @@ class Schema(_XMLObject):
 
     _default_nsid = "kml"
 
-    name: Optional[str]
+    name: str | None
     fields: list[SimpleField]
     array_fields: list[SimpleArrayField]
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        name: Optional[str] = None,
-        fields: Optional[Iterable[SimpleField]] = None,
-        array_fields: Optional[Iterable[SimpleArrayField]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        name: str | None = None,
+        fields: Iterable[SimpleField] | None = None,
+        array_fields: Iterable[SimpleArrayField] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -279,7 +277,7 @@ class Schema(_XMLObject):
             ")"
         )
 
-    def append(self, field: Union[SimpleField, SimpleArrayField]) -> None:
+    def append(self, field: SimpleField | SimpleArrayField) -> None:
         """
         Append a field to the schema.
 
@@ -344,19 +342,19 @@ registry.register(
 class Data(_BaseObject):
     """Represents an untyped name/value pair with optional display name."""
 
-    name: Optional[str]
-    value: Optional[str]
-    display_name: Optional[str]
+    name: str | None
+    value: str | None
+    display_name: str | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        name: Optional[str] = None,
-        value: Optional[str] = None,
-        display_name: Optional[str] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        name: str | None = None,
+        value: str | None = None,
+        display_name: str | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -472,15 +470,15 @@ class SimpleData(_XMLObject):
 
     _default_nsid = "kml"
 
-    name: Optional[str]
-    value: Optional[str]
+    name: str | None
+    value: str | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        name: Optional[str] = None,
-        value: Optional[str] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        name: str | None = None,
+        value: str | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -570,19 +568,19 @@ class SchemaData(_BaseObject):
     SchemaData element.
     """
 
-    schema_url: Optional[str]
+    schema_url: str | None
     data: list[SimpleData]
     array_data: list[SimpleArrayData]
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        schema_url: Optional[str] = None,
-        data: Optional[Iterable[SimpleData]] = None,
-        array_data: Optional[Iterable[SimpleArrayData]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        schema_url: str | None = None,
+        data: Iterable[SimpleData] | None = None,
+        array_data: Iterable[SimpleArrayData] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -644,7 +642,7 @@ class SchemaData(_BaseObject):
         """
         return (bool(self.data) or bool(self.array_data)) and bool(self.schema_url)
 
-    def append_data(self, data: Union[SimpleData, SimpleArrayData]) -> None:
+    def append_data(self, data: SimpleData | SimpleArrayData) -> None:
         """
         Append a data object to the SchemaData.
 
@@ -700,13 +698,13 @@ class ExtendedData(_XMLObject):
     """Represents a list of untyped name/value pairs."""
 
     _default_nsid = "kml"
-    elements: list[Union[Data, SchemaData]]
+    elements: list[Data | SchemaData]
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        elements: Optional[Iterable[Union[Data, SchemaData]]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        elements: Iterable[Data | SchemaData] | None = None,
         **kwargs: Any,
     ) -> None:
         """

--- a/fastkml/features.py
+++ b/fastkml/features.py
@@ -22,8 +22,6 @@ These are the objects that can be added to a KML file.
 import logging
 from collections.abc import Iterable
 from typing import Any
-from typing import Optional
-from typing import Union
 
 from pygeoif.types import GeoCollectionType
 from pygeoif.types import GeoType
@@ -73,16 +71,16 @@ __all__ = ["NetworkLink", "Placemark", "Snippet"]
 
 logger = logging.getLogger(__name__)
 
-KmlGeometry = Union[
-    Point,
-    LineString,
-    LinearRing,
-    Polygon,
-    Model,
-    MultiGeometry,
-    MultiTrack,
-    Track,
-]
+KmlGeometry = (
+    Point
+    | LineString
+    | LinearRing
+    | Polygon
+    | Model
+    | MultiGeometry
+    | MultiTrack
+    | Track
+)
 
 
 class Snippet(_XMLObject):
@@ -104,15 +102,15 @@ class Snippet(_XMLObject):
 
     _default_nsid = config.KML
 
-    text: Optional[str]
-    max_lines: Optional[int] = None
+    text: str | None
+    max_lines: int | None = None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        text: Optional[str] = None,
-        max_lines: Optional[int] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        text: str | None = None,
+        max_lines: int | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -209,42 +207,42 @@ class _Feature(TimeMixin, _BaseObject):
         - NetworkLink.
     """
 
-    name: Optional[str]
-    visibility: Optional[bool]
-    isopen: Optional[bool]
-    atom_author: Optional[atom.Author]
-    atom_link: Optional[atom.Link]
-    address: Optional[str]
-    phone_number: Optional[str]
-    snippet: Optional[Snippet]
-    description: Optional[str]
-    style_url: Optional[StyleUrl]
-    styles: list[Union[Style, StyleMap]]
-    view: Union[Camera, LookAt, None]
-    region: Optional[Region]
-    extended_data: Optional[ExtendedData]
+    name: str | None
+    visibility: bool | None
+    isopen: bool | None
+    atom_author: atom.Author | None
+    atom_link: atom.Link | None
+    address: str | None
+    phone_number: str | None
+    snippet: Snippet | None
+    description: str | None
+    style_url: StyleUrl | None
+    styles: list[Style | StyleMap]
+    view: Camera | LookAt | None
+    region: Region | None
+    extended_data: ExtendedData | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        name: Optional[str] = None,
-        visibility: Optional[bool] = None,
-        isopen: Optional[bool] = None,
-        atom_link: Optional[atom.Link] = None,
-        atom_author: Optional[atom.Author] = None,
-        address: Optional[str] = None,
-        phone_number: Optional[str] = None,
-        snippet: Optional[Snippet] = None,
-        description: Optional[str] = None,
-        view: Optional[Union[Camera, LookAt]] = None,
-        times: Optional[Union[TimeSpan, TimeStamp]] = None,
-        style_url: Optional[StyleUrl] = None,
-        styles: Optional[Iterable[Union[Style, StyleMap]]] = None,
-        region: Optional[Region] = None,
-        extended_data: Optional[ExtendedData] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        name: str | None = None,
+        visibility: bool | None = None,
+        isopen: bool | None = None,
+        atom_link: atom.Link | None = None,
+        atom_author: atom.Author | None = None,
+        address: str | None = None,
+        phone_number: str | None = None,
+        snippet: Snippet | None = None,
+        description: str | None = None,
+        view: Camera | LookAt | None = None,
+        times: TimeSpan | TimeStamp | None = None,
+        style_url: StyleUrl | None = None,
+        styles: Iterable[Style | StyleMap] | None = None,
+        region: Region | None = None,
+        extended_data: ExtendedData | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -494,32 +492,32 @@ class Placemark(_Feature):
     marks a point on the Earth in the 3D viewer.
     """
 
-    kml_geometry: Optional[KmlGeometry]
+    kml_geometry: KmlGeometry | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        name: Optional[str] = None,
-        visibility: Optional[bool] = None,
-        isopen: Optional[bool] = None,
-        atom_link: Optional[atom.Link] = None,
-        atom_author: Optional[atom.Author] = None,
-        address: Optional[str] = None,
-        phone_number: Optional[str] = None,
-        snippet: Optional[Snippet] = None,
-        description: Optional[str] = None,
-        view: Optional[Union[Camera, LookAt]] = None,
-        times: Optional[Union[TimeSpan, TimeStamp]] = None,
-        style_url: Optional[StyleUrl] = None,
-        styles: Optional[Iterable[Union[Style, StyleMap]]] = None,
-        region: Optional[Region] = None,
-        extended_data: Optional[ExtendedData] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        name: str | None = None,
+        visibility: bool | None = None,
+        isopen: bool | None = None,
+        atom_link: atom.Link | None = None,
+        atom_author: atom.Author | None = None,
+        address: str | None = None,
+        phone_number: str | None = None,
+        snippet: Snippet | None = None,
+        description: str | None = None,
+        view: Camera | LookAt | None = None,
+        times: TimeSpan | TimeStamp | None = None,
+        style_url: StyleUrl | None = None,
+        styles: Iterable[Style | StyleMap] | None = None,
+        region: Region | None = None,
+        extended_data: ExtendedData | None = None,
         # Placemark specific
-        kml_geometry: Optional[KmlGeometry] = None,
-        geometry: Optional[Union[GeoType, GeoCollectionType]] = None,
+        kml_geometry: KmlGeometry | None = None,
+        geometry: GeoType | GeoCollectionType | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -647,7 +645,7 @@ class Placemark(_Feature):
         )
 
     @property
-    def geometry(self) -> Optional[AnyGeometryType]:
+    def geometry(self) -> AnyGeometryType | None:
         """
         Returns the geometry associated with this feature.
 
@@ -726,35 +724,35 @@ class NetworkLink(_Feature):
     https://developers.google.com/kml/documentation/kmlreference#networklink
     """
 
-    refresh_visibility: Optional[bool]
-    fly_to_view: Optional[bool]
-    link: Optional[Link]
+    refresh_visibility: bool | None
+    fly_to_view: bool | None
+    link: Link | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        name: Optional[str] = None,
-        visibility: Optional[bool] = None,
-        isopen: Optional[bool] = None,
-        atom_link: Optional[atom.Link] = None,
-        atom_author: Optional[atom.Author] = None,
-        address: Optional[str] = None,
-        phone_number: Optional[str] = None,
-        snippet: Optional[Snippet] = None,
-        description: Optional[str] = None,
-        view: Optional[Union[Camera, LookAt]] = None,
-        times: Optional[Union[TimeSpan, TimeStamp]] = None,
-        style_url: Optional[StyleUrl] = None,
-        styles: Optional[Iterable[Union[Style, StyleMap]]] = None,
-        region: Optional[Region] = None,
-        extended_data: Optional[ExtendedData] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        name: str | None = None,
+        visibility: bool | None = None,
+        isopen: bool | None = None,
+        atom_link: atom.Link | None = None,
+        atom_author: atom.Author | None = None,
+        address: str | None = None,
+        phone_number: str | None = None,
+        snippet: Snippet | None = None,
+        description: str | None = None,
+        view: Camera | LookAt | None = None,
+        times: TimeSpan | TimeStamp | None = None,
+        style_url: StyleUrl | None = None,
+        styles: Iterable[Style | StyleMap] | None = None,
+        region: Region | None = None,
+        extended_data: ExtendedData | None = None,
         # NetworkLink specific
-        refresh_visibility: Optional[bool] = None,
-        fly_to_view: Optional[bool] = None,
-        link: Optional[Link] = None,
+        refresh_visibility: bool | None = None,
+        fly_to_view: bool | None = None,
+        link: Link | None = None,
         **kwargs: Any,
     ) -> None:
         """

--- a/fastkml/geometry.py
+++ b/fastkml/geometry.py
@@ -42,7 +42,6 @@ from pygeoif.factories import shape
 from pygeoif.types import GeoCollectionType
 from pygeoif.types import GeoType
 from pygeoif.types import LineType
-from typing_extensions import Self
 
 from fastkml import config
 from fastkml.abstract_geometry import _Geometry
@@ -212,9 +211,10 @@ def subelement_coordinates_kwarg(
         return {}
     try:
         return {
-            kwarg: [  # type: ignore[dict-item]
-                tuple(float(c) for c in latlon.split(",")) for latlon in latlons
-            ],
+            kwarg: cast(
+                "LineType",
+                [tuple(float(c) for c in latlon.split(",")) for latlon in latlons],
+            ),
         }
     except ValueError as error:
         handle_invalid_geometry_error(
@@ -301,7 +301,7 @@ registry.register(
     Coordinates,
     item=RegistryItem(
         ns_ids=("kml", ""),
-        classes=(LineType,),  # type: ignore[arg-type]
+        classes=(object,),
         attr_name="coords",
         node_name="coordinates",
         get_kwarg=subelement_coordinates_kwarg,
@@ -363,8 +363,11 @@ class Point(_Geometry):
         if geometry is not None and kml_coordinates is not None:
             raise GeometryError(MsgMutualExclusive)
         if kml_coordinates is None and geometry:
+            # geo.Point.coords is `tuple[PointType] | tuple[()]`, always a
+            # single homogeneous 2- or 3-tuple, but not expressible as such
+            # in pygeoif's types.
             kml_coordinates = (
-                Coordinates(coords=geometry.coords)  # type: ignore[arg-type]
+                Coordinates(coords=cast("LineType", geometry.coords))
                 if geometry
                 else None
             )
@@ -1166,16 +1169,17 @@ def create_multigeometry(
         return None
     if len(geom_types) == 1:
         geom_type = geom_types.pop()
-        map_to_geometries = {
-            geo.Point.__name__: geo.MultiPoint.from_points,
-            geo.LineString.__name__: geo.MultiLineString.from_linestrings,
-            geo.Polygon.__name__: geo.MultiPolygon.from_polygons,
-        }
-        for geometry_name, constructor in map_to_geometries.items():
-            if geom_type == geometry_name:
-                return constructor(  # type: ignore[operator, no-any-return]
-                    *geometries,
-                )
+        if geom_type == geo.Point.__name__:
+            points = [geom for geom in geometries if isinstance(geom, geo.Point)]
+            return geo.MultiPoint.from_points(*points)
+        if geom_type == geo.LineString.__name__:
+            linestrings = [
+                geom for geom in geometries if isinstance(geom, geo.LineString)
+            ]
+            return geo.MultiLineString.from_linestrings(*linestrings)
+        if geom_type == geo.Polygon.__name__:
+            polygons = [geom for geom in geometries if isinstance(geom, geo.Polygon)]
+            return geo.MultiPolygon.from_polygons(*polygons)
 
     return geo.GeometryCollection(geometries)
 
@@ -1183,9 +1187,7 @@ def create_multigeometry(
 class MultiGeometry(_BaseObject):
     """A container for zero or more geometry primitives."""
 
-    kml_geometries: list[
-        Union[Point, LineString, Polygon, LinearRing, Self, Track, MultiTrack]
-    ]
+    kml_geometries: list["KMLGeometryType"]
 
     def __init__(
         self,
@@ -1197,11 +1199,7 @@ class MultiGeometry(_BaseObject):
         extrude: Optional[bool] = None,
         tessellate: Optional[bool] = None,
         altitude_mode: Optional[AltitudeMode] = None,
-        kml_geometries: Optional[
-            Iterable[
-                Union[Point, LineString, Polygon, LinearRing, Self, Track, MultiTrack]
-            ]
-        ] = None,
+        kml_geometries: Optional[Iterable["KMLGeometryType"]] = None,
         geometry: Optional[MultiGeometryType] = None,
         **kwargs: Any,
     ) -> None:
@@ -1256,7 +1254,7 @@ class MultiGeometry(_BaseObject):
             raise GeometryError(MsgMutualExclusive)
         if geometry is not None:
             kml_geometries = [
-                create_kml_geometry(  # type: ignore[misc]
+                create_kml_geometry(
                     geometry=geom,
                     ns=ns,
                     name_spaces=name_spaces,

--- a/fastkml/geometry.py
+++ b/fastkml/geometry.py
@@ -32,8 +32,6 @@ from collections.abc import Sequence
 from typing import Any
 from typing import Final
 from typing import NoReturn
-from typing import Optional
-from typing import Union
 from typing import cast
 
 import pygeoif.geometry as geo
@@ -83,14 +81,11 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-GeometryType = Union[geo.Polygon, geo.LineString, geo.LinearRing, geo.Point]
-MultiGeometryType = Union[
-    geo.MultiPoint,
-    geo.MultiLineString,
-    geo.MultiPolygon,
-    geo.GeometryCollection,
-]
-AnyGeometryType = Union[GeometryType, MultiGeometryType]
+GeometryType = geo.Polygon | geo.LineString | geo.LinearRing | geo.Point
+MultiGeometryType = (
+    geo.MultiPoint | geo.MultiLineString | geo.MultiPolygon | geo.GeometryCollection
+)
+AnyGeometryType = GeometryType | MultiGeometryType
 
 MsgMutualExclusive: Final = "Geometry and kml coordinates are mutually exclusive"
 
@@ -133,14 +128,42 @@ def handle_invalid_geometry_error(
         raise KMLParseError(msg) from error
 
 
+def _format_coordinates(coords: Any, *, precision: int | None) -> str:
+    """
+    Format coordinates as a KML coordinates string.
+
+    Args:
+    ----
+        coords: The coordinate tuples to format.
+        precision (Optional[int]): The precision of the coordinate values.
+
+    Returns:
+    -------
+        str: The formatted coordinates string.
+
+    Raises:
+    ------
+        KMLWriteError: If the coordinates have invalid dimensions.
+
+    """
+    if not coords or len(coords[0]) not in (2, 3):
+        msg = f"Invalid dimensions in coordinates '{coords}'"
+        raise KMLWriteError(msg)
+    if precision is None:
+        tuples = (",".join(str(c) for c in coord) for coord in coords)
+    else:
+        tuples = (",".join(f"{c:.{precision}f}" for c in coord) for coord in coords)
+    return " ".join(tuples)
+
+
 def coordinates_subelement(
     obj: _XMLObject,
     *,
     element: Element,
     attr_name: str,
     node_name: str,  # noqa: ARG001
-    precision: Optional[int],
-    verbosity: Optional[Verbosity],  # noqa: ARG001
+    precision: int | None,
+    verbosity: Verbosity | None,  # noqa: ARG001
     default: Any,  # noqa: ARG001
 ) -> None:
     """
@@ -163,14 +186,7 @@ def coordinates_subelement(
     """
     if getattr(obj, attr_name, None):
         coords = getattr(obj, attr_name)
-        if not coords or len(coords[0]) not in (2, 3):
-            msg = f"Invalid dimensions in coordinates '{coords}'"
-            raise KMLWriteError(msg)
-        if precision is None:
-            tuples = (",".join(str(c) for c in coord) for coord in coords)
-        else:
-            tuples = (",".join(f"{c:.{precision}f}" for c in coord) for coord in coords)
-        element.text = " ".join(tuples)
+        element.text = _format_coordinates(coords, precision=precision)
 
 
 def subelement_coordinates_kwarg(
@@ -245,9 +261,9 @@ class Coordinates(_XMLObject):
     def __init__(
         self,
         *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        coords: Optional[LineType] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        coords: LineType | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -322,20 +338,20 @@ class Point(_Geometry):
     https://developers.google.com/kml/documentation/kmlreference#point
     """
 
-    extrude: Optional[bool]
-    kml_coordinates: Optional[Coordinates]
+    extrude: bool | None
+    kml_coordinates: Coordinates | None
 
     def __init__(
         self,
         *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        extrude: Optional[bool] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
-        geometry: Optional[geo.Point] = None,
-        kml_coordinates: Optional[Coordinates] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        extrude: bool | None = None,
+        altitude_mode: AltitudeMode | None = None,
+        geometry: geo.Point | None = None,
+        kml_coordinates: Coordinates | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -434,7 +450,7 @@ class Point(_Geometry):
     __hash__ = None  # type: ignore[assignment]
 
     @property
-    def geometry(self) -> Optional[geo.Point]:
+    def geometry(self) -> geo.Point | None:
         """
         Get the geometry object of the Point.
 
@@ -503,22 +519,22 @@ class LineString(_Geometry):
     https://developers.google.com/kml/documentation/kmlreference#linestring
     """
 
-    extrude: Optional[bool]
-    tessellate: Optional[bool]
-    kml_coordinates: Optional[Coordinates]
+    extrude: bool | None
+    tessellate: bool | None
+    kml_coordinates: Coordinates | None
 
     def __init__(
         self,
         *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        extrude: Optional[bool] = None,
-        tessellate: Optional[bool] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
-        geometry: Optional[geo.LineString] = None,
-        kml_coordinates: Optional[Coordinates] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        extrude: bool | None = None,
+        tessellate: bool | None = None,
+        altitude_mode: AltitudeMode | None = None,
+        geometry: geo.LineString | None = None,
+        kml_coordinates: Coordinates | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -603,7 +619,7 @@ class LineString(_Geometry):
     __hash__ = None  # type: ignore[assignment]
 
     @property
-    def geometry(self) -> Optional[geo.LineString]:
+    def geometry(self) -> geo.LineString | None:
         """
         Get the LineString geometry.
 
@@ -684,15 +700,15 @@ class LinearRing(LineString):
     def __init__(
         self,
         *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        extrude: Optional[bool] = None,
-        tessellate: Optional[bool] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
-        geometry: Optional[geo.LinearRing] = None,
-        kml_coordinates: Optional[Coordinates] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        extrude: bool | None = None,
+        tessellate: bool | None = None,
+        altitude_mode: AltitudeMode | None = None,
+        geometry: geo.LinearRing | None = None,
+        kml_coordinates: Coordinates | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -740,7 +756,7 @@ class LinearRing(LineString):
         )
 
     @property
-    def geometry(self) -> Optional[geo.LinearRing]:
+    def geometry(self) -> geo.LinearRing | None:
         """
         Get the geometry of the LinearRing.
 
@@ -773,15 +789,15 @@ class BoundaryIs(_XMLObject):
     """
 
     _default_nsid = config.KML
-    kml_geometry: Optional[LinearRing]
+    kml_geometry: LinearRing | None
 
     def __init__(
         self,
         *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        geometry: Optional[geo.LinearRing] = None,
-        kml_geometry: Optional[LinearRing] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        geometry: geo.LinearRing | None = None,
+        kml_geometry: LinearRing | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -850,7 +866,7 @@ class BoundaryIs(_XMLObject):
         )
 
     @property
-    def geometry(self) -> Optional[geo.LinearRing]:
+    def geometry(self) -> geo.LinearRing | None:
         """
         Get the geometry of the OuterBoundaryIs object.
 
@@ -931,24 +947,24 @@ class Polygon(_Geometry):
     https://developers.google.com/kml/documentation/kmlreference#polygon
     """
 
-    extrude: Optional[bool]
-    tessellate: Optional[bool]
-    outer_boundary: Optional[OuterBoundaryIs]
+    extrude: bool | None
+    tessellate: bool | None
+    outer_boundary: OuterBoundaryIs | None
     inner_boundaries: list[InnerBoundaryIs]
 
     def __init__(
         self,
         *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        extrude: Optional[bool] = None,
-        tessellate: Optional[bool] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
-        outer_boundary: Optional[OuterBoundaryIs] = None,
-        inner_boundaries: Optional[Iterable[InnerBoundaryIs]] = None,
-        geometry: Optional[geo.Polygon] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        extrude: bool | None = None,
+        tessellate: bool | None = None,
+        altitude_mode: AltitudeMode | None = None,
+        outer_boundary: OuterBoundaryIs | None = None,
+        inner_boundaries: Iterable[InnerBoundaryIs] | None = None,
+        geometry: geo.Polygon | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -1022,7 +1038,7 @@ class Polygon(_Geometry):
         return bool(self.outer_boundary)
 
     @property
-    def geometry(self) -> Optional[geo.Polygon]:
+    def geometry(self) -> geo.Polygon | None:
         """
         Get the geometry object representing the geometry of the Polygon.
 
@@ -1149,9 +1165,38 @@ registry.register(
 )
 
 
+def _create_homogeneous_multigeometry(
+    geom_type: str,
+    geometries: Sequence[AnyGeometryType],
+) -> MultiGeometryType | None:
+    """
+    Create a MultiGeometry from a sequence of geometries of a single type.
+
+    Args:
+    ----
+        geom_type: The shared geom_type of the geometries.
+        geometries: Sequence of geometries, all of the given geom_type.
+
+    Returns:
+    -------
+        MultiGeometry if geom_type is recognized, else None.
+
+    """
+    if geom_type == geo.Point.__name__:
+        points = [geom for geom in geometries if isinstance(geom, geo.Point)]
+        return geo.MultiPoint.from_points(*points)
+    if geom_type == geo.LineString.__name__:
+        linestrings = [geom for geom in geometries if isinstance(geom, geo.LineString)]
+        return geo.MultiLineString.from_linestrings(*linestrings)
+    if geom_type == geo.Polygon.__name__:
+        polygons = [geom for geom in geometries if isinstance(geom, geo.Polygon)]
+        return geo.MultiPolygon.from_polygons(*polygons)
+    return None
+
+
 def create_multigeometry(
     geometries: Sequence[AnyGeometryType],
-) -> Optional[MultiGeometryType]:
+) -> MultiGeometryType | None:
     """
     Create a MultiGeometry from a sequence of geometries.
 
@@ -1168,18 +1213,12 @@ def create_multigeometry(
     if not geom_types:
         return None
     if len(geom_types) == 1:
-        geom_type = geom_types.pop()
-        if geom_type == geo.Point.__name__:
-            points = [geom for geom in geometries if isinstance(geom, geo.Point)]
-            return geo.MultiPoint.from_points(*points)
-        if geom_type == geo.LineString.__name__:
-            linestrings = [
-                geom for geom in geometries if isinstance(geom, geo.LineString)
-            ]
-            return geo.MultiLineString.from_linestrings(*linestrings)
-        if geom_type == geo.Polygon.__name__:
-            polygons = [geom for geom in geometries if isinstance(geom, geo.Polygon)]
-            return geo.MultiPolygon.from_polygons(*polygons)
+        multigeometry = _create_homogeneous_multigeometry(
+            geom_types.pop(),
+            geometries,
+        )
+        if multigeometry is not None:
+            return multigeometry
 
     return geo.GeometryCollection(geometries)
 
@@ -1192,15 +1231,15 @@ class MultiGeometry(_BaseObject):
     def __init__(
         self,
         *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        extrude: Optional[bool] = None,
-        tessellate: Optional[bool] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
-        kml_geometries: Optional[Iterable["KMLGeometryType"]] = None,
-        geometry: Optional[MultiGeometryType] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        extrude: bool | None = None,
+        tessellate: bool | None = None,
+        altitude_mode: AltitudeMode | None = None,
+        kml_geometries: Iterable["KMLGeometryType"] | None = None,
+        geometry: MultiGeometryType | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -1291,7 +1330,7 @@ class MultiGeometry(_BaseObject):
         )
 
     @property
-    def geometry(self) -> Optional[MultiGeometryType]:
+    def geometry(self) -> MultiGeometryType | None:
         """Return the geometry of the MultiGeometry."""
         return create_multigeometry(
             [geom.geometry for geom in self.kml_geometries if geom.geometry],
@@ -1320,18 +1359,12 @@ registry.register(
 )
 
 
-KMLGeometryType = Union[
-    Point,
-    LineString,
-    Polygon,
-    LinearRing,
-    MultiGeometry,
-    Track,
-    MultiTrack,
-]
+KMLGeometryType = (
+    Point | LineString | Polygon | LinearRing | MultiGeometry | Track | MultiTrack
+)
 
 
-def _unknown_geometry_type(geometry: Union[GeoType, GeoCollectionType]) -> NoReturn:
+def _unknown_geometry_type(geometry: GeoType | GeoCollectionType) -> NoReturn:
     """
     Raise an error for an unknown geometry type.
 
@@ -1349,15 +1382,15 @@ def _unknown_geometry_type(geometry: Union[GeoType, GeoCollectionType]) -> NoRet
 
 
 def create_kml_geometry(
-    geometry: Union[GeoType, GeoCollectionType],
+    geometry: GeoType | GeoCollectionType,
     *,
-    ns: Optional[str] = None,
-    name_spaces: Optional[dict[str, str]] = None,
-    id: Optional[str] = None,
-    target_id: Optional[str] = None,
-    extrude: Optional[bool] = None,
-    tessellate: Optional[bool] = None,
-    altitude_mode: Optional[AltitudeMode] = None,
+    ns: str | None = None,
+    name_spaces: dict[str, str] | None = None,
+    id: str | None = None,
+    target_id: str | None = None,
+    extrude: bool | None = None,
+    tessellate: bool | None = None,
+    altitude_mode: AltitudeMode | None = None,
 ) -> KMLGeometryType:
     """
     Create a KML geometry from a geometry object.
@@ -1380,7 +1413,7 @@ def create_kml_geometry(
 
     """
     _map_to_kml: dict[
-        type[Union[GeoType, GeoCollectionType]],
+        type[GeoType | GeoCollectionType],
         type[KMLGeometryType],
     ] = {
         geo.Point: Point,

--- a/fastkml/gx/data.py
+++ b/fastkml/gx/data.py
@@ -18,7 +18,6 @@
 
 from collections.abc import Iterable
 from typing import Any
-from typing import Optional
 
 from fastkml import config
 from fastkml.base import _XMLObject
@@ -63,17 +62,17 @@ class SimpleArrayField(_XMLObject):
 
     _default_nsid = config.GX
 
-    name: Optional[str]
-    type_: Optional[DataType]
-    display_name: Optional[str]
+    name: str | None
+    type_: DataType | None
+    display_name: str | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        name: Optional[str] = None,
-        type_: Optional[DataType] = None,
-        display_name: Optional[str] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        name: str | None = None,
+        type_: DataType | None = None,
+        display_name: str | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -180,17 +179,17 @@ class SimpleArrayData(_BaseObject):
     """
 
     _default_nsid = config.GX
-    name: Optional[str]
-    data: list[Optional[str]]
+    name: str | None
+    data: list[str | None]
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        name: Optional[str] = None,
-        data: Optional[Iterable[str]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        name: str | None = None,
+        data: Iterable[str] | None = None,
         **kwargs: Any,
     ) -> None:
         """

--- a/fastkml/gx/track.py
+++ b/fastkml/gx/track.py
@@ -93,7 +93,7 @@ class TrackItem:
 
     when: KmlDateTime
     coord: geo.Point
-    angle: Optional[Angle] = None
+    angle: Angle | None = None
 
 
 def track_items_to_geometry(track_items: Iterable[TrackItem]) -> geo.LineString:
@@ -139,15 +139,15 @@ class Track(_Geometry):
     def __init__(
         self,
         *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
-        track_items: Optional[Iterable[TrackItem]] = None,
-        whens: Optional[Iterable[KmlDateTime]] = None,
-        coords: Optional[Iterable[PointType]] = None,
-        angles: Optional[Iterable[PointType]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        altitude_mode: AltitudeMode | None = None,
+        track_items: Iterable[TrackItem] | None = None,
+        whens: Iterable[KmlDateTime] | None = None,
+        coords: Iterable[PointType] | None = None,
+        angles: Iterable[PointType] | None = None,
         extended_data: Optional["ExtendedData"] = None,
         **kwargs: Any,
     ) -> None:
@@ -199,7 +199,7 @@ class Track(_Geometry):
                     coord=geo.Point(*coord),
                     angle=Angle(*angles[i]) if i < len(angles) else Angle(),
                 )
-                for i, (when, coord) in enumerate(zip(whens, coords))
+                for i, (when, coord) in enumerate(zip(whens, coords, strict=False))
             ]
         self.track_items = list(track_items) if track_items else []
         self.extended_data = extended_data
@@ -236,7 +236,7 @@ class Track(_Geometry):
         )
 
     @property
-    def geometry(self) -> Optional[geo.LineString]:
+    def geometry(self) -> geo.LineString | None:
         """
         Get the geometry of the track.
 
@@ -399,13 +399,13 @@ class MultiTrack(_Geometry):
     def __init__(
         self,
         *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
-        tracks: Optional[Iterable[Track]] = None,
-        interpolate: Optional[bool] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        altitude_mode: AltitudeMode | None = None,
+        tracks: Iterable[Track] | None = None,
+        interpolate: bool | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -456,7 +456,7 @@ class MultiTrack(_Geometry):
         )
 
     @property
-    def geometry(self) -> Optional[geo.MultiLineString]:
+    def geometry(self) -> geo.MultiLineString | None:
         """
         Get the geometry of the gx object.
 

--- a/fastkml/gx/track.py
+++ b/fastkml/gx/track.py
@@ -21,7 +21,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Optional
 
 import pygeoif.geometry as geo
 from pygeoif.types import PointType
@@ -134,7 +133,7 @@ class Track(_Geometry):
 
     _default_nsid = config.GX
     track_items: list[TrackItem]
-    extended_data: Optional["ExtendedData"]
+    extended_data: "ExtendedData | None"
 
     def __init__(
         self,
@@ -148,7 +147,7 @@ class Track(_Geometry):
         whens: Iterable[KmlDateTime] | None = None,
         coords: Iterable[PointType] | None = None,
         angles: Iterable[PointType] | None = None,
-        extended_data: Optional["ExtendedData"] = None,
+        extended_data: "ExtendedData | None" = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -199,7 +198,7 @@ class Track(_Geometry):
                     coord=geo.Point(*coord),
                     angle=Angle(*angles[i]) if i < len(angles) else Angle(),
                 )
-                for i, (when, coord) in enumerate(zip(whens, coords, strict=False))
+                for i, (when, coord) in enumerate(zip(whens, coords, strict=True))
             ]
         self.track_items = list(track_items) if track_items else []
         self.extended_data = extended_data

--- a/fastkml/gx/track.py
+++ b/fastkml/gx/track.py
@@ -19,11 +19,9 @@
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
-from itertools import zip_longest
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
-from typing import cast
 
 import pygeoif.geometry as geo
 from pygeoif.types import PointType
@@ -192,18 +190,16 @@ class Track(_Geometry):
             msg = "Cannot specify both geometry and track_items"
             raise ValueError(msg)
         if not track_items and whens and coords:
+            # `whens`/`coords` form mandatory pairs (a track item always
+            # needs a timestamp and a coordinate); `angles` may be shorter
+            # and defaults to Angle()'s all-zero heading/tilt/roll.
             track_items = [
                 TrackItem(
-                    when=cast("KmlDateTime", when),
+                    when=when,
                     coord=geo.Point(*coord),
-                    angle=Angle(*angle),
+                    angle=Angle(*angles[i]) if i < len(angles) else Angle(),
                 )
-                for when, coord, angle in zip_longest(
-                    whens,
-                    coords,
-                    angles,
-                    fillvalue=(),
-                )
+                for i, (when, coord) in enumerate(zip(whens, coords))
             ]
         self.track_items = list(track_items) if track_items else []
         self.extended_data = extended_data
@@ -277,9 +273,9 @@ class Track(_Geometry):
 
         """
         return tuple(
-            item.coord.coords[0]  # type: ignore[misc]
+            item.coord.coords[0]
             for item in self.track_items
-            if item.coord
+            if item.coord and item.coord.coords
         )
 
     @property

--- a/fastkml/helpers.py
+++ b/fastkml/helpers.py
@@ -91,7 +91,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def clean_string(value: Optional[str]) -> Optional[str]:
+def clean_string(value: str | None) -> str | None:
     """Clean and validate a string value, returning None if empty."""
     return value.strip() or None if value else None
 
@@ -155,8 +155,8 @@ def get_value(
     *,
     attr_name: str,
     verbosity: Verbosity,
-    default: Optional[Any],
-) -> Optional[Any]:
+    default: Any | None,
+) -> Any | None:
     """
     Get the value of an attribute from an object.
 
@@ -185,9 +185,9 @@ def node_text(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[str],
+    default: str | None,
 ) -> None:
     """
     Set the text of an XML element based on the attribute value in the given object.
@@ -230,9 +230,9 @@ def text_subelement(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[str],
+    default: str | None,
 ) -> None:
     """
     Set the value of an attribute from a subelement with a text node.
@@ -271,9 +271,9 @@ def text_subelement_kml(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[str],
+    default: str | None,
 ) -> None:
     """
     Set the value of an attribute from subelement with a text node in KML namespace.
@@ -312,9 +312,9 @@ def text_subelement_list(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[str],
+    default: str | None,
 ) -> None:
     """
     Set the value of an attribute from subelements with a text node.
@@ -354,9 +354,9 @@ def text_attribute(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[str],
+    default: str | None,
 ) -> None:
     """
     Set the value of an attribute from a subelement with a text node.
@@ -391,9 +391,9 @@ def bool_subelement(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[bool],
+    default: bool | None,
 ) -> None:
     """
     Set the value of an attribute from a subelement with a text node.
@@ -428,9 +428,9 @@ def int_subelement(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[int],
+    default: int | None,
 ) -> None:
     """
     Set the value of an attribute from a subelement with a text node.
@@ -465,9 +465,9 @@ def int_attribute(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[int],
+    default: int | None,
 ) -> None:
     """
     Set the value of an attribute.
@@ -498,9 +498,9 @@ def float_subelement(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[float],
+    default: float | None,
 ) -> None:
     """Set the value of an attribute from a subelement with a text node."""
     value = get_value(obj, attr_name=attr_name, verbosity=verbosity, default=default)
@@ -518,9 +518,9 @@ def float_attribute(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[float],
+    default: float | None,
 ) -> None:
     """Set the value of an attribute."""
     value = get_value(obj, attr_name=attr_name, verbosity=verbosity, default=default)
@@ -534,9 +534,9 @@ def enum_subelement(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[Enum],
+    default: Enum | None,
 ) -> None:
     """Set the value of an attribute from a subelement with a text node."""
     value = get_value(obj, attr_name=attr_name, verbosity=verbosity, default=default)
@@ -555,9 +555,9 @@ def enum_attribute(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[Enum],
+    default: Enum | None,
 ) -> None:
     """Set the value of an attribute."""
     value = get_value(obj, attr_name=attr_name, verbosity=verbosity, default=default)
@@ -571,9 +571,9 @@ def datetime_subelement(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[str],
+    default: str | None,
 ) -> None:
     """Create the subelement for a KML datetime values."""
     if value := get_value(
@@ -596,9 +596,9 @@ def datetime_subelement_list(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[str],
+    default: str | None,
 ) -> None:
     """Create the subelements for a list of KML datetime values."""
     if value := get_value(
@@ -622,9 +622,9 @@ def coords_subelement_list(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[str],
+    default: str | None,
 ) -> None:
     """Create the subelements for a list of KML coordinate values."""
     if value := get_value(
@@ -651,7 +651,7 @@ def xml_subelement(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
     default: Optional["_XMLObject"],
 ) -> None:
@@ -691,9 +691,9 @@ def xml_subelement_list(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
+    precision: int | None,
     verbosity: Verbosity,
-    default: Optional[list["_XMLObject"]],
+    default: list["_XMLObject"] | None,
 ) -> None:
     """
     Add subelements to an XML element based on a list attribute of an object.

--- a/fastkml/helpers.py
+++ b/fastkml/helpers.py
@@ -35,7 +35,6 @@ from collections.abc import Iterable
 from enum import Enum
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Optional
 from typing import cast
 
 from pygeoif.types import PointType
@@ -653,7 +652,7 @@ def xml_subelement(
     node_name: str,
     precision: int | None,
     verbosity: Verbosity,
-    default: Optional["_XMLObject"],
+    default: "_XMLObject | None",
 ) -> None:
     """
     Add a subelement to an XML element based on the value of an attribute of an object.

--- a/fastkml/helpers.py
+++ b/fastkml/helpers.py
@@ -145,7 +145,7 @@ def handle_error(
 def get_ns(obj: "_XMLObject", value: object) -> str:
     """Get the namespace of an attribute, fall back on the objects namespace."""
     try:
-        return obj.name_spaces.get(value.get_ns_id(), "")  # type: ignore[attr-defined]
+        return obj.name_spaces.get(value.get_ns_id(), "")  # type: ignore[attr-defined]  # pyrefly: ignore  # ty: ignore[unresolved-attribute]
     except AttributeError:
         return obj.ns
 
@@ -1239,14 +1239,14 @@ def datetime_subelement_kwarg(
     strict: bool,
 ) -> dict[str, "KmlDateTime"]:
     """Extract a KML datetime from a subelement of an XML element."""
-    cls = classes[0]
+    cls = cast("type[KmlDateTime]", classes[0])
     node = element.find(f"{ns}{node_name}")
     if node is None:
         return {}
     node_text = node.text.strip() if node.text else ""
     if node_text:
         try:
-            return {kwarg: cls.parse(node_text)}  # type: ignore[attr-defined]
+            return {kwarg: cls.parse(node_text)}
         except ValueError as exc:
             handle_error(
                 error=exc,
@@ -1270,13 +1270,11 @@ def datetime_subelement_list_kwarg(
 ) -> dict[str, list["KmlDateTime"]]:
     """Extract a list of KML datetime values from subelements of an XML element."""
     args_list: list[KmlDateTime] = []
-    cls = classes[0]
+    cls = cast("type[KmlDateTime]", classes[0])
     if subelements := element.findall(f"{ns}{node_name}"):
         for subelement in subelements:
             try:
-                args_list.append(
-                    cls.parse(subelement.text),  # type: ignore[attr-defined]
-                )
+                args_list.append(cls.parse(subelement.text))
             except ValueError as exc:  # noqa: PERF203
                 handle_error(
                     error=exc,
@@ -1357,13 +1355,13 @@ def xml_subelement_kwarg(
         of the specified keyword argument.
 
     """
-    for cls in classes:
+    for cls in cast("tuple[type[_XMLObject], ...]", classes):
         subelement = element.find(
-            f"{ns}{cls.get_tag_name()}",  # type: ignore[attr-defined]
+            f"{ns}{cls.get_tag_name()}",
         )
         if subelement is not None:
             return {
-                kwarg: cls.class_from_element(  # type: ignore[attr-defined]
+                kwarg: cls.class_from_element(
                     ns=ns,
                     name_spaces=name_spaces,
                     element=subelement,
@@ -1405,13 +1403,13 @@ def xml_subelement_list_kwarg(
     args_list = []
     assert node_name is not None  # noqa: S101
     assert name_spaces is not None  # noqa: S101
-    for obj_class in classes:
+    for obj_class in cast("tuple[type[_XMLObject], ...]", classes):
         if subelements := element.findall(
-            f"{ns}{obj_class.get_tag_name()}",  # type: ignore[attr-defined]
+            f"{ns}{obj_class.get_tag_name()}",
         ):
             args_list.extend(
                 [
-                    obj_class.class_from_element(  # type: ignore[attr-defined]
+                    obj_class.class_from_element(
                         ns=ns,
                         name_spaces=name_spaces,
                         element=subelement,
@@ -1457,13 +1455,13 @@ def xml_subelement_list_multi_ns_kwarg(
     assert name_spaces is not None  # noqa: S101
     for name_space in ns_ids:
         ns = name_spaces.get(name_space, "")
-        for obj_class in classes:
+        for obj_class in cast("tuple[type[_XMLObject], ...]", classes):
             if subelements := element.findall(
-                f"{ns}{obj_class.get_tag_name()}",  # type: ignore[attr-defined]
+                f"{ns}{obj_class.get_tag_name()}",
             ):
                 args_list.extend(
                     [
-                        obj_class.class_from_element(  # type: ignore[attr-defined]
+                        obj_class.class_from_element(
                             ns=ns,
                             name_spaces=name_spaces,
                             element=subelement,

--- a/fastkml/kml.py
+++ b/fastkml/kml.py
@@ -33,8 +33,6 @@ from pathlib import Path
 from typing import IO
 from typing import Any
 from typing import AnyStr
-from typing import Optional
-from typing import Union
 from typing import cast
 
 from typing_extensions import Self
@@ -58,20 +56,15 @@ from fastkml.types import Element
 
 logger = logging.getLogger(__name__)
 
-kml_children = Union[
-    Folder,
-    Document,
-    Placemark,
-    GroundOverlay,
-    PhotoOverlay,
-    NetworkLinkControl,
-]
+kml_children = (
+    Folder | Document | Placemark | GroundOverlay | PhotoOverlay | NetworkLinkControl
+)
 
 
 def lxml_parse_and_validate(
-    file: Union[Path, str, IO[AnyStr]],
+    file: Path | str | IO[AnyStr],
     strict: bool,
-    validate: Optional[bool],
+    validate: bool | None,
 ) -> Element:
     """
     Parse and validate a KML file using lxml.
@@ -117,9 +110,9 @@ class KML(_XMLObject):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        features: Optional[Iterable[kml_children]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        features: Iterable[kml_children] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -153,7 +146,7 @@ class KML(_XMLObject):
 
     def etree_element(
         self,
-        precision: Optional[int] = None,
+        precision: int | None = None,
         verbosity: Verbosity = Verbosity.normal,
     ) -> Element:
         """
@@ -207,12 +200,12 @@ class KML(_XMLObject):
     @classmethod
     def parse(
         cls,
-        file: Union[Path, str, IO[AnyStr]],
+        file: Path | str | IO[AnyStr],
         *,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
         strict: bool = True,
-        validate: Optional[bool] = None,
+        validate: bool | None = None,
     ) -> Self:
         """
         Parse a KML file and return a KML object.
@@ -237,8 +230,8 @@ class KML(_XMLObject):
         except TypeError:
             root = config.etree.parse(file).getroot()
         if ns is None:
-            # lxml-stubs declares `_Element.tag` with a legacy `# type:`
-            # comment that pyrefly doesn't resolve to `str`.
+            # lxml-stubs declares `_Element.tag` with a legacy type comment
+            # that pyrefly doesn't resolve to `str`.
             tag = cast("str", root.tag)
             ns = tag[:-3] if tag.endswith("kml") else ""
         name_spaces = name_spaces or {}
@@ -257,7 +250,7 @@ class KML(_XMLObject):
         file_path: Path,
         *,
         prettyprint: bool = True,
-        precision: Optional[int] = None,
+        precision: int | None = None,
         verbosity: Verbosity = Verbosity.normal,
     ) -> None:
         """

--- a/fastkml/kml.py
+++ b/fastkml/kml.py
@@ -101,9 +101,10 @@ def lxml_parse_and_validate(
             recover=True,
         ),
     )
+    root = tree.getroot()
     if validate:
-        validator.validate(element=tree)
-    return cast("Element", tree.getroot())
+        validator.validate(element=root)
+    return root
 
 
 class KML(_XMLObject):
@@ -175,9 +176,11 @@ class KML(_XMLObject):
             )
             root.set("xmlns", config.KMLNS[1:-1])
         elif hasattr(config.etree, "LXML_VERSION"):
+            # lxml supports a `None` key in `nsmap` to declare a default
+            # namespace; lxml-stubs' `_NSMapArg` doesn't model this.
             root = config.etree.Element(
                 f"{self.ns}{self.get_tag_name()}",
-                nsmap={None: self.ns[1:-1]},
+                nsmap={None: self.ns[1:-1]},  # ty: ignore[invalid-argument-type]
             )
         else:
             root = config.etree.Element(
@@ -192,7 +195,7 @@ class KML(_XMLObject):
             verbosity=verbosity,
             default=None,
         )
-        return cast("Element", root)
+        return root
 
     def append(
         self,
@@ -234,7 +237,10 @@ class KML(_XMLObject):
         except TypeError:
             root = config.etree.parse(file).getroot()
         if ns is None:
-            ns = root.tag[:-3] if root.tag.endswith("kml") else ""
+            # lxml-stubs declares `_Element.tag` with a legacy `# type:`
+            # comment that pyrefly doesn't resolve to `str`.
+            tag = cast("str", root.tag)
+            ns = tag[:-3] if tag.endswith("kml") else ""
         name_spaces = name_spaces or {}
         if ns:
             name_spaces["kml"] = ns

--- a/fastkml/kml_base.py
+++ b/fastkml/kml_base.py
@@ -57,8 +57,8 @@ class _BaseObject(_XMLObject):
 
     _default_nsid = config.KML
 
-    id = None
-    target_id = None
+    id: str
+    target_id: str
 
     def __init__(
         self,

--- a/fastkml/kml_base.py
+++ b/fastkml/kml_base.py
@@ -31,7 +31,6 @@ elements, providing a foundation for all KML-specific classes in fastkml.
 """
 
 from typing import Any
-from typing import Optional
 
 from fastkml import config
 from fastkml.base import _XMLObject
@@ -62,10 +61,10 @@ class _BaseObject(_XMLObject):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
         **kwargs: Any,
     ) -> None:
         """

--- a/fastkml/links.py
+++ b/fastkml/links.py
@@ -16,7 +16,6 @@
 """Link and Icon elements."""
 
 from typing import Any
-from typing import Optional
 
 from fastkml.enums import RefreshMode
 from fastkml.enums import ViewRefreshMode
@@ -47,29 +46,29 @@ class Link(_BaseObject):
     https://developers.google.com/kml/documentation/kmlreference#link
     """
 
-    href: Optional[str]
-    refresh_mode: Optional[RefreshMode]
-    refresh_interval: Optional[float]
-    view_refresh_mode: Optional[ViewRefreshMode]
-    view_refresh_time: Optional[float]
-    view_bound_scale: Optional[float]
-    view_format: Optional[str]
-    http_query: Optional[str]
+    href: str | None
+    refresh_mode: RefreshMode | None
+    refresh_interval: float | None
+    view_refresh_mode: ViewRefreshMode | None
+    view_refresh_time: float | None
+    view_bound_scale: float | None
+    view_format: str | None
+    http_query: str | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        href: Optional[str] = None,
-        refresh_mode: Optional[RefreshMode] = None,
-        refresh_interval: Optional[float] = None,
-        view_refresh_mode: Optional[ViewRefreshMode] = None,
-        view_refresh_time: Optional[float] = None,
-        view_bound_scale: Optional[float] = None,
-        view_format: Optional[str] = None,
-        http_query: Optional[str] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        href: str | None = None,
+        refresh_mode: RefreshMode | None = None,
+        refresh_interval: float | None = None,
+        view_refresh_mode: ViewRefreshMode | None = None,
+        view_refresh_time: float | None = None,
+        view_bound_scale: float | None = None,
+        view_format: str | None = None,
+        http_query: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the KML Icon Object."""

--- a/fastkml/mixins.py
+++ b/fastkml/mixins.py
@@ -16,8 +16,6 @@
 """Mixins for the KML classes."""
 
 import logging
-from typing import Optional
-from typing import Union
 
 from fastkml.times import KmlDateTime
 from fastkml.times import TimeSpan
@@ -31,19 +29,19 @@ logger = logging.getLogger(__name__)
 class TimeMixin:
     """Mixin for classes that have a time element."""
 
-    times: Optional[Union[TimeSpan, TimeStamp]] = None
+    times: TimeSpan | TimeStamp | None = None
 
     @property
-    def time_stamp(self) -> Optional[KmlDateTime]:
+    def time_stamp(self) -> KmlDateTime | None:
         """Return the timestamp."""
         return self.times.timestamp if isinstance(self.times, TimeStamp) else None
 
     @property
-    def begin(self) -> Optional[KmlDateTime]:
+    def begin(self) -> KmlDateTime | None:
         """Return the start time of a time span."""
         return self.times.begin if isinstance(self.times, TimeSpan) else None
 
     @property
-    def end(self) -> Optional[KmlDateTime]:
+    def end(self) -> KmlDateTime | None:
         """Return the end time of a time span."""
         return self.times.end if isinstance(self.times, TimeSpan) else None

--- a/fastkml/model.py
+++ b/fastkml/model.py
@@ -25,7 +25,6 @@ https://developers.google.com/kml/documentation/kmlreference#model
 
 from collections.abc import Iterable
 from typing import Any
-from typing import Optional
 
 from pygeoif.geometry import Point
 
@@ -55,19 +54,19 @@ class Location(_BaseObject):
 
     _default_nsid = config.KML
 
-    latitude: Optional[float]
-    longitude: Optional[float]
-    altitude: Optional[float]
+    latitude: float | None
+    longitude: float | None
+    altitude: float | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        altitude: Optional[float] = None,
-        latitude: Optional[float] = None,
-        longitude: Optional[float] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        altitude: float | None = None,
+        latitude: float | None = None,
+        longitude: float | None = None,
         **kwargs: Any,
     ) -> None:
         """Create a new Location."""
@@ -102,7 +101,7 @@ class Location(_BaseObject):
         )
 
     @property
-    def geometry(self) -> Optional[Point]:
+    def geometry(self) -> Point | None:
         """Return a Point representation of the geometry."""
         if not self:
             return None
@@ -152,19 +151,19 @@ class Orientation(_BaseObject):
 
     _default_nsid = config.KML
 
-    heading: Optional[float]
-    tilt: Optional[float]
-    roll: Optional[float]
+    heading: float | None
+    tilt: float | None
+    roll: float | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        heading: Optional[float] = None,
-        tilt: Optional[float] = None,
-        roll: Optional[float] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        heading: float | None = None,
+        tilt: float | None = None,
+        roll: float | None = None,
         **kwargs: Any,
     ) -> None:
         """Create a new Orientation."""
@@ -244,19 +243,19 @@ class Scale(_BaseObject):
 
     _default_nsid = config.KML
 
-    x: Optional[float]
-    y: Optional[float]
-    z: Optional[float]
+    x: float | None
+    y: float | None
+    z: float | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        x: Optional[float] = None,
-        y: Optional[float] = None,
-        z: Optional[float] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        x: float | None = None,
+        y: float | None = None,
+        z: float | None = None,
         **kwargs: Any,
     ) -> None:
         """Create a new Scale."""
@@ -334,17 +333,17 @@ class Alias(_BaseObject):
 
     _default_nsid = config.KML
 
-    target_href: Optional[str]
-    source_href: Optional[str]
+    target_href: str | None
+    source_href: str | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        target_href: Optional[str] = None,
-        source_href: Optional[str] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        target_href: str | None = None,
+        source_href: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Create a new Alias."""
@@ -410,11 +409,11 @@ class ResourceMap(_BaseObject):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        aliases: Optional[Iterable[Alias]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        aliases: Iterable[Alias] | None = None,
         **kwargs: Any,
     ) -> None:
         """Create a new ResourceMap."""
@@ -461,25 +460,25 @@ registry.register(
 class Model(_BaseObject):
     """Represents a model in KML."""
 
-    altitude_mode: Optional[AltitudeMode]
-    location: Optional[Location]
-    orientation: Optional[Orientation]
-    scale: Optional[Scale]
-    link: Optional[Link]
-    resource_map: Optional[ResourceMap]
+    altitude_mode: AltitudeMode | None
+    location: Location | None
+    orientation: Orientation | None
+    scale: Scale | None
+    link: Link | None
+    resource_map: ResourceMap | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
-        location: Optional[Location] = None,
-        orientation: Optional[Orientation] = None,
-        scale: Optional[Scale] = None,
-        link: Optional[Link] = None,
-        resource_map: Optional[ResourceMap] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        altitude_mode: AltitudeMode | None = None,
+        location: Location | None = None,
+        orientation: Orientation | None = None,
+        scale: Scale | None = None,
+        link: Link | None = None,
+        resource_map: ResourceMap | None = None,
         **kwargs: Any,
     ) -> None:
         """Create a new Model."""
@@ -520,7 +519,7 @@ class Model(_BaseObject):
         )
 
     @property
-    def geometry(self) -> Optional[Point]:
+    def geometry(self) -> Point | None:
         """Return a Point representation of the geometry."""
         return self.location.geometry if self.location else None
 

--- a/fastkml/network_link_control.py
+++ b/fastkml/network_link_control.py
@@ -24,8 +24,6 @@ https://developers.google.com/kml/documentation/kmlreference#networklinkcontrol
 import logging
 from collections.abc import Iterable
 from typing import Any
-from typing import Optional
-from typing import Union
 
 from fastkml import config
 from fastkml.base import _XMLObject
@@ -70,9 +68,9 @@ class _UpdateAction(_XMLObject):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        objects: Optional[Iterable[_XMLObject]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        objects: Iterable[_XMLObject] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -297,15 +295,15 @@ class Update(_XMLObject):
 
     _default_nsid = config.KML
 
-    target_href: Optional[str]
-    operations: list[Union[Create, Delete, Change]]
+    target_href: str | None
+    operations: list[Create | Delete | Change]
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        target_href: Optional[str] = None,
-        operations: Optional[Iterable[Union[Create, Delete, Change]]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        target_href: str | None = None,
+        operations: Iterable[Create | Delete | Change] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -374,31 +372,31 @@ class NetworkLinkControl(_XMLObject):
 
     _default_nsid = config.KML
 
-    min_refresh_period: Optional[float]
-    max_session_length: Optional[float]
-    cookie: Optional[str]
-    message: Optional[str]
-    link_name: Optional[str]
-    link_description: Optional[str]
-    link_snippet: Optional[str]
-    expires: Optional[KmlDateTime]
-    view: Union[Camera, LookAt, None]
-    update: Optional[Update]
+    min_refresh_period: float | None
+    max_session_length: float | None
+    cookie: str | None
+    message: str | None
+    link_name: str | None
+    link_description: str | None
+    link_snippet: str | None
+    expires: KmlDateTime | None
+    view: Camera | LookAt | None
+    update: Update | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        min_refresh_period: Optional[float] = None,
-        max_session_length: Optional[float] = None,
-        cookie: Optional[str] = None,
-        message: Optional[str] = None,
-        link_name: Optional[str] = None,
-        link_description: Optional[str] = None,
-        link_snippet: Optional[str] = None,
-        expires: Optional[KmlDateTime] = None,
-        view: Optional[Union[Camera, LookAt]] = None,
-        update: Optional[Update] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        min_refresh_period: float | None = None,
+        max_session_length: float | None = None,
+        cookie: str | None = None,
+        message: str | None = None,
+        link_name: str | None = None,
+        link_description: str | None = None,
+        link_snippet: str | None = None,
+        expires: KmlDateTime | None = None,
+        view: Camera | LookAt | None = None,
+        update: Update | None = None,
         **kwargs: Any,
     ) -> None:
         """

--- a/fastkml/overlays.py
+++ b/fastkml/overlays.py
@@ -18,8 +18,6 @@
 import logging
 from collections.abc import Iterable
 from typing import Any
-from typing import Optional
-from typing import Union
 
 from fastkml import atom
 from fastkml import config
@@ -86,18 +84,18 @@ class _Overlay(_Feature):
     nested hierarchies.
     """
 
-    color: Optional[str]
+    color: str | None
     # Color values expressed in hexadecimal notation, including opacity (alpha)
     # values. The order of expression is alphaOverlay, blue, green, red
     # (AABBGGRR). The range of values for any one color is 0 to 255 (00 to ff).
     # For opacity, 00 is fully transparent and ff is fully opaque.
 
-    draw_order: Optional[int]
+    draw_order: int | None
     # Defines the stacking order for the images in overlapping overlays.
     # Overlays with higher <drawOrder> values are drawn on top of those with
     # lower <drawOrder> values.
 
-    icon: Optional[Icon]
+    icon: Icon | None
     # Defines the image associated with the overlay. Contains an <href> html
     # tag which defines the location of the image to be used as the overlay.
     # The location can be either on a local file system or on a webserver. If
@@ -106,29 +104,29 @@ class _Overlay(_Feature):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        name: Optional[str] = None,
-        visibility: Optional[bool] = None,
-        isopen: Optional[bool] = None,
-        atom_link: Optional[atom.Link] = None,
-        atom_author: Optional[atom.Author] = None,
-        address: Optional[str] = None,
-        phone_number: Optional[str] = None,
-        snippet: Optional[Snippet] = None,
-        description: Optional[str] = None,
-        view: Optional[Union[Camera, LookAt]] = None,
-        times: Optional[Union[TimeSpan, TimeStamp]] = None,
-        style_url: Optional[StyleUrl] = None,
-        styles: Optional[Iterable[Union[Style, StyleMap]]] = None,
-        region: Optional[Region] = None,
-        extended_data: Optional[ExtendedData] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        name: str | None = None,
+        visibility: bool | None = None,
+        isopen: bool | None = None,
+        atom_link: atom.Link | None = None,
+        atom_author: atom.Author | None = None,
+        address: str | None = None,
+        phone_number: str | None = None,
+        snippet: Snippet | None = None,
+        description: str | None = None,
+        view: Camera | LookAt | None = None,
+        times: TimeSpan | TimeStamp | None = None,
+        style_url: StyleUrl | None = None,
+        styles: Iterable[Style | StyleMap] | None = None,
+        region: Region | None = None,
+        extended_data: ExtendedData | None = None,
         # Overlay specific
-        color: Optional[str] = None,
-        draw_order: Optional[int] = None,
-        icon: Optional[Icon] = None,
+        color: str | None = None,
+        draw_order: int | None = None,
+        icon: Icon | None = None,
     ) -> None:
         """
         Initialize an Overlay object.
@@ -262,37 +260,37 @@ class ViewVolume(_BaseObject):
 
     _default_nsid = config.KML
 
-    left_fow: Optional[float]
+    left_fow: float | None
     # Angle, in degrees, between the camera's viewing direction and the left side
     # of the view volume.
 
-    right_fov: Optional[float]
+    right_fov: float | None
     # Angle, in degrees, between the camera's viewing direction and the right side
     # of the view volume.
 
-    bottom_fov: Optional[float]
+    bottom_fov: float | None
     # Angle, in degrees, between the camera's viewing direction and the bottom side
     # of the view volume.
 
-    top_fov: Optional[float]
+    top_fov: float | None
     # Angle, in degrees, between the camera's viewing direction and the top side
     # of the view volume.
 
-    near: Optional[float]
+    near: float | None
     # Measurement in meters along the viewing direction from the camera viewpoint
     # to the PhotoOverlay shape.
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        left_fov: Optional[float] = None,
-        right_fov: Optional[float] = None,
-        bottom_fov: Optional[float] = None,
-        top_fov: Optional[float] = None,
-        near: Optional[float] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        left_fov: float | None = None,
+        right_fov: float | None = None,
+        bottom_fov: float | None = None,
+        top_fov: float | None = None,
+        near: float | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -463,32 +461,32 @@ class ImagePyramid(_BaseObject):
 
     _default_nsid = config.KML
 
-    tile_size: Optional[int]
+    tile_size: int | None
     # Size of the tiles, in pixels. Tiles must be square, and <tileSize> must be a power
     # of 2. A tile size of 256 (the default) or 512 is recommended.
     # The original image is divided into tiles of this size, at varying resolutions.
 
-    max_width: Optional[int]
+    max_width: int | None
     # Width in pixels of the original image.
 
-    max_height: Optional[int]
+    max_height: int | None
     # Height in pixels of the original image.
 
-    grid_origin: Optional[GridOrigin]
+    grid_origin: GridOrigin | None
     # Specifies where to begin numbering the tiles in each layer of the pyramid.
     # A value of lowerLeft specifies that row 1, column 1 of each layer is in
     # the bottom left corner of the grid.
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        tile_size: Optional[int] = None,
-        max_width: Optional[int] = None,
-        max_height: Optional[int] = None,
-        grid_origin: Optional[GridOrigin] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        tile_size: int | None = None,
+        max_width: int | None = None,
+        max_height: int | None = None,
+        grid_origin: GridOrigin | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -636,26 +634,26 @@ class PhotoOverlay(_Overlay):
     https://developers.google.com/kml/documentation/kmlreference#photooverlay
     """
 
-    rotation: Optional[float]
+    rotation: float | None
     # Adjusts how the photo is placed inside the field of view. This element is
     # useful if your photo has been rotated and deviates slightly from a desired
     # horizontal view.
 
-    view_volume: Optional[ViewVolume]
+    view_volume: ViewVolume | None
     # Defines how much of the current scene is visible.
 
-    image_pyramid: Optional[ImagePyramid]
+    image_pyramid: ImagePyramid | None
     # Defines the format, resolution, and refresh rate for images that are
     # displayed in the PhotoOverlay.
 
-    point: Optional[Point]
+    point: Point | None
     # Defines the exact coordinates of the PhotoOverlay's origin, in latitude
     # and longitude, and in meters. Latitude and longitude measurements are
     # standard lat-lon projection with WGS84 datum. Altitude is distance above
     # the earth's surface, in meters, and is interpreted according to
     # altitudeMode.
 
-    shape: Optional[Shape]
+    shape: Shape | None
     # The PhotoOverlay is projected onto the <shape>.
     # The <shape> can be one of the following:
     #   rectangle (default) -
@@ -667,34 +665,34 @@ class PhotoOverlay(_Overlay):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        name: Optional[str] = None,
-        visibility: Optional[bool] = None,
-        isopen: Optional[bool] = None,
-        atom_link: Optional[atom.Link] = None,
-        atom_author: Optional[atom.Author] = None,
-        address: Optional[str] = None,
-        phone_number: Optional[str] = None,
-        snippet: Optional[Snippet] = None,
-        description: Optional[str] = None,
-        view: Optional[Union[Camera, LookAt]] = None,
-        times: Optional[Union[TimeSpan, TimeStamp]] = None,
-        style_url: Optional[StyleUrl] = None,
-        styles: Optional[Iterable[Union[Style, StyleMap]]] = None,
-        region: Optional[Region] = None,
-        extended_data: Optional[ExtendedData] = None,
-        color: Optional[str] = None,
-        draw_order: Optional[int] = None,
-        icon: Optional[Icon] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        name: str | None = None,
+        visibility: bool | None = None,
+        isopen: bool | None = None,
+        atom_link: atom.Link | None = None,
+        atom_author: atom.Author | None = None,
+        address: str | None = None,
+        phone_number: str | None = None,
+        snippet: Snippet | None = None,
+        description: str | None = None,
+        view: Camera | LookAt | None = None,
+        times: TimeSpan | TimeStamp | None = None,
+        style_url: StyleUrl | None = None,
+        styles: Iterable[Style | StyleMap] | None = None,
+        region: Region | None = None,
+        extended_data: ExtendedData | None = None,
+        color: str | None = None,
+        draw_order: int | None = None,
+        icon: Icon | None = None,
         # Photo Overlay specific
-        rotation: Optional[float] = None,
-        view_volume: Optional[ViewVolume] = None,
-        image_pyramid: Optional[ImagePyramid] = None,
-        point: Optional[Point] = None,
-        shape: Optional[Shape] = None,
+        rotation: float | None = None,
+        view_volume: ViewVolume | None = None,
+        image_pyramid: ImagePyramid | None = None,
+        point: Point | None = None,
+        shape: Shape | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -917,23 +915,23 @@ class LatLonBox(_BaseObject):
 
     _default_nsid = config.KML
 
-    north: Optional[float]
-    south: Optional[float]
-    east: Optional[float]
-    west: Optional[float]
-    rotation: Optional[float]
+    north: float | None
+    south: float | None
+    east: float | None
+    west: float | None
+    rotation: float | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        north: Optional[float] = None,
-        south: Optional[float] = None,
-        east: Optional[float] = None,
-        west: Optional[float] = None,
-        rotation: Optional[float] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        north: float | None = None,
+        south: float | None = None,
+        east: float | None = None,
+        west: float | None = None,
+        rotation: float | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -1086,11 +1084,11 @@ class GroundOverlay(_Overlay):
     https://developers.google.com/kml/documentation/kmlreference#groundoverlay
     """
 
-    altitude: Optional[float]
+    altitude: float | None
     # Specifies the distance above the earth's surface, in meters, and is
     # interpreted according to the altitude mode.
 
-    altitude_mode: Optional[AltitudeMode]
+    altitude_mode: AltitudeMode | None
     # Specifies how the <altitude> is interpreted. Possible values are:
     #   clampToGround -
     #       (default) Indicates to ignore the altitude specification and drape
@@ -1104,39 +1102,39 @@ class GroundOverlay(_Overlay):
     #       the terrain is 3 meters above sea level, the overlay will appear
     #       elevated above the terrain by 7 meters.
 
-    lat_lon_box: Optional[LatLonBox]
+    lat_lon_box: LatLonBox | None
     # Specifies where the top, bottom, right, and left sides of a bounding box
     # for the ground overlay are aligned. Also, optionally the rotation of the
     # overlay.
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        name: Optional[str] = None,
-        visibility: Optional[bool] = None,
-        isopen: Optional[bool] = None,
-        atom_link: Optional[atom.Link] = None,
-        atom_author: Optional[atom.Author] = None,
-        address: Optional[str] = None,
-        phone_number: Optional[str] = None,
-        snippet: Optional[Snippet] = None,
-        description: Optional[str] = None,
-        view: Optional[Union[Camera, LookAt]] = None,
-        times: Optional[Union[TimeSpan, TimeStamp]] = None,
-        style_url: Optional[StyleUrl] = None,
-        styles: Optional[Iterable[Union[Style, StyleMap]]] = None,
-        region: Optional[Region] = None,
-        extended_data: Optional[ExtendedData] = None,
-        color: Optional[str] = None,
-        draw_order: Optional[int] = None,
-        icon: Optional[Icon] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        name: str | None = None,
+        visibility: bool | None = None,
+        isopen: bool | None = None,
+        atom_link: atom.Link | None = None,
+        atom_author: atom.Author | None = None,
+        address: str | None = None,
+        phone_number: str | None = None,
+        snippet: Snippet | None = None,
+        description: str | None = None,
+        view: Camera | LookAt | None = None,
+        times: TimeSpan | TimeStamp | None = None,
+        style_url: StyleUrl | None = None,
+        styles: Iterable[Style | StyleMap] | None = None,
+        region: Region | None = None,
+        extended_data: ExtendedData | None = None,
+        color: str | None = None,
+        draw_order: int | None = None,
+        icon: Icon | None = None,
         # Ground Overlay specific
-        altitude: Optional[float] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
-        lat_lon_box: Optional[LatLonBox] = None,
+        altitude: float | None = None,
+        altitude_mode: AltitudeMode | None = None,
+        lat_lon_box: LatLonBox | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -1307,20 +1305,20 @@ class _XY(_XMLObject):
 
     _default_nsid = config.KML
 
-    x: Optional[float]
-    y: Optional[float]
-    x_units: Optional[Units]
+    x: float | None
+    y: float | None
+    x_units: Units | None
 
-    y_units: Optional[Units]
+    y_units: Units | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        x: Optional[float] = None,
-        y: Optional[float] = None,
-        x_units: Optional[Units] = None,
-        y_units: Optional[Units] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        x: float | None = None,
+        y: float | None = None,
+        x_units: Units | None = None,
+        y_units: Units | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -1476,34 +1474,34 @@ class ScreenOverlay(_Overlay):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        name: Optional[str] = None,
-        visibility: Optional[bool] = None,
-        isopen: Optional[bool] = None,
-        atom_link: Optional[atom.Link] = None,
-        atom_author: Optional[atom.Author] = None,
-        address: Optional[str] = None,
-        phone_number: Optional[str] = None,
-        snippet: Optional[Snippet] = None,
-        description: Optional[str] = None,
-        view: Optional[Union[Camera, LookAt]] = None,
-        times: Optional[Union[TimeSpan, TimeStamp]] = None,
-        style_url: Optional[StyleUrl] = None,
-        styles: Optional[Iterable[Union[Style, StyleMap]]] = None,
-        region: Optional[Region] = None,
-        extended_data: Optional[ExtendedData] = None,
-        color: Optional[str] = None,
-        draw_order: Optional[int] = None,
-        icon: Optional[Icon] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        name: str | None = None,
+        visibility: bool | None = None,
+        isopen: bool | None = None,
+        atom_link: atom.Link | None = None,
+        atom_author: atom.Author | None = None,
+        address: str | None = None,
+        phone_number: str | None = None,
+        snippet: Snippet | None = None,
+        description: str | None = None,
+        view: Camera | LookAt | None = None,
+        times: TimeSpan | TimeStamp | None = None,
+        style_url: StyleUrl | None = None,
+        styles: Iterable[Style | StyleMap] | None = None,
+        region: Region | None = None,
+        extended_data: ExtendedData | None = None,
+        color: str | None = None,
+        draw_order: int | None = None,
+        icon: Icon | None = None,
         # Screen Overlay specific
-        overlay_xy: Optional[OverlayXY] = None,
-        screen_xy: Optional[ScreenXY] = None,
-        rotation_xy: Optional[RotationXY] = None,
-        size: Optional[Size] = None,
-        rotation: Optional[float] = None,
+        overlay_xy: OverlayXY | None = None,
+        screen_xy: ScreenXY | None = None,
+        rotation_xy: RotationXY | None = None,
+        size: Size | None = None,
+        rotation: float | None = None,
         **kwargs: Any,
     ) -> None:
         """

--- a/fastkml/registry.py
+++ b/fastkml/registry.py
@@ -25,7 +25,6 @@ with the registry acting as a central configuration for these mappings.
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Optional
 
 from typing_extensions import Protocol
 
@@ -72,7 +71,7 @@ class SetElement(Protocol):
         element: Element,
         attr_name: str,
         node_name: str,
-        precision: Optional[int],
+        precision: int | None,
         verbosity: Verbosity,
         default: Any,
     ) -> None: ...
@@ -106,7 +105,7 @@ class RegistryItem:
     set_element: SetElement
     node_name: str
     default: Any = None
-    custom_get_kwarg: Optional[CustomGetKWArgs] = None
+    custom_get_kwarg: CustomGetKWArgs | None = None
 
 
 class Registry:
@@ -135,7 +134,7 @@ class Registry:
 
     def __init__(
         self,
-        registry: Optional[dict[type["_XMLObject"], list[RegistryItem]]] = None,
+        registry: dict[type["_XMLObject"], list[RegistryItem]] | None = None,
     ) -> None:
         """Initialize the registry."""
         self._registry = registry or {}

--- a/fastkml/styles.py
+++ b/fastkml/styles.py
@@ -25,8 +25,6 @@ part of how your data is displayed.
 import logging
 from collections.abc import Iterable
 from typing import Any
-from typing import Optional
-from typing import Union
 
 from fastkml import config
 from fastkml.base import _XMLObject
@@ -87,13 +85,13 @@ class StyleUrl(_XMLObject):
 
     _default_nsid = config.KML
 
-    url: Optional[str]
+    url: str | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        url: Optional[str] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        url: str | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -187,25 +185,25 @@ class _ColorStyle(_BaseObject):
     https://developers.google.com/kml/documentation/kmlreference#colorstyle
     """
 
-    color: Optional[str] = None
+    color: str | None = None
     # Color and opacity (alpha) values are expressed in hexadecimal notation.
     # The range of values for any one color is 0 to 255 (00 to ff).
     # For alpha, 00 is fully transparent and ff is fully opaque.
     # The order of expression is aabbggrr, where aa=alpha (00 to ff);
     # bb=blue (00 to ff); gg=green (00 to ff); rr=red (00 to ff).
 
-    color_mode: Optional[ColorMode]
+    color_mode: ColorMode | None
     # Values for <colorMode> are normal (no effect) and random.
     # A value of random applies a random linear scale to the base <color>
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        color: Optional[str] = None,
-        color_mode: Optional[ColorMode] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        color: str | None = None,
+        color_mode: ColorMode | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -280,21 +278,21 @@ class HotSpot(_XMLObject):
     https://developers.google.com/kml/documentation/kmlreference#hotspot
     """
 
-    x: Optional[float]
-    y: Optional[float]
-    xunits: Optional[Units]
-    yunits: Optional[Units]
+    x: float | None
+    y: float | None
+    xunits: Units | None
+    yunits: Units | None
 
     _default_nsid = config.KML
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        x: Optional[float] = None,
-        y: Optional[float] = None,
-        xunits: Optional[Units] = None,
-        yunits: Optional[Units] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        x: float | None = None,
+        y: float | None = None,
+        xunits: Units | None = None,
+        yunits: Units | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -415,28 +413,28 @@ class IconStyle(_ColorStyle):
     https://developers.google.com/kml/documentation/kmlreference#iconstyle
     """
 
-    scale: Optional[float]
+    scale: float | None
     # Resizes the icon. (float)
-    heading: Optional[float]
+    heading: float | None
     # Direction (that is, North, South, East, West), in degrees.
     # Default=0 (North).
-    icon: Optional[Icon]
+    icon: Icon | None
     # An HTTP address or a local file specification used to load an icon.
-    hot_spot: Optional[HotSpot]
+    hot_spot: HotSpot | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        color: Optional[str] = None,
-        color_mode: Optional[ColorMode] = None,
-        scale: Optional[float] = None,
-        heading: Optional[float] = None,
-        icon: Optional[Icon] = None,
-        icon_href: Optional[str] = None,
-        hot_spot: Optional[HotSpot] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        color: str | None = None,
+        color_mode: ColorMode | None = None,
+        scale: float | None = None,
+        heading: float | None = None,
+        icon: Icon | None = None,
+        icon_href: str | None = None,
+        hot_spot: HotSpot | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -516,7 +514,7 @@ class IconStyle(_ColorStyle):
         return bool(self.icon)
 
     @property
-    def icon_href(self) -> Optional[str]:
+    def icon_href(self) -> str | None:
         """Return the icon href."""
         return self.icon.href if self.icon else None
 
@@ -578,18 +576,18 @@ class LineStyle(_ColorStyle):
     https://developers.google.com/kml/documentation/kmlreference#linestyle
     """
 
-    width: Optional[float]
+    width: float | None
     # Width of the line, in pixels.
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        color: Optional[str] = None,
-        color_mode: Optional[ColorMode] = None,
-        width: Optional[float] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        color: str | None = None,
+        color_mode: ColorMode | None = None,
+        width: float | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -679,22 +677,22 @@ class PolyStyle(_ColorStyle):
     https://developers.google.com/kml/documentation/kmlreference#polystyle
     """
 
-    fill: Optional[bool]
+    fill: bool | None
     # Boolean value. Specifies whether to fill the polygon.
-    outline: Optional[bool]
+    outline: bool | None
     # Boolean value. Specifies whether to outline the polygon.
     # Polygon outlines use the current LineStyle.
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        color: Optional[str] = None,
-        color_mode: Optional[ColorMode] = None,
-        fill: Optional[bool] = None,
-        outline: Optional[bool] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        color: str | None = None,
+        color_mode: ColorMode | None = None,
+        fill: bool | None = None,
+        outline: bool | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -798,18 +796,18 @@ class LabelStyle(_ColorStyle):
     https://developers.google.com/kml/documentation/kmlreference#labelstyle
     """
 
-    scale: Optional[float]
+    scale: float | None
     # Resizes the label.
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        color: Optional[str] = None,
-        color_mode: Optional[ColorMode] = None,
-        scale: Optional[float] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        color: str | None = None,
+        color_mode: ColorMode | None = None,
+        scale: float | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -900,7 +898,7 @@ class BalloonStyle(_BaseObject):
     https://developers.google.com/kml/documentation/kmlreference#balloonstyle
     """
 
-    bg_color: Optional[str]
+    bg_color: str | None
     # Background color of the balloon (optional). Color and opacity (alpha)
     # values are expressed in hexadecimal notation. The range of values for
     # any one color is 0 to 255 (00 to ff). The order of expression is
@@ -914,10 +912,10 @@ class BalloonStyle(_BaseObject):
     # Note: The use of the <color> element within <BalloonStyle> has been
     # deprecated. Use <bgColor> instead.
 
-    text_color: Optional[str]
+    text_color: str | None
     # Foreground color for text. The default is black (ff000000).
 
-    text: Optional[str]
+    text: str | None
     # Text displayed in the balloon. If no text is specified, Google Earth
     # draws the default balloon (with the Feature <name> in boldface,
     # the Feature <description>, links for driving directions, a white
@@ -937,7 +935,7 @@ class BalloonStyle(_BaseObject):
     # in the Feature elements that use this BalloonStyle:
     # <text>This is $[name], whose description is:<br/>$[description]</text>
 
-    display_mode: Optional[DisplayMode]
+    display_mode: DisplayMode | None
     # If <displayMode> is default, Google Earth uses the information supplied
     # in <text> to create a balloon . If <displayMode> is hide, Google Earth
     # does not display the balloon. In Google Earth, clicking the List View
@@ -946,14 +944,14 @@ class BalloonStyle(_BaseObject):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        bg_color: Optional[str] = None,
-        text_color: Optional[str] = None,
-        text: Optional[str] = None,
-        display_mode: Optional[DisplayMode] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        bg_color: str | None = None,
+        text_color: str | None = None,
+        text: str | None = None,
+        display_mode: DisplayMode | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -1078,7 +1076,7 @@ registry.register(
 )
 
 
-AnyStyle = Union[BalloonStyle, IconStyle, LabelStyle, LineStyle, PolyStyle]
+AnyStyle = BalloonStyle | IconStyle | LabelStyle | LineStyle | PolyStyle
 
 
 class Style(_StyleSelector):
@@ -1096,11 +1094,11 @@ class Style(_StyleSelector):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        styles: Optional[Iterable[AnyStyle]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        styles: Iterable[AnyStyle] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -1192,17 +1190,17 @@ class Pair(_BaseObject):
     https://developers.google.com/kml/documentation/kmlreference#stylemap
     """
 
-    key: Optional[PairKey]
-    style: Optional[Union[StyleUrl, Style]]
+    key: PairKey | None
+    style: StyleUrl | Style | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        key: Optional[PairKey] = None,
-        style: Optional[Union[StyleUrl, Style]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        key: PairKey | None = None,
+        style: StyleUrl | Style | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -1308,11 +1306,11 @@ class StyleMap(_StyleSelector):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        pairs: Optional[Iterable[Pair]] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        pairs: Iterable[Pair] | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -1368,7 +1366,7 @@ class StyleMap(_StyleSelector):
         return bool(self.pairs)
 
     @property
-    def normal(self) -> Optional[Union[StyleUrl, Style]]:
+    def normal(self) -> StyleUrl | Style | None:
         """
         Get the normal style for the feature.
 
@@ -1383,7 +1381,7 @@ class StyleMap(_StyleSelector):
         )
 
     @property
-    def highlight(self) -> Optional[Union[StyleUrl, Style]]:
+    def highlight(self) -> StyleUrl | Style | None:
         """
         Return the highlight style associated with this StyleMap.
 

--- a/fastkml/times.py
+++ b/fastkml/times.py
@@ -202,7 +202,7 @@ class KmlDateTime:
         return self.dt.isoformat()
 
     @classmethod
-    def parse(cls, datestr: str) -> Optional["KmlDateTime"]:
+    def parse(cls, datestr: str) -> "KmlDateTime":
         """Parse a KML DateTime string into a KmlDateTime object."""
         resolution = None
         dt = None

--- a/fastkml/times.py
+++ b/fastkml/times.py
@@ -28,8 +28,6 @@ from datetime import date
 from datetime import datetime
 from datetime import timezone
 from typing import Any
-from typing import Optional
-from typing import Union
 
 import arrow
 
@@ -56,9 +54,9 @@ year_month_day = re.compile(
 
 
 def adjust_date_to_resolution(
-    dt: Union[date, datetime],
-    resolution: Optional[DateTimeResolution] = None,
-) -> Union[date, datetime]:
+    dt: date | datetime,
+    resolution: DateTimeResolution | None = None,
+) -> date | datetime:
     """
     Adjust the date or datetime to the specified resolution.
 
@@ -130,8 +128,8 @@ class KmlDateTime:
 
     def __init__(
         self,
-        dt: Union[date, datetime],
-        resolution: Optional[DateTimeResolution] = None,
+        dt: date | datetime,
+        resolution: DateTimeResolution | None = None,
     ) -> None:
         """
         Initialize a KmlDateTime object.
@@ -243,11 +241,11 @@ class TimeStamp(_TimePrimitive):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        timestamp: Optional[KmlDateTime] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        timestamp: KmlDateTime | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -322,12 +320,12 @@ class TimeSpan(_TimePrimitive):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        begin: Optional[KmlDateTime] = None,
-        end: Optional[KmlDateTime] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        begin: KmlDateTime | None = None,
+        end: KmlDateTime | None = None,
         **kwargs: Any,
     ) -> None:
         """

--- a/fastkml/types.py
+++ b/fastkml/types.py
@@ -31,34 +31,41 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 """Types for fastkml."""
 
-from collections.abc import Iterable
-from typing import Optional
-
-from typing_extensions import Protocol
+from typing import TYPE_CHECKING
 
 __all__ = ["Element"]
 
+if TYPE_CHECKING:
+    # fastkml treats lxml as the reference etree implementation for static
+    # type-checking (it is the preferred runtime backend, and its API is a
+    # superset of xml.etree.ElementTree's); see fastkml.config.
+    from lxml.etree import _Element as Element
+else:
+    from collections.abc import Iterable
+    from typing import Optional
 
-class Element(Protocol):
-    """Protocol for Element."""
+    from typing_extensions import Protocol
 
-    tag: str
-    text: str
+    class Element(Protocol):
+        """Protocol for Element."""
 
-    def set(self, tag: str, value: str) -> None:
-        """Set the value of the tag."""
+        tag: str
+        text: Optional[str]
 
-    def get(self, tag: str) -> str:
-        """Get the value of the tag."""
+        def set(self, tag: str, value: str) -> None:
+            """Set the value of the tag."""
 
-    def find(self, tag: str) -> Optional["Element"]:
-        """Find the first element with the given tag."""
+        def get(self, tag: str) -> str:
+            """Get the value of the tag."""
 
-    def findall(self, tag: str) -> Iterable["Element"]:
-        """Find all elements with the given tag."""
+        def find(self, tag: str) -> Optional["Element"]:
+            """Find the first element with the given tag."""
 
-    def append(self, element: "Element") -> None:
-        """Append an element to the current element."""
+        def findall(self, tag: str) -> Iterable["Element"]:
+            """Find all elements with the given tag."""
 
-    def remove(self, element: "Element") -> None:
-        """Remove an element from the current element."""
+        def append(self, element: "Element") -> None:
+            """Append an element to the current element."""
+
+        def remove(self, element: "Element") -> None:
+            """Remove an element from the current element."""

--- a/fastkml/types.py
+++ b/fastkml/types.py
@@ -37,7 +37,7 @@ __all__ = ["Element"]
 
 if TYPE_CHECKING:
     # fastkml treats lxml as the reference etree implementation for static
-    # type-checking (it is the preferred runtime backend, and its API is a
+    # analysis (it is the preferred runtime backend, and its API is a
     # superset of xml.etree.ElementTree's); see fastkml.config.
     from lxml.etree import _Element as Element
 else:
@@ -50,7 +50,7 @@ else:
         """Protocol for Element."""
 
         tag: str
-        text: Optional[str]
+        text: str | None
 
         def set(self, tag: str, value: str) -> None:
             """Set the value of the tag."""

--- a/fastkml/types.py
+++ b/fastkml/types.py
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
     from lxml.etree import _Element as Element
 else:
     from collections.abc import Iterable
-    from typing import Optional
 
     from typing_extensions import Protocol
 
@@ -58,7 +57,7 @@ else:
         def get(self, tag: str) -> str:
             """Get the value of the tag."""
 
-        def find(self, tag: str) -> Optional["Element"]:
+        def find(self, tag: str) -> "Element | None":
             """Find the first element with the given tag."""
 
         def findall(self, tag: str) -> Iterable["Element"]:

--- a/fastkml/utils.py
+++ b/fastkml/utils.py
@@ -2,9 +2,7 @@
 
 from collections.abc import Generator
 from typing import Any
-from typing import Optional
 from typing import TypeVar
-from typing import Union
 from typing import overload
 
 __all__ = ["find", "find_all", "has_attribute_values"]
@@ -84,7 +82,7 @@ def find_all(
 def find_all(
     obj: object,
     *,
-    of_type: Optional[Union[type[object], tuple[type[object], ...]]] = None,
+    of_type: type[object] | tuple[type[object], ...] | None = None,
     **kwargs: Any,
 ) -> Generator[object, None, None]:
     """
@@ -117,27 +115,27 @@ def find(
     *,
     of_type: type[_T],
     **kwargs: Any,
-) -> Optional[_T]: ...
+) -> _T | None: ...
 @overload
 def find(
     obj: object,
     *,
     of_type: tuple[type[_T], ...],
     **kwargs: Any,
-) -> Optional[_T]: ...
+) -> _T | None: ...
 @overload
 def find(
     obj: object,
     *,
     of_type: None = None,
     **kwargs: Any,
-) -> Optional[object]: ...
+) -> object | None: ...
 def find(
     obj: object,
     *,
-    of_type: Optional[Union[type[object], tuple[type[object], ...]]] = None,
+    of_type: type[object] | tuple[type[object], ...] | None = None,
     **kwargs: Any,
-) -> Optional[object]:
+) -> object | None:
     """
     Find the first instance of a given type in a given object.
 

--- a/fastkml/utils.py
+++ b/fastkml/utils.py
@@ -3,9 +3,13 @@
 from collections.abc import Generator
 from typing import Any
 from typing import Optional
+from typing import TypeVar
 from typing import Union
+from typing import overload
 
 __all__ = ["find", "find_all", "has_attribute_values"]
+
+_T = TypeVar("_T")
 
 
 def has_attribute_values(obj: object, **kwargs: Any) -> bool:
@@ -56,6 +60,27 @@ def get_all_attrs(obj: object) -> Generator[object, None, None]:
             yield attr
 
 
+@overload
+def find_all(
+    obj: object,
+    *,
+    of_type: type[_T],
+    **kwargs: Any,
+) -> Generator[_T, None, None]: ...
+@overload
+def find_all(
+    obj: object,
+    *,
+    of_type: tuple[type[_T], ...],
+    **kwargs: Any,
+) -> Generator[_T, None, None]: ...
+@overload
+def find_all(
+    obj: object,
+    *,
+    of_type: None = None,
+    **kwargs: Any,
+) -> Generator[object, None, None]: ...
 def find_all(
     obj: object,
     *,
@@ -86,6 +111,27 @@ def find_all(
         yield from find_all(attr, of_type=of_type, **kwargs)
 
 
+@overload
+def find(
+    obj: object,
+    *,
+    of_type: type[_T],
+    **kwargs: Any,
+) -> Optional[_T]: ...
+@overload
+def find(
+    obj: object,
+    *,
+    of_type: tuple[type[_T], ...],
+    **kwargs: Any,
+) -> Optional[_T]: ...
+@overload
+def find(
+    obj: object,
+    *,
+    of_type: None = None,
+    **kwargs: Any,
+) -> Optional[object]: ...
 def find(
     obj: object,
     *,

--- a/fastkml/validator.py
+++ b/fastkml/validator.py
@@ -21,15 +21,23 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 from typing import Final
 from typing import Optional
+from typing import cast
 
 from fastkml import config
 from fastkml.types import Element
 
 if TYPE_CHECKING:
-    import contextlib
+    from collections.abc import Iterable
 
-    with contextlib.suppress(ImportError):
-        from lxml import etree
+    from lxml import etree
+    from typing_extensions import Protocol
+
+    class _LogEntry(Protocol):
+        """A single entry of an lxml `_ErrorLog`, which lxml-stubs omits."""
+
+        message: str
+        path: str
+
 
 __all__ = [
     "get_schema_parser",
@@ -79,12 +87,13 @@ def handle_validation_error(
         element: The element to validate.
 
     """
-    log = schema_parser.error_log
+    # lxml-stubs' `_ErrorLog` is an empty stub with no `__iter__` or entry
+    # attributes, even though the real lxml class supports both.
+    log = cast("Iterable[_LogEntry]", schema_parser.error_log)
     for error_entry in log:
         try:
-            parent = element.xpath(error_entry.path)[  # type: ignore[attr-defined]
-                0
-            ].getparent()
+            matches = cast("list[Element]", element.xpath(error_entry.path))
+            parent = matches[0].getparent()
         except config.etree.XPathEvalError:
             parent = element
         if parent is None:
@@ -136,7 +145,7 @@ def validate(
         return None
 
     if file_to_validate is not None:
-        element = config.etree.parse(file_to_validate)
+        element = config.etree.parse(file_to_validate).getroot()
     assert element is not None  # noqa: S101
     try:
         schema_parser.assert_(element)  # noqa: PT009

--- a/fastkml/validator.py
+++ b/fastkml/validator.py
@@ -20,7 +20,6 @@ import pathlib
 from functools import lru_cache
 from typing import TYPE_CHECKING
 from typing import Final
-from typing import Optional
 from typing import cast
 
 from fastkml import config
@@ -53,7 +52,7 @@ REQUIRE_ONE_OF: Final = "Either element or file_to_validate must be provided."
 
 @lru_cache(maxsize=16)
 def get_schema_parser(
-    schema: Optional[pathlib.Path] = None,
+    schema: pathlib.Path | None = None,
 ) -> "etree.XMLSchema":
     """
     Parse the XML schema.
@@ -114,10 +113,10 @@ def handle_validation_error(
 
 def validate(
     *,
-    schema: Optional[pathlib.Path] = None,
-    element: Optional[Element] = None,
-    file_to_validate: Optional[pathlib.Path] = None,
-) -> Optional[bool]:
+    schema: pathlib.Path | None = None,
+    element: Element | None = None,
+    file_to_validate: pathlib.Path | None = None,
+) -> bool | None:
     """
     Validate a KML file against the XML schema.
 

--- a/fastkml/validator.py
+++ b/fastkml/validator.py
@@ -93,7 +93,7 @@ def handle_validation_error(
         try:
             matches = cast("list[Element]", element.xpath(error_entry.path))
             parent = matches[0].getparent()
-        except config.etree.XPathEvalError:
+        except (config.etree.XPathEvalError, IndexError):
             parent = element
         if parent is None:
             parent = element

--- a/fastkml/views.py
+++ b/fastkml/views.py
@@ -17,7 +17,6 @@
 
 import logging
 from typing import Any
-from typing import Optional
 
 from fastkml import config
 from fastkml.enums import AltitudeMode
@@ -46,24 +45,24 @@ class _AbstractView(TimeMixin, _BaseObject):
     This element is extended by the <Camera> and <LookAt> elements.
     """
 
-    longitude: Optional[float]
+    longitude: float | None
     # Longitude of the virtual camera (eye point). Angular distance in degrees,
     # relative to the Prime Meridian. Values west of the Meridian range from
     # -180 to 0 degrees. Values east of the Meridian range from 0 to 180 degrees.
 
-    latitude: Optional[float]
+    latitude: float | None
     # Latitude of the virtual camera. Degrees north or south of the Equator
     # (0 degrees). Values range from -90 degrees to 90 degrees.
 
-    altitude: Optional[float]
+    altitude: float | None
     # Distance of the camera from the earth's surface, in meters. Interpreted
     # according to the Camera's <altitudeMode> or <gx:altitudeMode>.
 
-    heading: Optional[float]
+    heading: float | None
     # Direction (azimuth) of the camera, in degrees. Default=0 (true North).
     # (See diagram.) Values range from 0 to 360 degrees.
 
-    tilt: Optional[float]
+    tilt: float | None
     # Rotation, in degrees, of the camera around the X axis. A value of 0
     # indicates that the view is aimed straight down toward the earth (the
     # most common case). A value for 90 for <tilt> indicates that the view
@@ -71,7 +70,7 @@ class _AbstractView(TimeMixin, _BaseObject):
     # view is pointed up into the sky. Values for <tilt> are clamped at +180
     # degrees.
 
-    altitude_mode: Optional[AltitudeMode]
+    altitude_mode: AltitudeMode | None
     # Specifies how the <altitude> specified for the Camera is interpreted.
     # Possible values are as follows:
     #   relativeToGround -
@@ -88,16 +87,16 @@ class _AbstractView(TimeMixin, _BaseObject):
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        longitude: Optional[float] = None,
-        latitude: Optional[float] = None,
-        altitude: Optional[float] = None,
-        heading: Optional[float] = None,
-        tilt: Optional[float] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        longitude: float | None = None,
+        latitude: float | None = None,
+        altitude: float | None = None,
+        heading: float | None = None,
+        tilt: float | None = None,
+        altitude_mode: AltitudeMode | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -235,23 +234,23 @@ class Camera(_AbstractView):
     https://developers.google.com/kml/documentation/kmlreference#camera
     """
 
-    roll: Optional[float]
+    roll: float | None
     # Rotation, in degrees, of the camera around the Z axis. Values range from
     # -180 to +180 degrees.
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        longitude: Optional[float] = None,
-        latitude: Optional[float] = None,
-        altitude: Optional[float] = None,
-        heading: Optional[float] = None,
-        tilt: Optional[float] = None,
-        roll: Optional[float] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        longitude: float | None = None,
+        latitude: float | None = None,
+        altitude: float | None = None,
+        heading: float | None = None,
+        tilt: float | None = None,
+        roll: float | None = None,
+        altitude_mode: AltitudeMode | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -349,23 +348,23 @@ class LookAt(_AbstractView):
     https://developers.google.com/kml/documentation/kmlreference#lookat
     """
 
-    range: Optional[float]
+    range: float | None
     # Distance in meters from the point specified by <longitude>, <latitude>,
     # and <altitude> to the LookAt position.
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        longitude: Optional[float] = None,
-        latitude: Optional[float] = None,
-        altitude: Optional[float] = None,
-        heading: Optional[float] = None,
-        tilt: Optional[float] = None,
-        range: Optional[float] = None,  # noqa: A002
-        altitude_mode: Optional[AltitudeMode] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        longitude: float | None = None,
+        latitude: float | None = None,
+        altitude: float | None = None,
+        heading: float | None = None,
+        tilt: float | None = None,
+        range: float | None = None,  # noqa: A002
+        altitude_mode: AltitudeMode | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -461,27 +460,27 @@ class LatLonAltBox(_BaseObject):
 
     _default_nsid = config.KML
 
-    north: Optional[float]
-    south: Optional[float]
-    east: Optional[float]
-    west: Optional[float]
-    min_altitude: Optional[float]
-    max_altitude: Optional[float]
-    altitude_mode: Optional[AltitudeMode]
+    north: float | None
+    south: float | None
+    east: float | None
+    west: float | None
+    min_altitude: float | None
+    max_altitude: float | None
+    altitude_mode: AltitudeMode | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        north: Optional[float] = None,
-        south: Optional[float] = None,
-        east: Optional[float] = None,
-        west: Optional[float] = None,
-        min_altitude: Optional[float] = None,
-        max_altitude: Optional[float] = None,
-        altitude_mode: Optional[AltitudeMode] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        north: float | None = None,
+        south: float | None = None,
+        east: float | None = None,
+        west: float | None = None,
+        min_altitude: float | None = None,
+        max_altitude: float | None = None,
+        altitude_mode: AltitudeMode | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -657,21 +656,21 @@ class Lod(_BaseObject):
 
     _default_nsid = config.KML
 
-    min_lod_pixels: Optional[int]
-    max_lod_pixels: Optional[int]
-    min_fade_extent: Optional[int]
-    max_fade_extent: Optional[int]
+    min_lod_pixels: int | None
+    max_lod_pixels: int | None
+    min_fade_extent: int | None
+    max_fade_extent: int | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        min_lod_pixels: Optional[int] = None,
-        max_lod_pixels: Optional[int] = None,
-        min_fade_extent: Optional[int] = None,
-        max_fade_extent: Optional[int] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        min_lod_pixels: int | None = None,
+        max_lod_pixels: int | None = None,
+        min_fade_extent: int | None = None,
+        max_fade_extent: int | None = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -797,17 +796,17 @@ class Region(_BaseObject):
     https://developers.google.com/kml/documentation/kmlreference#region
     """
 
-    lat_lon_alt_box: Optional[LatLonAltBox]
-    lod: Optional[Lod]
+    lat_lon_alt_box: LatLonAltBox | None
+    lod: Lod | None
 
     def __init__(
         self,
-        ns: Optional[str] = None,
-        name_spaces: Optional[dict[str, str]] = None,
-        id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        lat_lon_alt_box: Optional[LatLonAltBox] = None,
-        lod: Optional[Lod] = None,
+        ns: str | None = None,
+        name_spaces: dict[str, str] | None = None,
+        id: str | None = None,
+        target_id: str | None = None,
+        lat_lon_alt_box: LatLonAltBox | None = None,
+        lod: Lod | None = None,
         **kwargs: Any,
     ) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -41,7 +40,7 @@ dynamic = [
     "version",
 ]
 name = "fastkml"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.license]
 text = "LGPL"
@@ -83,8 +82,9 @@ tests = [
     "tzdata",
 ]
 typing = [
-    "mypy",
-    "types-python-dateutil",
+    "lxml-stubs",
+    "pyrefly",
+    "ty",
 ]
 
 [project.readme]
@@ -135,41 +135,6 @@ max_line_length = 89
 [tool.isort]
 force_single_line = true
 line_length = 88
-
-[tool.mypy]
-disallow_any_generics = true
-disallow_incomplete_defs = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-enable_error_code = [
-    "ignore-without-code",
-]
-ignore_errors = false
-ignore_missing_imports = true
-implicit_reexport = false
-no_implicit_optional = true
-show_error_codes = true
-strict_equality = true
-strict_optional = true
-warn_no_return = true
-warn_redundant_casts = true
-warn_return_any = true
-warn_unreachable = true
-warn_unused_configs = true
-warn_unused_ignores = true
-
-[[tool.mypy.overrides]]
-disable_error_code = "attr-defined, union-attr"
-module = "tests.oldunit_test"
-
-[[tool.mypy.overrides]]
-disable_error_code = "attr-defined, union-attr, no-untyped-def, no-untyped-call, arg-type"
-module = "examples.*"
-
-[[tool.mypy.overrides]]
-disable_error_code = "union-attr"
-module = "tests.*"
 
 [tool.pyright]
 exclude = [
@@ -231,6 +196,9 @@ select = [
     "S101",
     "SLF001",
 ]
+"tests/registry_test.py" = [
+    "ARG001",
+]
 "tests/repr_eq_test.py" = [
     "E501",
 ]
@@ -266,3 +234,57 @@ include = [
     "fastkml/py.typed",
 ]
 namespaces = false
+
+[tool.pyrefly]
+preset = "strict"
+ignore-missing-imports = ["*"]
+# lxml has no py.typed/inline stubs; lxml-stubs (installed for `ty`'s benefit,
+# which resolves it correctly) uses legacy `# type:` comments that pyrefly
+# misparses as literal `Ellipsis` values (e.g. `_Element.tag`/`.text`), so
+# pyrefly treats lxml as untyped instead.
+replace_imports_with_any = ["lxml.*"]
+
+[tool.pyrefly.errors]
+# Adding @override to ~80 call sites across nearly every module (__repr__,
+# __init__, get_tag_name, parse, ...) is pure ceremony for this codebase's
+# heavy, intentional use of inheritance; ty leaves this rule off by default.
+missing-override-decorator = "ignore"
+
+[[tool.pyrefly.sub-config]]
+matches = "tests/**/*"
+
+[tool.pyrefly.sub-config.errors]
+# Tests routinely construct an object and immediately assert on a field
+# typed `X | None`/`A | B | None` without a narrowing check first; mirrors
+# the old mypy per-module `union-attr` override for tests.*.
+missing-attribute = "ignore"
+
+[[tool.pyrefly.sub-config]]
+matches = "examples/**/*"
+
+[tool.pyrefly.sub-config.errors]
+# Example scripts demonstrate walking a heterogeneous feature tree and the
+# registry's dynamic-attribute-injection extension pattern (see
+# transform_cascading_style.py); neither is expressible in the class stubs.
+missing-attribute = "ignore"
+
+[tool.ty.rules]
+# Promote checks ty leaves at "warn"/"ignore" by default, to match the
+# strictness previously provided by mypy's strict flags.
+possibly-missing-attribute = "error"
+possibly-missing-import = "error"
+possibly-unresolved-reference = "error"
+missing-type-argument = "error"
+missing-override-decorator = "ignore"
+unused-ignore-comment = "error"
+unused-type-ignore-comment = "error"
+redundant-cast = "error"
+
+[[tool.ty.overrides]]
+include = ["tests/**"]
+# Same rationale as the pyrefly tests/**/* sub-config above.
+rules = { unresolved-attribute = "ignore", invalid-assignment = "ignore" }
+
+[[tool.ty.overrides]]
+include = ["examples/**"]
+rules = { unresolved-attribute = "ignore" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ lxml = [
     "lxml",
 ]
 tests = [
+    # 6.156+ has no cp315 wheel yet; unpin once hypothesis publishes one.
     "hypothesis[dateutil]<6.156",
     "pytest",
     "pytest-cov",
@@ -137,20 +138,37 @@ force_single_line = true
 line_length = 88
 
 [tool.pyrefly]
-ignore-missing-imports = [
-    "*",
-]
 preset = "strict"
-replace_imports_with_any = [
-    "lxml.*",
-]
-sub-config = [
-    { errors = { missing-attribute = "ignore" }, matches = "examples/**/*" },
-    { errors = { missing-attribute = "ignore" }, matches = "tests/**/*" },
-]
+ignore-missing-imports = ["*"]
+# lxml has no py.typed/inline stubs; lxml-stubs (installed for `ty`'s benefit,
+# which resolves it correctly) uses legacy `# type:` comments that pyrefly
+# misparses as literal `Ellipsis` values (e.g. `_Element.tag`/`.text`), so
+# pyrefly treats lxml as untyped instead.
+replace_imports_with_any = ["lxml.*"]
 
 [tool.pyrefly.errors]
+# Adding @override to ~80 call sites across nearly every module (__repr__,
+# __init__, get_tag_name, parse, ...) is pure ceremony for this codebase's
+# heavy, intentional use of inheritance; ty leaves this rule off by default.
 missing-override-decorator = "ignore"
+
+[[tool.pyrefly.sub-config]]
+matches = "tests/**/*"
+
+[tool.pyrefly.sub-config.errors]
+# Tests routinely construct an object and immediately assert on a field
+# typed `X | None`/`A | B | None` without a narrowing check first; mirrors
+# the old mypy per-module `union-attr` override for tests.*.
+missing-attribute = "ignore"
+
+[[tool.pyrefly.sub-config]]
+matches = "examples/**/*"
+
+[tool.pyrefly.sub-config.errors]
+# Example scripts demonstrate walking a heterogeneous feature tree and the
+# registry's dynamic-attribute-injection extension pattern (see
+# transform_cascading_style.py); neither is expressible in the class stubs.
+missing-attribute = "ignore"
 
 [tool.pyright]
 exclude = [
@@ -265,10 +283,13 @@ include = [
 ]
 
 [tool.ty.overrides.rules]
+# Same rationale as the pyrefly tests/**/* sub-config above.
 invalid-assignment = "ignore"
 unresolved-attribute = "ignore"
 
 [tool.ty.rules]
+# Promote checks ty leaves at "warn"/"ignore" by default, to match the
+# strictness previously provided by mypy's strict flags.
 missing-override-decorator = "ignore"
 missing-type-argument = "error"
 possibly-missing-attribute = "error"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,8 @@ lxml = [
     "lxml",
 ]
 tests = [
-    "hypothesis[dateutil]",
+    # 6.156+ has no cp315 wheel yet; unpin once hypothesis publishes one.
+    "hypothesis[dateutil]<6.156",
     "pytest",
     "pytest-cov",
     "pytz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ lxml = [
     "lxml",
 ]
 tests = [
-    # 6.156+ has no cp315 wheel yet; unpin once hypothesis publishes one.
     "hypothesis[dateutil]<6.156",
     "pytest",
     "pytest-cov",
@@ -136,6 +135,22 @@ max_line_length = 89
 [tool.isort]
 force_single_line = true
 line_length = 88
+
+[tool.pyrefly]
+ignore-missing-imports = [
+    "*",
+]
+preset = "strict"
+replace_imports_with_any = [
+    "lxml.*",
+]
+sub-config = [
+    { errors = { missing-attribute = "ignore" }, matches = "examples/**/*" },
+    { errors = { missing-attribute = "ignore" }, matches = "tests/**/*" },
+]
+
+[tool.pyrefly.errors]
+missing-override-decorator = "ignore"
 
 [tool.pyright]
 exclude = [
@@ -236,56 +251,29 @@ include = [
 ]
 namespaces = false
 
-[tool.pyrefly]
-preset = "strict"
-ignore-missing-imports = ["*"]
-# lxml has no py.typed/inline stubs; lxml-stubs (installed for `ty`'s benefit,
-# which resolves it correctly) uses legacy `# type:` comments that pyrefly
-# misparses as literal `Ellipsis` values (e.g. `_Element.tag`/`.text`), so
-# pyrefly treats lxml as untyped instead.
-replace_imports_with_any = ["lxml.*"]
+[[tool.ty.overrides]]
+include = [
+    "examples/**",
+]
 
-[tool.pyrefly.errors]
-# Adding @override to ~80 call sites across nearly every module (__repr__,
-# __init__, get_tag_name, parse, ...) is pure ceremony for this codebase's
-# heavy, intentional use of inheritance; ty leaves this rule off by default.
-missing-override-decorator = "ignore"
+[tool.ty.overrides.rules]
+unresolved-attribute = "ignore"
 
-[[tool.pyrefly.sub-config]]
-matches = "tests/**/*"
+[[tool.ty.overrides]]
+include = [
+    "tests/**",
+]
 
-[tool.pyrefly.sub-config.errors]
-# Tests routinely construct an object and immediately assert on a field
-# typed `X | None`/`A | B | None` without a narrowing check first; mirrors
-# the old mypy per-module `union-attr` override for tests.*.
-missing-attribute = "ignore"
-
-[[tool.pyrefly.sub-config]]
-matches = "examples/**/*"
-
-[tool.pyrefly.sub-config.errors]
-# Example scripts demonstrate walking a heterogeneous feature tree and the
-# registry's dynamic-attribute-injection extension pattern (see
-# transform_cascading_style.py); neither is expressible in the class stubs.
-missing-attribute = "ignore"
+[tool.ty.overrides.rules]
+invalid-assignment = "ignore"
+unresolved-attribute = "ignore"
 
 [tool.ty.rules]
-# Promote checks ty leaves at "warn"/"ignore" by default, to match the
-# strictness previously provided by mypy's strict flags.
+missing-override-decorator = "ignore"
+missing-type-argument = "error"
 possibly-missing-attribute = "error"
 possibly-missing-import = "error"
 possibly-unresolved-reference = "error"
-missing-type-argument = "error"
-missing-override-decorator = "ignore"
+redundant-cast = "error"
 unused-ignore-comment = "error"
 unused-type-ignore-comment = "error"
-redundant-cast = "error"
-
-[[tool.ty.overrides]]
-include = ["tests/**"]
-# Same rationale as the pyrefly tests/**/* sub-config above.
-rules = { unresolved-attribute = "ignore", invalid-assignment = "ignore" }
-
-[[tool.ty.overrides]]
-include = ["examples/**"]
-rules = { unresolved-attribute = "ignore" }

--- a/tests/base.py
+++ b/tests/base.py
@@ -21,7 +21,7 @@ import xml.etree.ElementTree as ET
 import pytest
 
 try:  # pragma: no cover
-    import lxml
+    import lxml.etree
 
     LXML = True
 except ImportError:  # pragma: no cover

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -21,7 +21,7 @@ from xml.etree import ElementTree as ET
 import pytest
 
 try:
-    import lxml
+    import lxml.etree
 
     LXML = True
 except ImportError:
@@ -68,7 +68,8 @@ def test_default_registered_namespaces() -> None:
 def test_set_default_namespaces() -> None:
     """Set the default namespaces."""
     config.set_etree_implementation(ET)
-    config.etree._namespace_map = {}
+    empty_namespace_map: dict[str, str] = {}
+    config.etree._namespace_map = empty_namespace_map
 
     config.set_default_namespaces()
 

--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -62,8 +62,8 @@ class TestStdLibrary(StdLibrary):
             "name": "Integer",
             "display_name": "An Integer",
         }
-        s.fields = [data.SimpleField(**fields)]  # type: ignore[arg-type]
-        assert s.fields[0] == data.SimpleField(**fields)  # type: ignore[arg-type]
+        s.fields = [data.SimpleField(**fields)]  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        assert s.fields[0] == data.SimpleField(**fields)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     def test_schema_from_string(self) -> None:
         doc = """<Schema name="TrailHeadType" id="TrailHeadTypeId"

--- a/tests/geometries/boundaries_test.py
+++ b/tests/geometries/boundaries_test.py
@@ -16,8 +16,6 @@
 
 """Test the Outer and Inner Boundary classes."""
 
-from typing import Union
-
 import pygeoif.geometry as geo
 import pytest
 
@@ -80,7 +78,7 @@ class TestBoundaries(StdLibrary):
 
     def _test_boundary_geometry_error(
         self,
-        boundary_class: Union[type[InnerBoundaryIs], type[OuterBoundaryIs]],
+        boundary_class: type[InnerBoundaryIs] | type[OuterBoundaryIs],
     ) -> None:
         p = geo.LinearRing(((1, 2), (2, 0)))
         coords = ((1, 2), (2, 0), (0, 0), (1, 2))

--- a/tests/geometries/functions_test.py
+++ b/tests/geometries/functions_test.py
@@ -15,7 +15,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 """Test the geometry error handling."""
 
-from typing import Callable
+from collections.abc import Callable
 from unittest.mock import Mock
 from unittest.mock import patch
 

--- a/tests/geometries/geometry_test.py
+++ b/tests/geometries/geometry_test.py
@@ -181,7 +181,8 @@ class TestGetGeometry(StdLibrary):
 
         g = MultiGeometry.from_string(doc)
 
-        assert len(g.geometry) == 2  # type: ignore[arg-type]
+        assert g.geometry is not None
+        assert len(g.geometry) == 2
 
     def test_multilinestring(self) -> None:
         doc = """
@@ -197,7 +198,8 @@ class TestGetGeometry(StdLibrary):
 
         g = MultiGeometry.from_string(doc)
 
-        assert len(g.geometry) == 2  # type: ignore[arg-type]
+        assert g.geometry is not None
+        assert len(g.geometry) == 2
 
     def test_multipolygon(self) -> None:
         doc = """
@@ -247,7 +249,8 @@ class TestGetGeometry(StdLibrary):
 
         g = MultiGeometry.from_string(doc)
 
-        assert len(g.geometry) == 2  # type: ignore[arg-type]
+        assert g.geometry is not None
+        assert len(g.geometry) == 2
 
     def test_geometrycollection(self) -> None:
         doc = """
@@ -273,7 +276,8 @@ class TestGetGeometry(StdLibrary):
 
         g = MultiGeometry.from_string(doc)
 
-        assert len(g.geometry) == 4  # type: ignore[arg-type]
+        assert g.geometry is not None
+        assert len(g.geometry) == 4
 
     def test_geometrycollection_with_linearring(self) -> None:
         doc = """
@@ -591,7 +595,7 @@ class TestCreateKmlGeometry(StdLibrary):
             AttributeError,
             match=r"^'str' object has no attribute '__geo_interface__'$",
         ):
-            create_kml_geometry("not a geometry")  # type: ignore[arg-type]
+            create_kml_geometry("not a geometry")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
 
 class TestGetGeometryLxml(Lxml, TestGetGeometry):

--- a/tests/geometries/point_test.py
+++ b/tests/geometries/point_test.py
@@ -160,7 +160,7 @@ class TestPoint(StdLibrary):
 
     def test_to_string_empty_geometry(self) -> None:
         """Test the to_string method."""
-        point = Point(geometry=geo.Point(None, None))  # type: ignore[arg-type]
+        point = Point(geometry=geo.Point(None, None))  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
         assert not point
 

--- a/tests/gx/data_test.py
+++ b/tests/gx/data_test.py
@@ -61,8 +61,8 @@ class TestStdLibrary(StdLibrary):
             "name": "Integer",
             "display_name": "An Integer",
         }
-        s.array_fields = [SimpleArrayField(**fields)]  # type: ignore[arg-type]
-        assert s.array_fields[0] == SimpleArrayField(**fields)  # type: ignore[arg-type]
+        s.array_fields = [SimpleArrayField(**fields)]  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+        assert s.array_fields[0] == SimpleArrayField(**fields)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     def test_schema_from_string(self) -> None:
         doc = """    <Schema id="schema"

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -15,8 +15,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 """Test the helper functions edge cases."""
 
+from collections.abc import Callable
 from enum import Enum
-from typing import Callable
 from unittest.mock import Mock
 from unittest.mock import patch
 

--- a/tests/hypothesis/atom_test.py
+++ b/tests/hypothesis/atom_test.py
@@ -21,8 +21,6 @@ roundtrip and string representation of Link and Author classes under various
 input conditions.
 """
 
-from typing import Optional
-
 from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.provisional import urls
@@ -50,12 +48,12 @@ class TestLxml(Lxml):
     )
     def test_fuzz_link(
         self,
-        href: Optional[str],
-        rel: Optional[str],
-        type: Optional[str],
-        hreflang: Optional[str],
-        title: Optional[str],
-        length: Optional[int],
+        href: str | None,
+        rel: str | None,
+        type: str | None,
+        hreflang: str | None,
+        title: str | None,
+        length: int | None,
     ) -> None:
         link = fastkml.atom.Link(
             href=href,
@@ -78,9 +76,9 @@ class TestLxml(Lxml):
     )
     def test_fuzz_author(
         self,
-        name: Optional[str],
-        uri: Optional[str],
-        email: Optional[str],
+        name: str | None,
+        uri: str | None,
+        email: str | None,
     ) -> None:
         author = fastkml.atom.Author(name=name, uri=uri, email=email)
 

--- a/tests/hypothesis/data_test.py
+++ b/tests/hypothesis/data_test.py
@@ -17,8 +17,6 @@
 
 from collections.abc import Iterable
 from functools import partial
-from typing import Optional
-from typing import Union
 
 from hypothesis import given
 from hypothesis import strategies as st
@@ -72,9 +70,9 @@ class TestLxml(Lxml):
     )
     def test_fuzz_simple_field(
         self,
-        name: Optional[str],
-        type_: Optional[fastkml.enums.DataType],
-        display_name: Optional[str],
+        name: str | None,
+        type_: fastkml.enums.DataType | None,
+        display_name: str | None,
     ) -> None:
         simple_field = fastkml.data.SimpleField(
             name=name,
@@ -95,10 +93,10 @@ class TestLxml(Lxml):
     )
     def test_fuzz_schema(
         self,
-        id: Optional[str],
-        name: Optional[str],
-        fields: Optional[Iterable[fastkml.data.SimpleField]],
-        array_fields: Optional[Iterable[fastkml.gx.data.SimpleArrayField]],
+        id: str | None,
+        name: str | None,
+        fields: Iterable[fastkml.data.SimpleField] | None,
+        array_fields: Iterable[fastkml.gx.data.SimpleArrayField] | None,
     ) -> None:
         schema = fastkml.Schema(
             id=id,
@@ -121,11 +119,11 @@ class TestLxml(Lxml):
     )
     def test_fuzz_data(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        name: Optional[str],
-        value: Optional[str],
-        display_name: Optional[str],
+        id: str | None,
+        target_id: str | None,
+        name: str | None,
+        value: str | None,
+        display_name: str | None,
     ) -> None:
         data = fastkml.Data(
             id=id,
@@ -146,8 +144,8 @@ class TestLxml(Lxml):
     )
     def test_fuzz_simple_data(
         self,
-        name: Optional[str],
-        value: Optional[str],
+        name: str | None,
+        value: str | None,
     ) -> None:
         simple_data = fastkml.data.SimpleData(
             name=name,
@@ -168,11 +166,11 @@ class TestLxml(Lxml):
     )
     def test_fuzz_schema_data(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        schema_url: Optional[str],
-        data: Optional[Iterable[fastkml.data.SimpleData]],
-        array_data: Optional[Iterable[fastkml.gx.data.SimpleArrayData]],
+        id: str | None,
+        target_id: str | None,
+        schema_url: str | None,
+        data: Iterable[fastkml.data.SimpleData] | None,
+        array_data: Iterable[fastkml.gx.data.SimpleArrayData] | None,
     ) -> None:
         schema_data = fastkml.SchemaData(
             id=id,
@@ -210,7 +208,7 @@ class TestLxml(Lxml):
     )
     def test_fuzz_extended_data(
         self,
-        elements: Optional[Iterable[Union[fastkml.Data, fastkml.SchemaData]]],
+        elements: Iterable[fastkml.Data | fastkml.SchemaData] | None,
     ) -> None:
         extended_data = fastkml.ExtendedData(
             elements=(

--- a/tests/hypothesis/feature_test.py
+++ b/tests/hypothesis/feature_test.py
@@ -16,8 +16,6 @@
 """Property-based tests for the views module."""
 
 from collections.abc import Iterable
-from typing import Optional
-from typing import Union
 
 import pygeoif.types
 from hypothesis import given
@@ -59,8 +57,8 @@ class TestLxml(Lxml):
     )
     def test_fuzz_snippet(
         self,
-        text: Optional[str],
-        max_lines: Optional[int],
+        text: str | None,
+        max_lines: int | None,
     ) -> None:
         snippet = fastkml.features.Snippet(text=text, max_lines=max_lines)
 
@@ -77,11 +75,7 @@ class TestLxml(Lxml):
     )
     def test_fuzz_placemark_geometry_only(
         self,
-        geometry: Union[
-            pygeoif.types.GeoType,
-            pygeoif.types.GeoCollectionType,
-            None,
-        ],
+        geometry: pygeoif.types.GeoType | pygeoif.types.GeoCollectionType | None,
     ) -> None:
         placemark = fastkml.Placemark(
             geometry=geometry,
@@ -153,9 +147,9 @@ class TestLxml(Lxml):
     )
     def test_fuzz_placemark_view_times(
         self,
-        view: Union[fastkml.Camera, fastkml.LookAt, None],
-        times: Union[fastkml.TimeSpan, fastkml.TimeStamp, None],
-        region: Optional[fastkml.views.Region],
+        view: fastkml.Camera | fastkml.LookAt | None,
+        times: fastkml.TimeSpan | fastkml.TimeStamp | None,
+        region: fastkml.views.Region | None,
     ) -> None:
         placemark = fastkml.Placemark(
             view=view,
@@ -191,10 +185,10 @@ class TestLxml(Lxml):
     )
     def test_fuzz_placemark_str(
         self,
-        address: Optional[str],
-        phone_number: Optional[str],
-        snippet: Optional[fastkml.features.Snippet],
-        description: Optional[str],
+        address: str | None,
+        phone_number: str | None,
+        snippet: fastkml.features.Snippet | None,
+        description: str | None,
     ) -> None:
         placemark = fastkml.Placemark(
             address=address,
@@ -233,13 +227,13 @@ class TestLxml(Lxml):
     )
     def test_fuzz_placemark_atom(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        name: Optional[str],
-        visibility: Optional[bool],
-        isopen: Optional[bool],
-        atom_link: Optional[fastkml.atom.Link],
-        atom_author: Optional[fastkml.atom.Author],
+        id: str | None,
+        target_id: str | None,
+        name: str | None,
+        visibility: bool | None,
+        isopen: bool | None,
+        atom_link: fastkml.atom.Link | None,
+        atom_author: fastkml.atom.Author | None,
     ) -> None:
         placemark = fastkml.Placemark(
             id=id,
@@ -289,10 +283,7 @@ class TestLxml(Lxml):
     )
     def test_fuzz_placemark_gx_track(
         self,
-        kml_geometry: Union[
-            fastkml.gx.Track,
-            fastkml.gx.MultiTrack,
-        ],
+        kml_geometry: fastkml.gx.Track | fastkml.gx.MultiTrack,
     ) -> None:
         placemark = fastkml.Placemark(
             kml_geometry=kml_geometry,
@@ -331,7 +322,7 @@ class TestLxml(Lxml):
     )
     def test_fuzz_placemark_extended_data(
         self,
-        extended_data: Optional[fastkml.ExtendedData],
+        extended_data: fastkml.ExtendedData | None,
     ) -> None:
         placemark = fastkml.Placemark(
             extended_data=extended_data,
@@ -407,8 +398,8 @@ class TestLxml(Lxml):
     )
     def test_fuzz_placemark_styles(
         self,
-        style_url: Optional[fastkml.StyleUrl],
-        styles: Optional[Iterable[Union[fastkml.Style, fastkml.StyleMap]]],
+        style_url: fastkml.StyleUrl | None,
+        styles: Iterable[fastkml.Style | fastkml.StyleMap] | None,
     ) -> None:
         placemark = fastkml.Placemark(
             style_url=style_url,
@@ -471,9 +462,9 @@ class TestLxml(Lxml):
     )
     def test_network_link(
         self,
-        refresh_visibility: Optional[bool],
-        fly_to_view: Optional[bool],
-        link: Optional[fastkml.links.Link],
+        refresh_visibility: bool | None,
+        fly_to_view: bool | None,
+        link: fastkml.links.Link | None,
     ) -> None:
         """Test NetworkLink object with optional parameters."""
         network_link = fastkml.features.NetworkLink(

--- a/tests/hypothesis/geometry_test.py
+++ b/tests/hypothesis/geometry_test.py
@@ -17,8 +17,6 @@
 """Property based tests of the Geometry classes."""
 
 from collections.abc import Sequence
-from typing import Optional
-from typing import Union
 
 from hypothesis import given
 from hypothesis import settings
@@ -51,11 +49,9 @@ eval_locals = {
     "fastkml": fastkml,
 }
 
-kml_geometry = Union[
-    fastkml.geometry.Point,
-    fastkml.geometry.LineString,
-    fastkml.geometry.Polygon,
-]
+kml_geometry = (
+    fastkml.geometry.Point | fastkml.geometry.LineString | fastkml.geometry.Polygon
+)
 
 coordinates = {
     "coords": st.one_of(st.none(), line_coords(srs=epsg4326, min_points=1)),
@@ -139,11 +135,9 @@ class TestLxml(Lxml):
     @settings(deadline=None)
     def test_coordinates_str_roundtrip(
         self,
-        coords: Union[
-            Sequence[tuple[float, float]],
-            Sequence[tuple[float, float, float]],
-            None,
-        ],
+        coords: Sequence[tuple[float, float]]
+        | Sequence[tuple[float, float, float]]
+        | None,
     ) -> None:
         coordinate = fastkml.geometry.Coordinates(coords=coords)
 
@@ -157,11 +151,9 @@ class TestLxml(Lxml):
     @given(**coordinates)
     def test_coordinates_repr_roundtrip(
         self,
-        coords: Union[
-            Sequence[tuple[float, float]],
-            Sequence[tuple[float, float, float]],
-            None,
-        ],
+        coords: Sequence[tuple[float, float]]
+        | Sequence[tuple[float, float, float]]
+        | None,
     ) -> None:
         coordinate = fastkml.geometry.Coordinates(coords=coords)
 
@@ -179,12 +171,12 @@ class TestLxml(Lxml):
     )
     def test_point_repr_roundtrip(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        extrude: Optional[bool],
-        altitude_mode: Optional[AltitudeMode],
-        tessellate: Optional[bool],  # noqa: ARG002
-        geometry: Optional[Point],
+        id: str | None,
+        target_id: str | None,
+        extrude: bool | None,
+        altitude_mode: AltitudeMode | None,
+        tessellate: bool | None,  # noqa: ARG002
+        geometry: Point | None,
     ) -> None:
         point = fastkml.geometry.Point(
             id=id,
@@ -205,12 +197,12 @@ class TestLxml(Lxml):
     )
     def test_point_str_roundtrip(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        extrude: Optional[bool],
-        tessellate: Optional[bool],  # noqa: ARG002
-        altitude_mode: Optional[AltitudeMode],
-        geometry: Optional[Point],
+        id: str | None,
+        target_id: str | None,
+        extrude: bool | None,
+        tessellate: bool | None,  # noqa: ARG002
+        altitude_mode: AltitudeMode | None,
+        geometry: Point | None,
     ) -> None:
         point = fastkml.geometry.Point(
             id=id,
@@ -231,12 +223,12 @@ class TestLxml(Lxml):
     )
     def test_point_str_roundtrip_terse(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        extrude: Optional[bool],
-        tessellate: Optional[bool],  # noqa: ARG002
-        altitude_mode: Optional[AltitudeMode],
-        geometry: Optional[Point],
+        id: str | None,
+        target_id: str | None,
+        extrude: bool | None,
+        tessellate: bool | None,  # noqa: ARG002
+        altitude_mode: AltitudeMode | None,
+        geometry: Point | None,
     ) -> None:
         point = fastkml.geometry.Point(
             id=id,
@@ -257,12 +249,12 @@ class TestLxml(Lxml):
     )
     def test_point_str_roundtrip_verbose(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        extrude: Optional[bool],
-        tessellate: Optional[bool],  # noqa: ARG002
-        altitude_mode: Optional[AltitudeMode],
-        geometry: Optional[Point],
+        id: str | None,
+        target_id: str | None,
+        extrude: bool | None,
+        tessellate: bool | None,  # noqa: ARG002
+        altitude_mode: AltitudeMode | None,
+        geometry: Point | None,
     ) -> None:
         point = fastkml.geometry.Point(
             id=id,
@@ -283,12 +275,12 @@ class TestLxml(Lxml):
     )
     def test_linestring_repr_roundtrip(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        extrude: Optional[bool],
-        tessellate: Optional[bool],
-        altitude_mode: Optional[AltitudeMode],
-        geometry: Optional[LineString],
+        id: str | None,
+        target_id: str | None,
+        extrude: bool | None,
+        tessellate: bool | None,
+        altitude_mode: AltitudeMode | None,
+        geometry: LineString | None,
     ) -> None:
         line = fastkml.geometry.LineString(
             id=id,
@@ -310,12 +302,12 @@ class TestLxml(Lxml):
     )
     def test_linestring_str_roundtrip(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        extrude: Optional[bool],
-        tessellate: Optional[bool],
-        altitude_mode: Optional[AltitudeMode],
-        geometry: Optional[LineString],
+        id: str | None,
+        target_id: str | None,
+        extrude: bool | None,
+        tessellate: bool | None,
+        altitude_mode: AltitudeMode | None,
+        geometry: LineString | None,
     ) -> None:
         line = fastkml.geometry.LineString(
             id=id,
@@ -337,12 +329,12 @@ class TestLxml(Lxml):
     )
     def test_linestring_str_roundtrip_terse(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        extrude: Optional[bool],
-        tessellate: Optional[bool],
-        altitude_mode: Optional[AltitudeMode],
-        geometry: Optional[LineString],
+        id: str | None,
+        target_id: str | None,
+        extrude: bool | None,
+        tessellate: bool | None,
+        altitude_mode: AltitudeMode | None,
+        geometry: LineString | None,
     ) -> None:
         line = fastkml.geometry.LineString(
             id=id,
@@ -364,12 +356,12 @@ class TestLxml(Lxml):
     )
     def test_linestring_str_roundtrip_verbose(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        extrude: Optional[bool],
-        tessellate: Optional[bool],
-        altitude_mode: Optional[AltitudeMode],
-        geometry: Optional[LineString],
+        id: str | None,
+        target_id: str | None,
+        extrude: bool | None,
+        tessellate: bool | None,
+        altitude_mode: AltitudeMode | None,
+        geometry: LineString | None,
     ) -> None:
         line = fastkml.geometry.LineString(
             id=id,
@@ -391,12 +383,12 @@ class TestLxml(Lxml):
     )
     def test_polygon_repr_roundtrip(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        extrude: Optional[bool],
-        tessellate: Optional[bool],
-        altitude_mode: Optional[AltitudeMode],
-        geometry: Optional[Polygon],
+        id: str | None,
+        target_id: str | None,
+        extrude: bool | None,
+        tessellate: bool | None,
+        altitude_mode: AltitudeMode | None,
+        geometry: Polygon | None,
     ) -> None:
         polygon = fastkml.geometry.Polygon(
             id=id,
@@ -418,12 +410,12 @@ class TestLxml(Lxml):
     )
     def test_polygon_str_roundtrip(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        extrude: Optional[bool],
-        tessellate: Optional[bool],
-        altitude_mode: Optional[AltitudeMode],
-        geometry: Optional[Polygon],
+        id: str | None,
+        target_id: str | None,
+        extrude: bool | None,
+        tessellate: bool | None,
+        altitude_mode: AltitudeMode | None,
+        geometry: Polygon | None,
     ) -> None:
         polygon = fastkml.geometry.Polygon(
             id=id,
@@ -445,12 +437,12 @@ class TestLxml(Lxml):
     )
     def test_polygon_str_roundtrip_terse(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        extrude: Optional[bool],
-        tessellate: Optional[bool],
-        altitude_mode: Optional[AltitudeMode],
-        geometry: Optional[Polygon],
+        id: str | None,
+        target_id: str | None,
+        extrude: bool | None,
+        tessellate: bool | None,
+        altitude_mode: AltitudeMode | None,
+        geometry: Polygon | None,
     ) -> None:
         polygon = fastkml.geometry.Polygon(
             id=id,
@@ -472,12 +464,12 @@ class TestLxml(Lxml):
     )
     def test_polygon_str_roundtrip_verbose(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        extrude: Optional[bool],
-        tessellate: Optional[bool],
-        altitude_mode: Optional[AltitudeMode],
-        geometry: Optional[Polygon],
+        id: str | None,
+        target_id: str | None,
+        extrude: bool | None,
+        tessellate: bool | None,
+        altitude_mode: AltitudeMode | None,
+        geometry: Polygon | None,
     ) -> None:
         polygon = fastkml.geometry.Polygon(
             id=id,

--- a/tests/hypothesis/gx/data_test.py
+++ b/tests/hypothesis/gx/data_test.py
@@ -16,7 +16,6 @@
 """Test gx SimpleArrayData and SimpleArrayField."""
 
 from collections.abc import Iterable
-from typing import Optional
 
 from hypothesis import given
 from hypothesis import strategies as st
@@ -43,10 +42,10 @@ class TestLxml(Lxml):
     )
     def test_fuzz_simple_array_data(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        name: Optional[str],
-        data: Optional[Iterable[str]],
+        id: str | None,
+        target_id: str | None,
+        name: str | None,
+        data: Iterable[str] | None,
     ) -> None:
         simple_array_data = fastkml.gx.data.SimpleArrayData(
             id=id,
@@ -67,9 +66,9 @@ class TestLxml(Lxml):
     )
     def test_fuzz_simple_array_field(
         self,
-        name: Optional[str],
-        type_: Optional[DataType],
-        display_name: Optional[str],
+        name: str | None,
+        type_: DataType | None,
+        display_name: str | None,
     ) -> None:
         simple_array_field = fastkml.gx.data.SimpleArrayField(
             name=name,

--- a/tests/hypothesis/gx/track_test.py
+++ b/tests/hypothesis/gx/track_test.py
@@ -16,7 +16,6 @@
 """Test gx Track and MultiTrack."""
 
 from collections.abc import Iterable
-from typing import Optional
 
 from hypothesis import given
 from hypothesis import strategies as st
@@ -87,11 +86,11 @@ class TestLxml(Lxml):
     )
     def test_fuzz_track_track_items(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        altitude_mode: Optional[fastkml.enums.AltitudeMode],
-        track_items: Optional[Iterable[fastkml.gx.TrackItem]],
-        extended_data: Optional[fastkml.ExtendedData],
+        id: str | None,
+        target_id: str | None,
+        altitude_mode: fastkml.enums.AltitudeMode | None,
+        track_items: Iterable[fastkml.gx.TrackItem] | None,
+        extended_data: fastkml.ExtendedData | None,
     ) -> None:
         track = fastkml.gx.Track(
             id=id,
@@ -129,11 +128,11 @@ class TestLxml(Lxml):
     )
     def test_fuzz_multi_track(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        altitude_mode: Optional[fastkml.enums.AltitudeMode],
-        tracks: Optional[Iterable[fastkml.gx.Track]],
-        interpolate: Optional[bool],
+        id: str | None,
+        target_id: str | None,
+        altitude_mode: fastkml.enums.AltitudeMode | None,
+        tracks: Iterable[fastkml.gx.Track] | None,
+        interpolate: bool | None,
     ) -> None:
         multi_track = fastkml.gx.MultiTrack(
             id=id,

--- a/tests/hypothesis/kml_test.py
+++ b/tests/hypothesis/kml_test.py
@@ -63,7 +63,7 @@ class TestLxml(Lxml):
         feature: fastkml.features._Feature,
     ) -> None:
         kml = fastkml.kml.KML(
-            features=[feature],  # type: ignore[list-item]
+            features=[feature],  # type: ignore[list-item]  # ty: ignore[invalid-argument-type]
         )
 
         assert_repr_roundtrip(kml)

--- a/tests/hypothesis/links_test.py
+++ b/tests/hypothesis/links_test.py
@@ -16,8 +16,6 @@
 """Test Link and Icon."""
 
 import string
-from typing import Optional
-from typing import Union
 
 import pytest
 from hypothesis import given
@@ -69,17 +67,17 @@ class TestLxml(Lxml):
     @given(**common_link)
     def test_fuzz_link(
         self,
-        cls: Union[type[fastkml.Link], type[fastkml.Icon]],
-        id: Optional[str],
-        target_id: Optional[str],
-        href: Optional[str],
-        refresh_mode: Optional[fastkml.enums.RefreshMode],
-        refresh_interval: Optional[float],
-        view_refresh_mode: Optional[fastkml.enums.ViewRefreshMode],
-        view_refresh_time: Optional[float],
-        view_bound_scale: Optional[float],
-        view_format: Optional[str],
-        http_query: Optional[str],
+        cls: type[fastkml.Link] | type[fastkml.Icon],
+        id: str | None,
+        target_id: str | None,
+        href: str | None,
+        refresh_mode: fastkml.enums.RefreshMode | None,
+        refresh_interval: float | None,
+        view_refresh_mode: fastkml.enums.ViewRefreshMode | None,
+        view_refresh_time: float | None,
+        view_bound_scale: float | None,
+        view_format: str | None,
+        http_query: str | None,
     ) -> None:
         link = cls(
             id=id,

--- a/tests/hypothesis/model_test.py
+++ b/tests/hypothesis/model_test.py
@@ -16,7 +16,6 @@
 """Hypothesis tests for the fastkml.model module."""
 
 from collections.abc import Iterable
-from typing import Optional
 
 from hypothesis import given
 from hypothesis import strategies as st
@@ -66,11 +65,11 @@ class TestLxml(Lxml):
     )
     def test_fuzz_location(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        altitude: Optional[float],
-        latitude: Optional[float],
-        longitude: Optional[float],
+        id: str | None,
+        target_id: str | None,
+        altitude: float | None,
+        latitude: float | None,
+        longitude: float | None,
     ) -> None:
         location = fastkml.model.Location(
             id=id,
@@ -121,11 +120,11 @@ class TestLxml(Lxml):
     )
     def test_fuzz_orientation(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        heading: Optional[float],
-        tilt: Optional[float],
-        roll: Optional[float],
+        id: str | None,
+        target_id: str | None,
+        heading: float | None,
+        tilt: float | None,
+        roll: float | None,
     ) -> None:
         orientation = fastkml.model.Orientation(
             id=id,
@@ -149,11 +148,11 @@ class TestLxml(Lxml):
     )
     def test_fuzz_scale(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        x: Optional[float],
-        y: Optional[float],
-        z: Optional[float],
+        id: str | None,
+        target_id: str | None,
+        x: float | None,
+        y: float | None,
+        z: float | None,
     ) -> None:
         scale = fastkml.model.Scale(id=id, target_id=target_id, x=x, y=y, z=z)
 
@@ -170,10 +169,10 @@ class TestLxml(Lxml):
     )
     def test_fuzz_alias(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        target_href: Optional[str],
-        source_href: Optional[str],
+        id: str | None,
+        target_id: str | None,
+        target_href: str | None,
+        source_href: str | None,
     ) -> None:
         alias = fastkml.model.Alias(
             id=id,
@@ -203,9 +202,9 @@ class TestLxml(Lxml):
     )
     def test_fuzz_resource_map(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        aliases: Optional[Iterable[fastkml.model.Alias]],
+        id: str | None,
+        target_id: str | None,
+        aliases: Iterable[fastkml.model.Alias] | None,
     ) -> None:
         resource_map = fastkml.model.ResourceMap(
             id=id,
@@ -300,14 +299,14 @@ class TestLxml(Lxml):
     )
     def test_fuzz_model(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        altitude_mode: Optional[fastkml.enums.AltitudeMode],
-        location: Optional[fastkml.model.Location],
-        orientation: Optional[fastkml.model.Orientation],
-        scale: Optional[fastkml.model.Scale],
-        link: Optional[fastkml.Link],
-        resource_map: Optional[fastkml.model.ResourceMap],
+        id: str | None,
+        target_id: str | None,
+        altitude_mode: fastkml.enums.AltitudeMode | None,
+        location: fastkml.model.Location | None,
+        orientation: fastkml.model.Orientation | None,
+        scale: fastkml.model.Scale | None,
+        link: fastkml.Link | None,
+        resource_map: fastkml.model.ResourceMap | None,
     ) -> None:
         model = fastkml.model.Model(
             id=id,

--- a/tests/hypothesis/multi_geometry_test.py
+++ b/tests/hypothesis/multi_geometry_test.py
@@ -97,7 +97,7 @@ def _test_geometry_str_roundtrip(
     assert new_g.geometry
     assert geometry.geometry
     assert type(new_g.geometry) is cls
-    for g1, g2 in zip(new_g.kml_geometries, geometry.kml_geometries):
+    for g1, g2 in zip(new_g.kml_geometries, geometry.kml_geometries, strict=False):
         assert g1.extrude == g2.extrude == extrude
         assert g1.altitude_mode == g2.altitude_mode == altitude_mode
         if not isinstance(g1, fastkml.geometry.Point):
@@ -125,7 +125,7 @@ def _test_geometry_str_roundtrip_terse(
     assert new_g.geometry
     assert geometry.geometry
     assert type(new_g.geometry) is cls
-    for new, orig in zip(new_g.kml_geometries, geometry.kml_geometries):
+    for new, orig in zip(new_g.kml_geometries, geometry.kml_geometries, strict=False):
         if extrude:
             assert new.extrude == orig.extrude == extrude
         else:
@@ -162,7 +162,7 @@ def _test_geometry_str_roundtrip_verbose(
     assert new_g.geometry
     assert geometry.geometry
     assert type(new_g.geometry) is cls
-    for new, orig in zip(new_g.kml_geometries, geometry.kml_geometries):
+    for new, orig in zip(new_g.kml_geometries, geometry.kml_geometries, strict=False):
         if isinstance(new, fastkml.geometry.MultiGeometry):  # pragma: no cover
             continue  # pragma: no cover
         assert not isinstance(orig, fastkml.geometry.MultiGeometry)

--- a/tests/hypothesis/network_link_control_test.py
+++ b/tests/hypothesis/network_link_control_test.py
@@ -15,9 +15,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 """Hypothesis tests for the fastkml.network_link_control module."""
 
-from typing import Optional
-from typing import Union
-
 from hypothesis import given
 from hypothesis import strategies as st
 
@@ -95,15 +92,15 @@ class TestLxml(Lxml):
     )
     def test_fuzz_network_link_control(
         self,
-        min_refresh_period: Optional[float],
-        max_session_length: Optional[float],
-        cookie: Optional[str],
-        message: Optional[str],
-        link_name: Optional[str],
-        link_description: Optional[str],
-        link_snippet: Optional[str],
-        expires: Optional[fastkml.KmlDateTime],
-        view: Union[fastkml.Camera, fastkml.LookAt, None],
+        min_refresh_period: float | None,
+        max_session_length: float | None,
+        cookie: str | None,
+        message: str | None,
+        link_name: str | None,
+        link_description: str | None,
+        link_snippet: str | None,
+        expires: fastkml.KmlDateTime | None,
+        view: fastkml.Camera | fastkml.LookAt | None,
     ) -> None:
         nlc = fastkml.NetworkLinkControl(
             min_refresh_period=min_refresh_period,
@@ -149,7 +146,7 @@ class TestLxml(Lxml):
     def test_fuzz_update_with_change(
         self,
         target_href: str,
-        placemark_name: Optional[str],
+        placemark_name: str | None,
     ) -> None:
         placemark = fastkml.Placemark(
             id="pm1",
@@ -177,7 +174,7 @@ class TestLxml(Lxml):
     def test_fuzz_network_link_control_with_update(
         self,
         target_href: str,
-        placemark_name: Optional[str],
+        placemark_name: str | None,
     ) -> None:
         placemark = fastkml.Placemark(
             id="pm1",

--- a/tests/hypothesis/overlay_test.py
+++ b/tests/hypothesis/overlay_test.py
@@ -15,9 +15,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 """Test Link and Icon."""
 
-from typing import Optional
-from typing import Union
-
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
@@ -60,13 +57,13 @@ class TestLxml(Lxml):
     )
     def test_fuzz_view_volume(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        left_fov: Optional[float],
-        right_fov: Optional[float],
-        bottom_fov: Optional[float],
-        top_fov: Optional[float],
-        near: Optional[float],
+        id: str | None,
+        target_id: str | None,
+        left_fov: float | None,
+        right_fov: float | None,
+        bottom_fov: float | None,
+        top_fov: float | None,
+        near: float | None,
     ) -> None:
         view_volume = fastkml.overlays.ViewVolume(
             id=id,
@@ -93,12 +90,12 @@ class TestLxml(Lxml):
     )
     def test_fuzz_image_pyramid(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        tile_size: Optional[int],
-        max_width: Optional[int],
-        max_height: Optional[int],
-        grid_origin: Optional[fastkml.enums.GridOrigin],
+        id: str | None,
+        target_id: str | None,
+        tile_size: int | None,
+        max_width: int | None,
+        max_height: int | None,
+        grid_origin: fastkml.enums.GridOrigin | None,
     ) -> None:
         image_pyramid = fastkml.overlays.ImagePyramid(
             id=id,
@@ -140,13 +137,13 @@ class TestLxml(Lxml):
     )
     def test_fuzz_lat_lon_box(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        north: Optional[float],
-        south: Optional[float],
-        east: Optional[float],
-        west: Optional[float],
-        rotation: Optional[float],
+        id: str | None,
+        target_id: str | None,
+        north: float | None,
+        south: float | None,
+        east: float | None,
+        west: float | None,
+        rotation: float | None,
     ) -> None:
         lat_lon_box = fastkml.overlays.LatLonBox(
             id=id,
@@ -205,11 +202,11 @@ class TestLxml(Lxml):
     )
     def test_fuzz_photo_overlay(
         self,
-        rotation: Optional[float],
-        view_volume: Optional[fastkml.overlays.ViewVolume],
-        image_pyramid: Optional[fastkml.overlays.ImagePyramid],
-        point: Optional[fastkml.geometry.Point],
-        shape: Optional[fastkml.enums.Shape],
+        rotation: float | None,
+        view_volume: fastkml.overlays.ViewVolume | None,
+        image_pyramid: fastkml.overlays.ImagePyramid | None,
+        point: fastkml.geometry.Point | None,
+        shape: fastkml.enums.Shape | None,
     ) -> None:
         photo_overlay = fastkml.overlays.PhotoOverlay(
             id="photo_overlay1",
@@ -248,9 +245,9 @@ class TestLxml(Lxml):
     )
     def test_fuzz_ground_overlay(
         self,
-        altitude: Optional[float],
-        altitude_mode: Optional[fastkml.enums.AltitudeMode],
-        lat_lon_box: Optional[fastkml.overlays.LatLonBox],
+        altitude: float | None,
+        altitude_mode: fastkml.enums.AltitudeMode | None,
+        lat_lon_box: fastkml.overlays.LatLonBox | None,
     ) -> None:
         ground_overlay = fastkml.overlays.GroundOverlay(
             id="ground_overlay1",
@@ -282,16 +279,14 @@ class TestLxml(Lxml):
     )
     def test_fuzz_xy(
         self,
-        cls: Union[
-            type[fastkml.overlays.OverlayXY],
-            type[fastkml.overlays.RotationXY],
-            type[fastkml.overlays.ScreenXY],
-            type[fastkml.overlays.Size],
-        ],
-        x: Optional[float],
-        y: Optional[float],
-        x_units: Optional[fastkml.enums.Units],
-        y_units: Optional[fastkml.enums.Units],
+        cls: type[fastkml.overlays.OverlayXY]
+        | type[fastkml.overlays.RotationXY]
+        | type[fastkml.overlays.ScreenXY]
+        | type[fastkml.overlays.Size],
+        x: float | None,
+        y: float | None,
+        x_units: fastkml.enums.Units | None,
+        y_units: fastkml.enums.Units | None,
     ) -> None:
         xy = cls(x=x, y=y, x_units=x_units, y_units=y_units)
 
@@ -309,11 +304,11 @@ class TestLxml(Lxml):
     )
     def test_screen_overlay(
         self,
-        overlay_xy: Optional[fastkml.overlays.OverlayXY],
-        screen_xy: Optional[fastkml.overlays.ScreenXY],
-        rotation_xy: Optional[fastkml.overlays.RotationXY],
-        size: Optional[fastkml.overlays.Size],
-        rotation: Optional[float],
+        overlay_xy: fastkml.overlays.OverlayXY | None,
+        screen_xy: fastkml.overlays.ScreenXY | None,
+        rotation_xy: fastkml.overlays.RotationXY | None,
+        size: fastkml.overlays.Size | None,
+        rotation: float | None,
     ) -> None:
         screen_overlay = fastkml.overlays.ScreenOverlay(
             id="screen_overlay1",

--- a/tests/hypothesis/style_test.py
+++ b/tests/hypothesis/style_test.py
@@ -16,8 +16,6 @@
 """Property-based tests for the styles module."""
 
 from collections.abc import Iterable
-from typing import Optional
-from typing import Union
 
 from hypothesis import given
 from hypothesis import strategies as st
@@ -44,7 +42,7 @@ class TestLxml(Lxml):
     )
     def test_fuzz_style_url(
         self,
-        url: Optional[str],
+        url: str | None,
     ) -> None:
         style_url = fastkml.StyleUrl(
             url=url,
@@ -63,10 +61,10 @@ class TestLxml(Lxml):
     )
     def test_fuzz_hot_spot(
         self,
-        x: Optional[float],
-        y: Optional[float],
-        xunits: Optional[fastkml.enums.Units],
-        yunits: Optional[fastkml.enums.Units],
+        x: float | None,
+        y: float | None,
+        xunits: fastkml.enums.Units | None,
+        yunits: fastkml.enums.Units | None,
     ) -> None:
         hot_spot = fastkml.styles.HotSpot(
             x=x,
@@ -119,14 +117,14 @@ class TestLxml(Lxml):
     )
     def test_fuzz_icon_style(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        color: Optional[str],
-        color_mode: Optional[fastkml.enums.ColorMode],
-        scale: Optional[float],
-        heading: Optional[float],
-        icon: Optional[fastkml.links.Icon],
-        hot_spot: Optional[fastkml.styles.HotSpot],
+        id: str | None,
+        target_id: str | None,
+        color: str | None,
+        color_mode: fastkml.enums.ColorMode | None,
+        scale: float | None,
+        heading: float | None,
+        icon: fastkml.links.Icon | None,
+        hot_spot: fastkml.styles.HotSpot | None,
     ) -> None:
         icon_style = fastkml.IconStyle(
             id=id,
@@ -157,11 +155,11 @@ class TestLxml(Lxml):
     )
     def test_fuzz_line_style(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        color: Optional[str],
-        color_mode: Optional[fastkml.enums.ColorMode],
-        width: Optional[float],
+        id: str | None,
+        target_id: str | None,
+        color: str | None,
+        color_mode: fastkml.enums.ColorMode | None,
+        width: float | None,
     ) -> None:
         line_style = fastkml.LineStyle(
             id=id,
@@ -186,12 +184,12 @@ class TestLxml(Lxml):
     )
     def test_fuzz_poly_style(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        color: Optional[str],
-        color_mode: Optional[fastkml.enums.ColorMode],
-        fill: Optional[bool],
-        outline: Optional[bool],
+        id: str | None,
+        target_id: str | None,
+        color: str | None,
+        color_mode: fastkml.enums.ColorMode | None,
+        fill: bool | None,
+        outline: bool | None,
     ) -> None:
         poly_style = fastkml.PolyStyle(
             id=id,
@@ -219,11 +217,11 @@ class TestLxml(Lxml):
     )
     def test_fuzz_label_style(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        color: Optional[str],
-        color_mode: Optional[fastkml.enums.ColorMode],
-        scale: Optional[float],
+        id: str | None,
+        target_id: str | None,
+        color: str | None,
+        color_mode: fastkml.enums.ColorMode | None,
+        scale: float | None,
     ) -> None:
         label_style = fastkml.LabelStyle(
             id=id,
@@ -248,12 +246,12 @@ class TestLxml(Lxml):
     )
     def test_fuzz_balloon_style(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        bg_color: Optional[str],
-        text_color: Optional[str],
-        text: Optional[str],
-        display_mode: Optional[fastkml.enums.DisplayMode],
+        id: str | None,
+        target_id: str | None,
+        bg_color: str | None,
+        text_color: str | None,
+        text: str | None,
+        display_mode: fastkml.enums.DisplayMode | None,
     ) -> None:
         balloon_style = fastkml.BalloonStyle(
             id=id,
@@ -321,19 +319,16 @@ class TestLxml(Lxml):
     )
     def test_fuzz_style(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        styles: Optional[
-            Iterable[
-                Union[
-                    fastkml.BalloonStyle,
-                    fastkml.IconStyle,
-                    fastkml.LabelStyle,
-                    fastkml.LineStyle,
-                    fastkml.PolyStyle,
-                ]
-            ]
-        ],
+        id: str | None,
+        target_id: str | None,
+        styles: Iterable[
+            fastkml.BalloonStyle
+            | fastkml.IconStyle
+            | fastkml.LabelStyle
+            | fastkml.LineStyle
+            | fastkml.PolyStyle
+        ]
+        | None,
     ) -> None:
         style = fastkml.Style(id=id, target_id=target_id, styles=styles)
 
@@ -381,18 +376,15 @@ class TestLxml(Lxml):
     )
     def test_fuzz_styles_no_icon_style(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        styles: Optional[
-            Iterable[
-                Union[
-                    fastkml.BalloonStyle,
-                    fastkml.LabelStyle,
-                    fastkml.LineStyle,
-                    fastkml.PolyStyle,
-                ]
-            ]
-        ],
+        id: str | None,
+        target_id: str | None,
+        styles: Iterable[
+            fastkml.BalloonStyle
+            | fastkml.LabelStyle
+            | fastkml.LineStyle
+            | fastkml.PolyStyle
+        ]
+        | None,
     ) -> None:
         style = fastkml.Style(id=id, target_id=target_id, styles=styles)
 
@@ -422,10 +414,10 @@ class TestLxml(Lxml):
     )
     def test_fuzz_pair(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        key: Optional[fastkml.enums.PairKey],
-        style: Union[fastkml.StyleUrl, fastkml.Style, None],
+        id: str | None,
+        target_id: str | None,
+        key: fastkml.enums.PairKey | None,
+        style: fastkml.StyleUrl | fastkml.Style | None,
     ) -> None:
         pair = fastkml.styles.Pair(id=id, target_id=target_id, key=key, style=style)
 
@@ -463,9 +455,9 @@ class TestLxml(Lxml):
     )
     def test_fuzz_style_map_one_pair(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        pairs: Optional[tuple[fastkml.styles.Pair]],
+        id: str | None,
+        target_id: str | None,
+        pairs: tuple[fastkml.styles.Pair] | None,
     ) -> None:
         style_map = fastkml.StyleMap(id=id, target_id=target_id, pairs=pairs)
 
@@ -518,9 +510,9 @@ class TestLxml(Lxml):
     )
     def test_fuzz_style_map_pairs(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        pairs: Optional[tuple[fastkml.styles.Pair]],
+        id: str | None,
+        target_id: str | None,
+        pairs: tuple[fastkml.styles.Pair] | None,
     ) -> None:
         style_map = fastkml.StyleMap(id=id, target_id=target_id, pairs=pairs)
 

--- a/tests/hypothesis/times_test.py
+++ b/tests/hypothesis/times_test.py
@@ -20,8 +20,6 @@ These tests use the hypothesis library to generate random input for the
 functions under test. The tests are run with pytest.
 """
 
-from typing import Optional
-
 from hypothesis import given
 from hypothesis import strategies as st
 
@@ -45,9 +43,9 @@ class TestTimes(Lxml):
     )
     def test_fuzz_time_stamp(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        timestamp: Optional[fastkml.times.KmlDateTime],
+        id: str | None,
+        target_id: str | None,
+        timestamp: fastkml.times.KmlDateTime | None,
     ) -> None:
         time_stamp = fastkml.TimeStamp(id=id, target_id=target_id, timestamp=timestamp)
 
@@ -64,10 +62,10 @@ class TestTimes(Lxml):
     )
     def test_fuzz_time_span(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        begin: Optional[fastkml.times.KmlDateTime],
-        end: Optional[fastkml.times.KmlDateTime],
+        id: str | None,
+        target_id: str | None,
+        begin: fastkml.times.KmlDateTime | None,
+        end: fastkml.times.KmlDateTime | None,
     ) -> None:
         time_span = fastkml.TimeSpan(id=id, target_id=target_id, begin=begin, end=end)
 

--- a/tests/hypothesis/views_test.py
+++ b/tests/hypothesis/views_test.py
@@ -15,8 +15,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 """Property-based tests for the views module."""
 
-from typing import Optional
-
 from hypothesis import given
 from hypothesis import strategies as st
 
@@ -80,12 +78,12 @@ class TestLxml(Lxml):
     )
     def test_fuzz_lod(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        min_lod_pixels: Optional[int],
-        max_lod_pixels: Optional[int],
-        min_fade_extent: Optional[int],
-        max_fade_extent: Optional[int],
+        id: str | None,
+        target_id: str | None,
+        min_lod_pixels: int | None,
+        max_lod_pixels: int | None,
+        min_fade_extent: int | None,
+        max_fade_extent: int | None,
     ) -> None:
         lod = fastkml.views.Lod(
             id=id,
@@ -142,15 +140,15 @@ class TestLxml(Lxml):
     )
     def test_fuzz_lat_lon_alt_box(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        north: Optional[float],
-        south: Optional[float],
-        east: Optional[float],
-        west: Optional[float],
-        min_altitude: Optional[float],
-        max_altitude: Optional[float],
-        altitude_mode: Optional[fastkml.enums.AltitudeMode],
+        id: str | None,
+        target_id: str | None,
+        north: float | None,
+        south: float | None,
+        east: float | None,
+        west: float | None,
+        min_altitude: float | None,
+        max_altitude: float | None,
+        altitude_mode: fastkml.enums.AltitudeMode | None,
     ) -> None:
         lat_lon_alt_box = fastkml.views.LatLonAltBox(
             id=id,
@@ -177,10 +175,10 @@ class TestLxml(Lxml):
     )
     def test_fuzz_region(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        lat_lon_alt_box: Optional[fastkml.views.LatLonAltBox],
-        lod: Optional[fastkml.views.Lod],
+        id: str | None,
+        target_id: str | None,
+        lat_lon_alt_box: fastkml.views.LatLonAltBox | None,
+        lod: fastkml.views.Lod | None,
     ) -> None:
         region = fastkml.views.Region(
             id=id,
@@ -208,15 +206,15 @@ class TestLxml(Lxml):
     )
     def test_fuzz_camera(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        longitude: Optional[float],
-        latitude: Optional[float],
-        altitude: Optional[float],
-        heading: Optional[float],
-        tilt: Optional[float],
-        altitude_mode: Optional[fastkml.enums.AltitudeMode],
-        roll: Optional[float],
+        id: str | None,
+        target_id: str | None,
+        longitude: float | None,
+        latitude: float | None,
+        altitude: float | None,
+        heading: float | None,
+        tilt: float | None,
+        altitude_mode: fastkml.enums.AltitudeMode | None,
+        roll: float | None,
     ) -> None:
         camera = fastkml.Camera(
             id=id,
@@ -244,15 +242,15 @@ class TestLxml(Lxml):
     )
     def test_fuzz_look_at(
         self,
-        id: Optional[str],
-        target_id: Optional[str],
-        longitude: Optional[float],
-        latitude: Optional[float],
-        altitude: Optional[float],
-        heading: Optional[float],
-        tilt: Optional[float],
-        altitude_mode: Optional[fastkml.enums.AltitudeMode],
-        range: Optional[float],
+        id: str | None,
+        target_id: str | None,
+        longitude: float | None,
+        latitude: float | None,
+        altitude: float | None,
+        heading: float | None,
+        tilt: float | None,
+        altitude_mode: fastkml.enums.AltitudeMode | None,
+        range: float | None,
     ) -> None:
         look_at = fastkml.LookAt(
             id=id,

--- a/tests/overlays_test.py
+++ b/tests/overlays_test.py
@@ -402,8 +402,8 @@ class TestPhotoOverlay(StdLibrary):
 
     def test_camera_altitude_mode_absolute(self) -> None:
         po = overlays.PhotoOverlay(view=views.Camera())
-        po.view.altitude_mode = "absolute"
-        assert po.view.altitude_mode == "absolute"
+        po.view.altitude_mode = AltitudeMode("absolute")
+        assert po.view.altitude_mode == AltitudeMode("absolute")
 
     def test_camera_initialization(self) -> None:
         po = overlays.PhotoOverlay(view=views.Camera())

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -59,7 +59,7 @@ def set_element(
     """Get an attribute from an XML object."""
 
 
-def get_kwarg(  # type: ignore[empty-body]
+def get_kwarg(
     *,
     element: Element,
     ns: str,
@@ -70,6 +70,7 @@ def get_kwarg(  # type: ignore[empty-body]
     strict: bool,
 ) -> dict[str, Any]:
     """Get the kwarg for the constructor from the element."""
+    return {}
 
 
 def test_registry_get_root() -> None:

--- a/tests/registry_test.py
+++ b/tests/registry_test.py
@@ -17,7 +17,6 @@
 
 from enum import Enum
 from typing import Any
-from typing import Optional
 
 from fastkml.base import _XMLObject
 from fastkml.enums import Verbosity
@@ -52,8 +51,8 @@ def set_element(
     element: Element,
     attr_name: str,
     node_name: str,
-    precision: Optional[int],
-    verbosity: Optional[Verbosity],
+    precision: int | None,
+    verbosity: Verbosity | None,
     default: Any,
 ) -> None:
     """Get an attribute from an XML object."""

--- a/tests/times_test.py
+++ b/tests/times_test.py
@@ -89,7 +89,7 @@ class TestDateTime(StdLibrary):
 
     def test_kml_datetime_no_datetime(self) -> None:
         """When we pass dt as None bool() should return False."""
-        kdt = KmlDateTime(None)  # type: ignore[arg-type]
+        kdt = KmlDateTime(None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
         assert kdt.resolution == DateTimeResolution.date
         assert not bool(kdt)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [flake8]
-min_python_version = 3.9
+min_python_version = 3.10
 exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
 max_line_length = 89
 ignore=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a migration guide for moving from one type checker to newer alternatives.
  * Updated example and documentation install commands for a newer workflow.

* **Bug Fixes**
  * Improved compatibility with Python 3.10+ across the library and examples.
  * Refined XML and geometry handling to better support static analysis and edge cases.

* **Chores**
  * Dropped Python 3.9 from supported test and CI matrices.
  * Replaced the previous type-checking setup with newer checkers in CI and pre-commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->