### PR TITLE
Fix Change-registry review findings from PR #507

### DIFF
--- a/fastkml/_registry_setup.py
+++ b/fastkml/_registry_setup.py
@@ -30,13 +30,14 @@ from fastkml.geometry import LineString
 from fastkml.geometry import MultiGeometry
 from fastkml.geometry import Point
 from fastkml.geometry import Polygon
-from fastkml.gx.data import SimpleArrayData
 from fastkml.gx.track import MultiTrack
 from fastkml.gx.track import Track
 from fastkml.helpers import xml_subelement
 from fastkml.helpers import xml_subelement_kwarg
 from fastkml.helpers import xml_subelement_list
 from fastkml.helpers import xml_subelement_list_kwarg
+from fastkml.helpers import xml_subelement_list_kwarg_ordered
+from fastkml.links import Icon
 from fastkml.links import Link
 from fastkml.model import Alias
 from fastkml.model import Location
@@ -106,6 +107,7 @@ registry.register(
         classes=_create_classes,
         get_kwarg=xml_subelement_list_kwarg,
         set_element=xml_subelement_list,
+        custom_get_kwarg=xml_subelement_list_kwarg_ordered,
     ),
 )
 
@@ -129,6 +131,7 @@ registry.register(
         classes=_delete_classes,
         get_kwarg=xml_subelement_list_kwarg,
         set_element=xml_subelement_list,
+        custom_get_kwarg=xml_subelement_list_kwarg_ordered,
     ),
 )
 
@@ -184,22 +187,22 @@ _change_classes = (
     ResourceMap,
     Scale,
     # Links
+    Icon,
     Link,
     # Data
     Data,
     SchemaData,
-    # GX Data
-    SimpleArrayData,
 )
 _change_node_name = ",".join(cls.get_tag_name() for cls in _change_classes)
 registry.register(
     Change,
     RegistryItem(
-        ns_ids=("kml", ""),
+        ns_ids=("kml", "", "gx"),
         attr_name="objects",
         node_name=_change_node_name,
         classes=_change_classes,
         get_kwarg=xml_subelement_list_kwarg,
         set_element=xml_subelement_list,
+        custom_get_kwarg=xml_subelement_list_kwarg_ordered,
     ),
 )

--- a/fastkml/helpers.py
+++ b/fastkml/helpers.py
@@ -1478,3 +1478,65 @@ def xml_subelement_list_multi_ns_kwarg(
                     ],
                 )
     return {kwarg: args_list} if args_list else {}
+
+
+def xml_subelement_list_kwarg_ordered(
+    *,
+    element: Element,
+    ns_ids: tuple[str, ...],
+    name_spaces: dict[str, str],
+    node_name: str,
+    kwarg: str,
+    classes: tuple[type[object], ...],
+    strict: bool,
+) -> dict[str, list["_XMLObject"]]:
+    """
+    Return subelements in document order, matched across namespaces.
+
+    Unlike ``xml_subelement_list_kwarg``/``xml_subelement_list_multi_ns_kwarg``,
+    which group results by class (i.e. by ``classes`` registration order), this
+    walks the element's direct children once and matches each against every
+    registered class/namespace combination -- preserving the original document
+    order and correctly finding classes registered outside the primary
+    namespace (e.g. ``gx:*``). Use as a ``custom_get_kwarg`` wherever sibling
+    order among differently-typed children is semantically significant (KML's
+    ``Update``/``Create``/``Delete``/``Change`` all require this).
+
+    Args:
+    ----
+        element (Element): The XML element to search within.
+        ns_ids (Tuple[str, ...]): The namespace IDs of the XML element.
+        name_spaces (Dict[str, str]): A dictionary mapping namespace prefixes to URIs.
+        node_name (str): The name of the XML node to search for.
+        kwarg (str): The name of the keyword argument to store the found subelements.
+        classes (Tuple[Type[object], ...]): A tuple of classes that represent the types.
+        strict (bool): A flag indicating whether to enforce strict parsing rules.
+
+    Returns:
+    -------
+        Dict[str, List["_XMLObject"]]: A dictionary containing the specified keyword
+            argument and its list of subelements.
+
+    """
+    assert node_name is not None  # noqa: S101
+    assert name_spaces is not None  # noqa: S101
+    tag_to_ns_class: dict[str, tuple[str, type[_XMLObject]]] = {}
+    for name_space in ns_ids:
+        ns = name_spaces.get(name_space, "")
+        for obj_class in cast("tuple[type[_XMLObject], ...]", classes):
+            tag_to_ns_class[f"{ns}{obj_class.get_tag_name()}"] = (ns, obj_class)
+    args_list = []
+    for child in element:
+        match = tag_to_ns_class.get(child.tag)
+        if match is None:
+            continue
+        ns, obj_class = match
+        args_list.append(
+            obj_class.class_from_element(
+                ns=ns,
+                name_spaces=name_spaces,
+                element=child,
+                strict=strict,
+            ),
+        )
+    return {kwarg: args_list} if args_list else {}

