### PR TITLE
fix: pass non-string values through clean_string (CDATA support)

### DIFF
--- a/fastkml/helpers.py
+++ b/fastkml/helpers.py
@@ -90,9 +90,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def clean_string(value: str | None) -> str | None:
-    """Clean and validate a string value, returning None if empty."""
-    if not value:
+def clean_string(value: Any) -> Any:
+    """
+    Clean and validate a string value, returning None if empty.
+
+    For string inputs, returns the stripped string, or ``None`` if the
+    result is empty. Non-string values (e.g. ``lxml.etree.CDATA`` or other
+    objects) are returned unchanged.
+    """
+    if value is None:
         return None
     if not isinstance(value, str):
         # Pass non-string values (e.g. ``lxml.etree.CDATA``) through unchanged.

--- a/fastkml/helpers.py
+++ b/fastkml/helpers.py
@@ -92,7 +92,12 @@ logger = logging.getLogger(__name__)
 
 def clean_string(value: str | None) -> str | None:
     """Clean and validate a string value, returning None if empty."""
-    return value.strip() or None if value else None
+    if not value:
+        return None
+    if not isinstance(value, str):
+        # Pass non-string values (e.g. ``lxml.etree.CDATA``) through unchanged.
+        return value
+    return value.strip() or None
 
 
 def handle_error(

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -20,7 +20,12 @@ from enum import Enum
 from unittest.mock import Mock
 from unittest.mock import patch
 
-import lxml.etree
+try:
+    import lxml.etree
+
+    LXML = True
+except ImportError:
+    LXML = False
 
 from fastkml.features import Placemark
 from fastkml.helpers import attribute_enum_kwarg

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -20,12 +20,17 @@ from enum import Enum
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import lxml.etree
+
+from fastkml.features import Placemark
 from fastkml.helpers import attribute_enum_kwarg
 from fastkml.helpers import attribute_float_kwarg
+from fastkml.helpers import clean_string
 from fastkml.helpers import subelement_bool_kwarg
 from fastkml.helpers import subelement_enum_kwarg
 from fastkml.helpers import subelement_float_kwarg
 from fastkml.helpers import subelement_int_kwarg
+from tests.base import Lxml
 from tests.base import StdLibrary
 
 
@@ -146,3 +151,28 @@ class TestStdLibrary(StdLibrary):
 
         assert res == {}
         element.find.assert_called_once_with("nsnode")
+
+    def test_clean_string(self) -> None:
+        assert clean_string("  text  ") == "text"
+        assert clean_string("   ") is None
+        assert clean_string("") is None
+        assert clean_string(None) is None
+
+
+class TestLxml(Lxml):
+    """Test with lxml."""
+
+    def test_clean_string_passes_cdata_through(self) -> None:
+        """CDATA has no ``strip`` and must be returned unchanged (#418)."""
+        cdata = lxml.etree.CDATA("<b>bold</b>")
+
+        assert clean_string(cdata) is cdata
+
+    def test_placemark_description_cdata_is_not_escaped(self) -> None:
+        """A CDATA description round-trips unescaped (#418)."""
+        placemark = Placemark(
+            ns="{http://www.opengis.net/kml/2.2}",
+            description=lxml.etree.CDATA("<b>bold</b>"),
+        )
+
+        assert "<![CDATA[<b>bold</b>]]>" in placemark.to_string()

--- a/tests/helper_test.py
+++ b/tests/helper_test.py
@@ -162,6 +162,9 @@ class TestStdLibrary(StdLibrary):
         assert clean_string("   ") is None
         assert clean_string("") is None
         assert clean_string(None) is None
+        # Falsy non-string values pass through unchanged, like any other
+        # non-string input.
+        assert clean_string(0) == 0
 
 
 class TestLxml(Lxml):
@@ -180,4 +183,7 @@ class TestLxml(Lxml):
             description=lxml.etree.CDATA("<b>bold</b>"),
         )
 
-        assert "<![CDATA[<b>bold</b>]]>" in placemark.to_string()
+        serialized = placemark.to_string()
+        assert "<![CDATA[<b>bold</b>]]>" in serialized
+        # The description must not be both wrapped in CDATA *and* escaped.
+        assert "&lt;b&gt;bold&lt;/b&gt;" not in serialized


### PR DESCRIPTION
Closes #418

`clean_string()` called `.strip()` on any truthy value, so passing an `lxml.etree.CDATA` object as a `description` raised `AttributeError: 'lxml.etree.CDATA' object has no attribute 'strip'`. Non-string values are now passed through unchanged — the approach suggested on the issue — so a CDATA description serialises as `<![CDATA[...]]>` instead of being escaped.

Regression tests added to `tests/helper_test.py`; both fail without the change and pass with it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.

## Summary by Sourcery

Preserve non-string description values while continuing to normalize string inputs.

Bug Fixes:
- Preserve non-string values passed to `clean_string`, allowing lxml CDATA descriptions to serialize correctly without escaping.

Tests:
- Add regression coverage for string cleaning, CDATA pass-through, and unescaped CDATA serialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-string values during string cleanup while preserving expected behavior for empty, null, and whitespace-only values.
  * Preserved CDATA content without unwanted escaping when serializing placemark descriptions.

* **Tests**
  * Added coverage for empty, null, trimmed string, non-string, and CDATA input scenarios.
  * Verified that placemark descriptions retain their original CDATA content during serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->