--- a/fastkml/network_link_control.py
+++ b/fastkml/network_link_control.py
@@ -41,6 +41,7 @@ from fastkml.helpers import xml_subelement
 from fastkml.helpers import xml_subelement_kwarg
 from fastkml.helpers import xml_subelement_list
 from fastkml.helpers import xml_subelement_list_kwarg
+from fastkml.helpers import xml_subelement_list_kwarg_ordered
 from fastkml.registry import RegistryItem
 from fastkml.registry import registry
 from fastkml.times import KmlDateTime
@@ -59,9 +60,9 @@ if TYPE_CHECKING:
     from fastkml.geometry import MultiGeometry
     from fastkml.geometry import Point
     from fastkml.geometry import Polygon
-    from fastkml.gx.data import SimpleArrayData
     from fastkml.gx.track import MultiTrack
     from fastkml.gx.track import Track
+    from fastkml.links import Icon
     from fastkml.links import Link
     from fastkml.model import Alias
     from fastkml.model import Location
@@ -91,6 +92,10 @@ if TYPE_CHECKING:
 
     # Type aliases for the objects allowed in each Update action element.
     # These narrow the generic type parameter T of _UpdateAction for type checkers.
+    # Kept in sync by hand with the runtime _create_classes/_delete_classes/
+    # _change_classes tuples in fastkml/_registry_setup.py -- that module
+    # imports from this one, so the reverse import needed to derive these
+    # aliases from the runtime tuples would be circular.
     _CreateObjects = Document | Folder
     _DeleteObjects = (
         Document
@@ -149,12 +154,11 @@ if TYPE_CHECKING:
         | ResourceMap
         | Scale
         # Links
+        | Icon
         | Link
         # Data
         | Data
         | SchemaData
-        # GX Data
-        | SimpleArrayData
     )
 else:
     _CreateObjects = _XMLObject
@@ -212,10 +216,13 @@ class _UpdateAction(_XMLObject, Generic[T]):
             name_spaces=name_spaces,
             **kwargs,
         )
-        if objects is not None and not isinstance(objects, Iterable):
+        if objects is not None and (
+            isinstance(objects, (str, bytes))  # type: ignore[unreachable]
+            or not isinstance(objects, Iterable)
+        ):
             msg = f"objects must be an iterable, got {type(objects).__name__}"  # type: ignore[unreachable]
             raise TypeError(msg)
-        self.objects = list(objects) if objects else []
+        self.objects = list(objects) if objects is not None else []
 
     def __repr__(self) -> str:
         """
@@ -736,5 +743,6 @@ registry.register(
         classes=(Create, Delete, Change),
         get_kwarg=xml_subelement_list_kwarg,
         set_element=xml_subelement_list,
+        custom_get_kwarg=xml_subelement_list_kwarg_ordered,
     ),
 )

--- a/tests/network_link_control_test.py
+++ b/tests/network_link_control_test.py
@@ -19,6 +19,7 @@
 import datetime
 from collections.abc import Callable
 
+import pygeoif.geometry as geo
 import pytest
 from dateutil.tz import tzutc
 
@@ -29,6 +30,9 @@ from fastkml.exceptions import KMLParseError
 from fastkml.features import Placemark
 from fastkml.geometry import Coordinates
 from fastkml.geometry import Point
+from fastkml.gx.track import Track
+from fastkml.gx.track import TrackItem
+from fastkml.links import Icon
 from fastkml.network_link_control import Change
 from fastkml.network_link_control import Create
 from fastkml.network_link_control import Delete
@@ -44,47 +48,41 @@ from fastkml.times import TimeStamp
 from tests.base import Lxml
 from tests.base import StdLibrary
 
-_STYLE_CHANGE_KML = """
+
+def _change_kml(inner: str) -> str:
+    """Wrap a raw KML element in a NetworkLinkControl/Update/Change document."""
+    return f"""
 <kml:NetworkLinkControl xmlns:kml="http://www.opengis.net/kml/2.2">
   <kml:Update>
     <kml:targetHref>http://example.com/target.kml</kml:targetHref>
     <kml:Change>
-      <kml:Style targetId="mystyle">
+      {inner}
+    </kml:Change>
+  </kml:Update>
+</kml:NetworkLinkControl>
+"""
+
+
+_STYLE_CHANGE_KML = _change_kml(
+    """<kml:Style targetId="mystyle">
         <kml:IconStyle>
           <kml:color>ff0000ff</kml:color>
         </kml:IconStyle>
-      </kml:Style>
-    </kml:Change>
-  </kml:Update>
-</kml:NetworkLinkControl>
-"""
+      </kml:Style>""",
+)
 
-_POINT_CHANGE_KML = """
-<kml:NetworkLinkControl xmlns:kml="http://www.opengis.net/kml/2.2">
-  <kml:Update>
-    <kml:targetHref>http://example.com/target.kml</kml:targetHref>
-    <kml:Change>
-      <kml:Point targetId="point123">
+_POINT_CHANGE_KML = _change_kml(
+    """<kml:Point targetId="point123">
         <kml:coordinates>-95.48,40.43,0</kml:coordinates>
-      </kml:Point>
-    </kml:Change>
-  </kml:Update>
-</kml:NetworkLinkControl>
-"""
+      </kml:Point>""",
+)
 
-_INVALID_ALTITUDE_MODE_CHANGE_KML = """
-<kml:NetworkLinkControl xmlns:kml="http://www.opengis.net/kml/2.2">
-  <kml:Update>
-    <kml:targetHref>http://example.com/target.kml</kml:targetHref>
-    <kml:Change>
-      <kml:Point targetId="point123">
+_INVALID_ALTITUDE_MODE_CHANGE_KML = _change_kml(
+    """<kml:Point targetId="point123">
         <kml:altitudeMode>INVALID</kml:altitudeMode>
         <kml:coordinates>-95.48,40.43,0</kml:coordinates>
-      </kml:Point>
-    </kml:Change>
-  </kml:Update>
-</kml:NetworkLinkControl>
-"""
+      </kml:Point>""",
+)
 
 
 class TestStdLibrary(StdLibrary):
@@ -389,6 +387,95 @@ class TestStdLibrary(StdLibrary):
         """Test that a non-iterable objects argument raises TypeError."""
         with pytest.raises(TypeError, match="objects must be an iterable"):
             Change(objects=123)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_change_objects_rejects_str(self) -> None:
+        """Test that a str objects argument raises TypeError instead of exploding."""
+        with pytest.raises(TypeError, match="objects must be an iterable"):
+            Change(objects="abc")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_change_objects_rejects_bytes(self) -> None:
+        """Test that a bytes objects argument raises TypeError instead of exploding."""
+        with pytest.raises(TypeError, match="objects must be an iterable"):
+            Change(objects=b"abc")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+    def test_change_with_gx_track_roundtrip(self) -> None:
+        """Test Change with a gx:Track object can round-trip."""
+        track = Track(
+            target_id="track1",
+            track_items=[
+                TrackItem(
+                    when=KmlDateTime(dt=datetime.datetime(2024, 1, 1, tzinfo=tzutc())),
+                    coord=geo.Point(10.0, 20.0, 0.0),
+                ),
+            ],
+        )
+        change = Change(objects=[track])
+        update = Update(
+            target_href="http://example.com/target.kml",
+            operations=[change],
+        )
+        nlc = NetworkLinkControl(update=update)
+
+        parsed_nlc = NetworkLinkControl.from_string(nlc.to_string())
+
+        assert parsed_nlc.update is not None
+        assert len(parsed_nlc.update.operations) == 1
+        obj = parsed_nlc.update.operations[0].objects[0]
+        assert isinstance(obj, Track)
+        assert obj.target_id == "track1"
+
+    def test_change_with_icon_roundtrip(self) -> None:
+        """Test Change with an Icon object can round-trip."""
+        icon = Icon(target_id="icon1", href="http://example.com/new.png")
+        change = Change(objects=[icon])
+        update = Update(
+            target_href="http://example.com/target.kml",
+            operations=[change],
+        )
+        nlc = NetworkLinkControl(update=update)
+
+        parsed_nlc = NetworkLinkControl.from_string(nlc.to_string())
+
+        assert parsed_nlc.update is not None
+        assert len(parsed_nlc.update.operations) == 1
+        obj = parsed_nlc.update.operations[0].objects[0]
+        assert isinstance(obj, Icon)
+        assert obj.target_id == "icon1"
+
+    def test_change_with_mixed_objects_preserves_document_order(self) -> None:
+        """Test that parsing a Change with mixed types preserves document order."""
+        doc = _change_kml(
+            """<kml:Point targetId="p1">
+        <kml:coordinates>1,2,3</kml:coordinates>
+      </kml:Point>
+      <kml:Style targetId="s1">
+        <kml:IconStyle><kml:color>ff0000ff</kml:color></kml:IconStyle>
+      </kml:Style>""",
+        )
+
+        nlc = NetworkLinkControl.from_string(doc)
+
+        objects = nlc.update.operations[0].objects
+        assert [type(obj) for obj in objects] == [Point, Style]
+
+    def test_update_operations_preserve_document_order(self) -> None:
+        """Test that Update.operations preserve document order on parsing."""
+        doc = """
+        <kml:NetworkLinkControl xmlns:kml="http://www.opengis.net/kml/2.2">
+          <kml:Update>
+            <kml:targetHref>http://example.com/target.kml</kml:targetHref>
+            <kml:Delete><kml:Placemark targetId="p1"/></kml:Delete>
+            <kml:Create><kml:Folder targetId="f1"/></kml:Create>
+            <kml:Change>
+              <kml:Placemark targetId="p2"><kml:name>x</kml:name></kml:Placemark>
+            </kml:Change>
+          </kml:Update>
+        </kml:NetworkLinkControl>
+        """
+
+        nlc = NetworkLinkControl.from_string(doc)
+
+        assert [type(op) for op in nlc.update.operations] == [Delete, Create, Change]
 
     def test_change_kml_parsing_invalid_altitude_mode_strict(self) -> None:
         """Test that an invalid nested enum value raises KMLParseError by default."""

--- a/tests/ogc_conformance/document_test.py
+++ b/tests/ogc_conformance/document_test.py
@@ -47,6 +47,11 @@ class TestLxml(Lxml):
         any KML object: this fixture's ``Update > Change`` contains a ``TimeSpan``,
         which previously wasn't in ``Change``'s registered classes and was silently
         dropped on parse (and thus missing entirely from the round-tripped output).
+
+        It dropped again, from 97 to 96, once ``Update.operations`` started
+        parsing ``Delete``/``Create``/``Change`` in document order instead of
+        registration order: this fixture's ``Update`` lists ``Delete`` before
+        ``Create``, which the old code silently swapped on every round-trip.
         """
         clean_doc = KMLFILEDIR / "Document-clean.kml"
         expected = clean_doc.read_bytes()
@@ -54,7 +59,7 @@ class TestLxml(Lxml):
         doc = fastkml.kml.KML.parse(clean_doc)
         diff = xmldiff(doc.to_string(), expected)
 
-        assert len(diff) == 97, diff
+        assert len(diff) == 96, diff
         assert fastkml.validator.validate(file_to_validate=clean_doc)
         assert fastkml.validator.validate(element=doc.etree_element())
 


### PR DESCRIPTION
## Summary

Follow-up to #507 (Broaden `Change` registry to all KML object types), addressing code-review findings surfaced afterward.

- **Schema membership**: `Icon` was missing from `_change_classes` despite `substitutionGroup="kml:AbstractObjectGroup"` in the bundled schema (a legal `Change` target); `SimpleArrayData` was wrongly included -- its `substitutionGroup` is `kml:SchemaDataExtension` (valid only inside `<SchemaData>`), not `AbstractObjectGroup`.
- **Silent parse failure**: `gx:Track`/`gx:MultiTrack` inside a `<Change>` were never found on parse -- the registry only searched `ns_ids=("kml", "")`. `Change` now uses `ns_ids=("kml", "", "gx")` with a namespace-aware `custom_get_kwarg`.
- **Document order**: added `xml_subelement_list_kwarg_ordered` (`fastkml/helpers.py`), which parses an element's children in document order instead of grouping by class-registration order. Applied to `Create`/`Delete`/`Change` and to `Update.operations` itself, which had the identical bug -- KML requires `Update`'s operations be processed in the order they appear in the document.
- **`_UpdateAction.__init__`**: fixed treating a `str`/`bytes` `objects` argument as a valid iterable (previously silently exploded `"abc"` into three bogus single-character objects), and switched a truthiness check (`if objects else []`) to an identity check, avoiding misbehavior on iterables with ambiguous/raising `__bool__`.
- Updated the pinned round-trip diff count in `tests/ogc_conformance/document_test.py`: fixing `Update.operations`' document order removes one `MoveNode` action (97 -> 96).
- Deduped three near-identical raw-KML `Change` test fixtures into one `_change_kml()` helper.

All changes verified against the bundled OGC KML 2.2 / gx XSDs (`fastkml/schema/*.xsd`) and with live round-trip reproductions for each fix.

## Test plan
- [x] `pytest tests/` full suite green (one pre-existing, unrelated Hypothesis timing flake in `multi_geometry_test.py`, reproduced on `develop` too)
- [x] `pre-commit run` (ruff, ty, pyrefly, etc.) clean on all touched files
- [x] `zuban check fastkml` clean
- [x] Added regression tests: `Icon`/`gx:Track` round-trip through `Change`, mixed-type `Change` document order, `Update.operations` document order, `str`/`bytes` rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure KML Update/Change operations and objects are parsed in document order, expand Change support to additional KML/gx object types, and tighten validation of Change objects initialization.

New Features:
- Support Icon objects as valid Change targets and round-trip them through NetworkLinkControl updates.
- Support gx:Track objects as valid Change targets and round-trip them through NetworkLinkControl updates.

Bug Fixes:
- Fix Change registry namespace handling so gx:Track/MultiTrack and other non-primary-namespace objects are discovered on parse.
- Correct the set of object types allowed in Change by removing SimpleArrayData, which is not a legal Change target.
- Ensure Update.operations and Change with mixed object types preserve document order when parsing instead of reordering by class registration.
- Prevent _UpdateAction / Change from treating str or bytes as iterables and exploding them into individual characters, while handling iterables with ambiguous truthiness safely.
- Update OGC conformance expectations to reflect the corrected document-order handling in Update operations.

Enhancements:
- Introduce a helper that returns subelements in document order across namespaces and use it for Update/Create/Delete/Change parsing.
- Deduplicate raw-KML Change test fixtures by introducing a reusable wrapper helper for NetworkLinkControl/Update/Change documents.

Tests:
- Add regression tests for string/bytes rejection in Change objects initialization.
- Add round-trip tests for Change with gx:Track and Icon objects.
- Add tests verifying document order preservation for Change with mixed object types and for Update.operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original document order when parsing mixed update operations and changed objects.
  * Improved support for changing and round-tripping icons and GX tracks.
  * Added validation to reject strings and bytes where collections of change objects are expected.
* **Tests**
  * Expanded coverage for ordering, round-trip behavior, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->